### PR TITLE
Update HotChocolate to latest version

### DIFF
--- a/Cosmos.GraphQL.Service/Cosmos.GraphQL.Service/Cosmos.GraphQL.Service.csproj
+++ b/Cosmos.GraphQL.Service/Cosmos.GraphQL.Service/Cosmos.GraphQL.Service.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
 
-    <PackageReference Include="HotChocolate" Version="12.0.0-rc.8" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="12.0.0-rc.8" />
+    <PackageReference Include="HotChocolate" Version="12.0.1" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="12.0.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.18.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.10.0-3.final" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />


### PR DESCRIPTION
HotChocalate 12.0 has come out of RC. Let's use the stable version
instead.