### PR TITLE
Make dotnet watch run restart on json and gql changes

### DIFF
--- a/DataGateway.Service/Azure.DataGateway.Service.csproj
+++ b/DataGateway.Service/Azure.DataGateway.Service.csproj
@@ -15,6 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- extends watching group to include .json and .gql files -->
+    <Watch Include="**\*.json;**\*.gql" Exclude="obj\**\*;bin\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
 
     <PackageReference Include="HotChocolate" Version="12.0.1" />
     <PackageReference Include="HotChocolate.AspNetCore" Version="12.0.1" />


### PR DESCRIPTION
When running with `dotnet watch run` the binary gets rebuilt and
restarted whenever a `.cs` file changes. For this project a lot of
behaviour is defined in the config files though. This makes sure the
`watch run` restarts the program whenever a json or gql file is modified
in the project.