### PR TITLE
Az Pipelines Config - Correct placement of displayName

### DIFF
--- a/cosmos-pipelines.yml
+++ b/cosmos-pipelines.yml
@@ -28,12 +28,13 @@ steps:
 - task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2
+  displayName: Restore NuGet packages
   inputs:
     restoreSolution: '$(solution)'
 
 - task: FileTransform@1
+  displayName: 'Generate appsettings.Test.json'
   inputs:
-    displayName: 'Generate appsettings.Test.json'
     folderPath: '$(System.DefaultWorkingDirectory)'
     fileType: 'json'
     targetFiles: 'DataGateway.Service/appsettings.Test.json'
@@ -46,8 +47,8 @@ steps:
     arguments: '--configuration $(buildConfiguration)' # Update this to match your need
 
 - task: DotNetCoreCLI@2
+  displayName: 'Run Cosmos DB Integration Tests'
   inputs:
-    displayName: 'Run Cosmos DB Integration Tests'
     command: test
     arguments: '--filter "TestCategory=Cosmos" --configuration $(buildConfiguration)'
     projects: '**/*Tests/*.csproj'


### PR DESCRIPTION
### Why This Change:
Pipeline runs were not displaying the configured task `displayName`. This is because the `displayName` attribute was not placed correctly in the YAML for each task. This was corrected for Cosmos.
![image](https://user-images.githubusercontent.com/6414189/140972234-260f0616-d5fe-44de-9deb-f54421ae6906.png)

### How Solution was Implemented
Example of Previous Config:
```
- task: NuGetCommand@2  
  inputs:
    displayName: Restore NuGet packages
    restoreSolution: '$(solution)'
```

Example of Corrected Config:
```
- task: NuGetCommand@2
  displayName: Restore NuGet packages
  inputs:
    restoreSolution: '$(solution)'
```

### Documentation
Syntax for `Task` in Azure Pipeline YAML is as follows:
https://docs.microsoft.com/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#task