### PR TITLE
Reenable logging stacktraces of uncaught exceptions

### DIFF
--- a/DataGateway.Service/Services/GraphQLService.cs
+++ b/DataGateway.Service/Services/GraphQLService.cs
@@ -45,8 +45,12 @@ namespace Azure.DataGateway.Services
                 .AddAuthorization()
                 .AddErrorFilter(error =>
             {
-                Console.WriteLine(error.Code);
-                Console.WriteLine(error.Message);
+                if (error.Exception != null)
+                {
+                    Console.Error.WriteLine(error.Exception.Message);
+                    Console.Error.WriteLine(error.Exception.StackTrace);
+                }
+
                 return error;
             });
 
@@ -63,7 +67,7 @@ namespace Azure.DataGateway.Services
         public IRequestExecutor Executor { get; private set; }
 
         /// <summary>
-        /// Executes GraphQL request within GraphQL Library components. 
+        /// Executes GraphQL request within GraphQL Library components.
         /// </summary>
         /// <param name="requestBody">GraphQL request body</param>
         /// <param name="requestProperties">key/value pairs of properties to be used in GraphQL library pipeline</param>


### PR DESCRIPTION
Logging of stacktraces was disabled by #97. Based on PR comments the
reason for this was that for most types of errors `error.Exception`
would be `null`. Thus the exception logging code would actually create a
new error by dereferencing a `null`.

This was addressed by only logging the error `Code` and `Message`.
However, logging these is not very useful. They are already passed to
the frontend. So this fixes the problem in a better way, by only logging
to stderr when the error its `error.Exception` field is non-null.