### PR TITLE
Fix git commit hook after directory refactor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,8 @@ cat > .git/hooks/pre-commit << __EOF__
 set -euo pipefail
 
 get_files() {
-    git diff --cached --name-only --diff-filter=ACMR DataGateway.Service |\\
-        grep '\.cs$' |\\
-        sed s=^DataGateway.Service/==g
+    git diff --cached --name-only --diff-filter=ACMR |\\
+        grep '\.cs$'
 }
 
 if [ "\$(get_files)" = '' ]; then


### PR DESCRIPTION
In [#65][1] directory structure was simplified. The git commit hook had
some code that was required to address this more complex directory
structure. After the directory structure simplification this now
unnecessary code had the unintended effect of the causing the Test
directory not to be formatted by the hook. This fixes the commit hook.

[1]: https://github.com/Azure/hawaii-gql/pull/65