### PR TITLE
Fix the value for code and message fields in case of Internal Server Errors

### DIFF
--- a/DataGateway.Service.Tests/SqlTests/RestApiTestBase.cs
+++ b/DataGateway.Service.Tests/SqlTests/RestApiTestBase.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using System.Threading.Tasks;
 using Azure.DataGateway.Service.Controllers;
+using Azure.DataGateway.Service.Exceptions;
 using Azure.DataGateway.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -146,9 +148,9 @@ namespace Azure.DataGateway.Service.Tests.SqlTests
                 sqlQuery: GetQuery(nameof(FindTestWithInvalidFields)),
                 controller: _restController,
                 exception: true,
-                expectedErrorMessage: "Invalid Field name: null or white space",
-                expectedStatusCode: 500,
-                expectedSubStatusCode: "While processing your request the server ran into an unexpected error"
+                expectedErrorMessage: RestController.SERVER_ERROR,
+                expectedStatusCode: (int)HttpStatusCode.InternalServerError,
+                expectedSubStatusCode: DatagatewayException.SubStatusCodes.UnexpectedError.ToString()
             );
         }
 

--- a/DataGateway.Service/Controllers/RestController.cs
+++ b/DataGateway.Service/Controllers/RestController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Security.Claims;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -24,7 +25,7 @@ namespace Azure.DataGateway.Service.Controllers
         /// <summary>
         /// String representing the value associated with "code" for a server error
         /// </summary>
-        private const string SERVER_ERROR = "While processing your request the server ran into an unexpected error";
+        public const string SERVER_ERROR = "While processing your request the server ran into an unexpected error.";
 
         /// <summary>
         /// Constructor.
@@ -38,8 +39,8 @@ namespace Azure.DataGateway.Service.Controllers
         /// Helper function returns a JsonResult with provided arguments in a
         /// form that complies with vNext Api guidelines.
         /// </summary>
-        /// <param name="code">string provides a description of general error</param>
-        /// <param name="message">string provides a message associated with this error</param>
+        /// <param name="code">One of a server-defined set of error codes.</param>
+        /// <param name="message">string provides a message associated with this error.</param>
         /// <param name="status">int provides the http response status code associated with this error</param>
         /// <returns></returns>
         public static JsonResult ErrorResponse(string code, string message, int status)
@@ -112,8 +113,11 @@ namespace Azure.DataGateway.Service.Controllers
             {
                 Console.Error.WriteLine(ex.Message);
                 Console.Error.WriteLine(ex.StackTrace);
-                Response.StatusCode = (int)System.Net.HttpStatusCode.InternalServerError;
-                return ErrorResponse(SERVER_ERROR, ex.Message, (int)System.Net.HttpStatusCode.InternalServerError);
+                Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+                return ErrorResponse(
+                    DatagatewayException.SubStatusCodes.UnexpectedError.ToString(),
+                    SERVER_ERROR,
+                    (int)HttpStatusCode.InternalServerError);
             }
         }
     }

--- a/DataGateway.Service/Exceptions/DatagatewayException.cs
+++ b/DataGateway.Service/Exceptions/DatagatewayException.cs
@@ -24,7 +24,11 @@ namespace Azure.DataGateway.Service.Exceptions
             /// <summary>
             /// Request failed authorization.
             /// </summary>
-            AuthorizationCheckFailed
+            AuthorizationCheckFailed,
+            /// <summary>
+            /// Unexpected error.
+            /// </summary>,
+            UnexpectedError
         }
 
         public int StatusCode { get; }


### PR DESCRIPTION
- In the POST request review, it was discovered that the database errors are still being propagated to the end users which is undesirable from security perspective.

- This PR is to fix this issue to hide the actual exception message but give a generic error code and message indicating something failed on the server.
- As before, any unknown exceptions caught by the service will be thrown as an InternalServer Error of the following form

```
{
    "error": {
        "code": "UnexpectedError",
        "message": "While processing your request the server ran into an unexpected error.",
        "status": 500
    }
}
```