### PR TITLE
Check for null DatabaseSchema before creating new filter parser

### DIFF
--- a/DataGateway.Service/Services/FileMetadataStoreProvider.cs
+++ b/DataGateway.Service/Services/FileMetadataStoreProvider.cs
@@ -102,7 +102,11 @@ namespace Azure.DataGateway.Service
                 _mutationResolvers.Add(resolver.Id, resolver);
             }
 
-            _filterParser = new(_config.DatabaseSchema);
+            // Database Schema may be null for CosmosDB
+            if (_config.DatabaseSchema is not null)
+            {
+                _filterParser = new(_config.DatabaseSchema);
+            }
         }
         /// <summary>
         /// Reads generated JSON configuration file with GraphQL Schema


### PR DESCRIPTION
In `FileMetaDataStoreProvider` we create a new `FilterParser` from the DatabaseSchema in the `ResolverConfig`. However, for cosmos db, this Database Schema is currently null, and so we add a null check before creating this filter parser.