### PR TITLE
Added space to end of cosmos pipeline yaml

### DIFF
--- a/cosmos-pipelines.yml
+++ b/cosmos-pipelines.yml
@@ -53,4 +53,3 @@ steps:
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(Agent.TempDirectory)/**/*cobertura.xml'
-    


### PR DESCRIPTION
A format change was not added to the last PR, this just adds a space at the end of one of the files that was missed.