### PR TITLE
ODataASTVisitor Unit Testing Added

### DIFF
--- a/DataGateway.Service.Tests/REST/ODataASTVisitorUnitTests.cs
+++ b/DataGateway.Service.Tests/REST/ODataASTVisitorUnitTests.cs
@@ -184,7 +184,7 @@ namespace Azure.DataGateway.Service.Tests.REST
 
         /// <summary>
         /// Tests that we throw an exception when trying to use an invalid
-        /// operator in our filter. In those case an add operator.
+        /// operator in our filter. In this case an add operator.
         /// </summary>
         [TestMethod]
         public void InvalidNullBinaryOpTest()


### PR DESCRIPTION
This PR simply creates some unit tests for the `ODataASTVisitor` class. Testing certain code paths with integration testing is either not possible, or overly cumbersome. For those cases we create unit tests that can test those code paths directly and use mocked objects as needed to facilitate this testing.