### PR TITLE
Format response fix for POST

### DIFF
--- a/DataGateway.Service.Tests/SqlTests/SqlTestHelper.cs
+++ b/DataGateway.Service.Tests/SqlTests/SqlTestHelper.cs
@@ -150,8 +150,7 @@ namespace Azure.DataGateway.Service.Tests.SqlTests
                 case CreatedResult createdResult:
                     Assert.AreEqual((int)expectedStatusCode, createdResult.StatusCode);
                     Assert.AreEqual(expectedLocationHeader, createdResult.Location);
-                    OkObjectResult innerResult = (OkObjectResult)createdResult.Value;
-                    actual = JsonSerializer.Serialize(innerResult.Value);
+                    actual = JsonSerializer.Serialize(createdResult.Value);
                     break;
                 // NoContentResult does not have value property for messages
                 case NoContentResult noContentResult:

--- a/DataGateway.Service/Controllers/RestController.cs
+++ b/DataGateway.Service/Controllers/RestController.cs
@@ -269,7 +269,7 @@ namespace Azure.DataGateway.Service.Controllers
                             primaryKeyRoute = _restService.ConstructPrimaryKeyRoute(entityName, resultElement);
                             string location =
                                 UriHelper.GetEncodedUrl(HttpContext.Request) + "/" + primaryKeyRoute;
-                            return new CreatedResult(location: location, formattedResult);
+                            return new CreatedResult(location: location, formattedResult.Value);
                         case Operation.Delete:
                             return new NoContentResult();
                         case Operation.Upsert:
@@ -277,7 +277,7 @@ namespace Azure.DataGateway.Service.Controllers
                             primaryKeyRoute = _restService.ConstructPrimaryKeyRoute(entityName, resultElement);
                             location =
                                 UriHelper.GetEncodedUrl(HttpContext.Request) + "/" + primaryKeyRoute;
-                            return new CreatedResult(location: location, formattedResult);
+                            return new CreatedResult(location: location, formattedResult.Value);
                         default:
                             throw new NotSupportedException($"Unsupported Operation: \" {operationType}\".");
                     }


### PR DESCRIPTION
The `CreatedResult` that was returned for POST was constructed improperly. Rather than associating the value of the `CreatedResult` with the value of the response from the DB, we were associating the value of `CreatedResult` with the key/value pair saved when formatting the response from the DB. This would result in something like `value : value = [<DB Response>]`. This is a fix which changes how the `CreatedResult` is formed to use the inner value instead of the entire key/value pair.

`return new CreatedResult(location: location, formattedResult.Value);`
