### PR TITLE
Add Unit Tests for RESTRequestContext

### DIFF
--- a/DataGateway.Service.Tests/REST/RequestContextUnitTests.cs
+++ b/DataGateway.Service.Tests/REST/RequestContextUnitTests.cs
@@ -43,7 +43,7 @@ namespace Azure.DataGateway.Service.Tests.REST
 
         /// <summary>
         /// Verify that if a payload deserializes to
-        /// the empty string that we instantiate an
+        /// the empty string, we instantiate an
         /// empty FieldsValuePairsInBody
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
## Summary
Not all units of work within the various `RESTRequestContext` classes have been covered through the integration testing. This PR seeks to create a Unit Test class that will close those gaps. We begin with adding unit testing for `InsertRequestContext` for a cause where the payload finally deserializes into a `null`, a case where we expect a `DataGatewayException` to be thrown. We create this case, and verify that the correct exception throws.