### PR TITLE
Update docker image to compile for linux, fix dockercompose for cosmos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,9 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0 as build
 
 COPY ["Directory.Build.props", "."]
 WORKDIR /src
+
 COPY ["DataGateway.Service/", "./"]
-RUN dotnet build "./Azure.DataGateway.Service.csproj" -c Docker -o /out
+RUN dotnet build "./Azure.DataGateway.Service.csproj" -c Docker -o /out -r linux-x64
 
 FROM mcr.microsoft.com/dotnet/aspnet:5.0 as runtime
 

--- a/docker-compose-cosmos.yml
+++ b/docker-compose-cosmos.yml
@@ -6,5 +6,5 @@ services:
       - "5000:5000"
     volumes:
       - "./DataGateway.Service/appsettings.cosmos.json:/App/appsettings.json"
-      - "./DataGateway.Service/cosmos-config.json:/App/config.json"
+      - "./DataGateway.Service/cosmos-config.json:/App/cosmos-config.json"
       - "./DataGateway.Service/schema.gql:/App/schema.gql"


### PR DESCRIPTION
# Why is this change being made?
Phoenix is setup to use Linux containers, so we need this docker image to be compiled for linux.

# What changed?
- Compile for linux
- Fix docker-compose-cosmos to use the correct config file.

# How was this validated?
- [x] Built the image. Ran it in phoenix locally.