### PR TITLE
Update build pipeline to only push images from main to ACR.

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -68,7 +68,18 @@ steps:
       $date=$(Get-Date -format yyyyMMdd-HHmmss)
       Write-Host "##vso[task.setvariable variable=BuildDate]$date"
 
-# Build a docker image and push it to the container registry.
+# Build a docker image, but don't push it if branch isn't main.
+- task: Docker@2
+  displayName: "Build docker image"
+  inputs:
+    containerRegistry: 'CosmosDB GraphQL/Hawaii'
+    repository: 'hawaii/$(Build.SourceBranch)'
+    command: 'build'
+    Dockerfile: '**/Dockerfile'
+    tags: '$(BuildDate)-$(Build.SourceVersion)' # Use build date and commitId as the tag for the image
+  condition: ne(variables['Build.SourceBranch'], 'refs/heads/main')
+
+# Build a docker image and push it to the container registry if main branch.
 - task: Docker@2
   displayName: "Build and push docker image to Azure Container Registry"
   inputs:
@@ -77,3 +88,4 @@ steps:
     command: 'buildAndPush'
     Dockerfile: '**/Dockerfile'
     tags: '$(BuildDate)-$(Build.SourceVersion)' # Use build date and commitId as the tag for the image
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')


### PR DESCRIPTION
# Why is this change being made ?
We don't need to push every CI build to our ACR, only the official builds from main branch.

# What changed ?
Added a condition to look for main branch to build and push or just build in the pipeline.

# How was this validated?
CI pipeline just ran and validated that it only built the image and didn't push it.
Checking this in will allow us to validate the buildAndPush. 