### PR TITLE
Loop through relationships instead of all foreign keys

### DIFF
--- a/DataGateway.Service.GraphQLBuilder/Sql/SchemaConverter.cs
+++ b/DataGateway.Service.GraphQLBuilder/Sql/SchemaConverter.cs
@@ -79,7 +79,7 @@ namespace Azure.DataGateway.Service.GraphQLBuilder.Sql
 
                     if (foreignKeyDefinitions is not null)
                     {
-                        foreach(ForeignKeyDefinition fk in foreignKeyDefinitions)
+                        foreach (ForeignKeyDefinition fk in foreignKeyDefinitions)
                         {
                             foreach (string columnName in fk.ReferencingColumns)
                             {


### PR DESCRIPTION
Looping through Relationships helps us add Nested Fields under entities which don't have a corresponding FK.

Optionally, if FK is indeed present, add the information in them as directives for foreign keys.
If FK is absent, this PR doesn't modify the TableDefinition to fabricate them and add - which would still be required for correct query generation. That will be handled in issue #376

@aaronpowell, please review and merge in your PR #368 