### PR TITLE
Bugfix: Use name of restverb in tabledefinition for permissions

### DIFF
--- a/DataGateway.Service/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/DataGateway.Service/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -279,7 +279,7 @@ namespace Azure.DataGateway.Service.Services
 
                     OperationAuthorizationRequirement restVerb
                             = HttpRestVerbs.GetVerb(actionName);
-                    if (!tableDefinition.HttpVerbs.ContainsKey(restVerb.ToString()!))
+                    if (!tableDefinition.HttpVerbs.ContainsKey(restVerb.Name.ToString()!))
                     {
                         AuthorizationRule rule = new()
                         {
@@ -288,7 +288,7 @@ namespace Azure.DataGateway.Service.Services
                                   typeof(AuthorizationType), permission.Role, ignoreCase: true)
                         };
 
-                        tableDefinition.HttpVerbs.Add(restVerb.ToString()!, rule);
+                        tableDefinition.HttpVerbs.Add(restVerb.Name.ToString()!, rule);
                     }
                 }
             }


### PR DESCRIPTION
When we populate the `tabledefinition` we include the rest verbs that are authorized. These verbs have a name which references their actual verb, ie: "GET". When we store these in `tabledefinition` we want to store the `toString` of the `Name` so that it matches the verb in the request context. This just adds `.Name` to where we add these verbs through the `toString()` to the `tabledefinition`.