### PR TITLE
Throw exception when primary key could not be determined

### DIFF
--- a/DataGateway.Service.Tests/SqlTests/PostgreSqlRestApiTests.cs
+++ b/DataGateway.Service.Tests/SqlTests/PostgreSqlRestApiTests.cs
@@ -928,6 +928,13 @@ namespace Azure.DataGateway.Service.Tests.SqlTests
             throw new NotImplementedException();
         }
 
+        [TestMethod]
+        [Ignore]
+        public override Task FindTestWithInvalidFieldsInQueryStringOnViews()
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetDefaultSchema()
         {
             return DEFAULT_SCHEMA;

--- a/DataGateway.Service/PostgreSqlBooks.sql
+++ b/DataGateway.Service/PostgreSqlBooks.sql
@@ -1,6 +1,3 @@
-DROP VIEW IF EXISTS books_view_all;
-DROP VIEW IF EXISTS stocks_view_selected;
-DROP VIEW IF EXISTS books_publishers_view_composite;
 DROP TABLE IF EXISTS book_author_link;
 DROP TABLE IF EXISTS reviews;
 DROP TABLE IF EXISTS authors;
@@ -157,16 +154,3 @@ SELECT setval('book_website_placements_id_seq', 5000);
 SELECT setval('publishers_id_seq', 5000);
 SELECT setval('authors_id_seq', 5000);
 SELECT setval('reviews_id_seq', 5000);
-
-DO $do$
- BEGIN
- EXECUTE('CREATE VIEW books_view_all AS SELECT * FROM books');
- EXECUTE('CREATE VIEW stocks_view_selected AS SELECT
-          categoryid,pieceid,"categoryName","piecesAvailable"
-          FROM stocks');
- EXECUTE('CREATE VIEW books_publishers_view_composite as SELECT
-          publishers.name,books.id,books.publisher_id
-          FROM books,publishers
-          where publishers.id = books.publisher_id');
- END
- $do$;

--- a/DataGateway.Service/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/DataGateway.Service/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -374,12 +374,12 @@ namespace Azure.DataGateway.Service.Services
 
             List<DataColumn> primaryKeys = new(dataTable.PrimaryKey);
 
-            if (primaryKeys.Count == 0 && !(this.GetType() == typeof(PostgreSqlMetadataProvider)))
+            if (primaryKeys.Count == 0)
             {
                 throw new DataGatewayException(
                        message: $"Primary key not configured on the given database object {tableName}",
-                       statusCode: System.Net.HttpStatusCode.BadRequest,
-                       subStatusCode: DataGatewayException.SubStatusCodes.UnexpectedError);
+                       statusCode: System.Net.HttpStatusCode.NotImplemented,
+                       subStatusCode: DataGatewayException.SubStatusCodes.ErrorInInitialization);
             }
 
             tableDefinition.PrimaryKey = new(primaryKeys.Select(primaryKey => primaryKey.ColumnName));

--- a/DataGateway.Service/hawaii-config.PostgreSql.json
+++ b/DataGateway.Service/hawaii-config.PostgreSql.json
@@ -207,57 +207,6 @@
       "source": "website_users",
       "rest": false,
       "permissions": []
-    },
-    "books_view_all": {
-      "source": "books_view_all",
-      "rest": true,
-      "graphql": true,
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [ "read" ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [ "read" ]
-        }
-      ],
-      "relationships": {
-      }
-    },
-    "stocks_view_selected": {
-      "source": "stocks_view_selected",
-      "rest": true,
-      "graphql": true,
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [ "read" ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [ "read" ]
-        }
-      ],
-      "relationships": {
-      }
-    },
-    "books_publishers_view_composite": {
-      "source": "books_publishers_view_composite",
-      "rest": true,
-      "graphql": true,
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [ "read" ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [ "read" ]
-        }
-      ],
-      "relationships": {
-      }
     }
   }
 }


### PR DESCRIPTION
**Why is the change needed?**

Sometimes, view definition can be quite complicated and ADO.NET db data adapter may not be able to determine PK of a view. In such cases, we need to fail initialization and throw an exception.

**How was this done?**
Throw an exception when the primaryKeys list for a view is empty.