### PR TITLE
Add correct mock to test in RequestValidator

### DIFF
--- a/DataGateway.Service.Tests/Unittests/RequestValidatorUnitTests.cs
+++ b/DataGateway.Service.Tests/Unittests/RequestValidatorUnitTests.cs
@@ -249,7 +249,7 @@ namespace Azure.DataGateway.Service.Tests.UnitTests
 
             _mockMetadataStore.Setup(x => x.GetTableDefinition(It.IsAny<string>())).Returns(tableDef);
             FindRequestContext findRequestContext = new(entityName: DEFAULT_NAME,
-                                                        dbo:GetDbo(DEFAULT_SCHEMA, DEFAULT_NAME),
+                                                        dbo: GetDbo(DEFAULT_SCHEMA, DEFAULT_NAME),
                                                         isList: false);
             string primaryKeyRoute = "id/12345/isbn/2/name/TwoTowers";
             RequestParser.ParsePrimaryKey(primaryKeyRoute, findRequestContext);


### PR DESCRIPTION
`MatchingCompositePrimaryKeyNotOrdered` was missing the proper mock setup, we add that here.

This test is currently passing in the pipeline, but fails locally. More investigation is needed to determine why it currently passes in the pipeline without this change. When this change was first made, it passed locally as well, but has since deprecated to fail in the local environment, which is the expected behavior without this PR's change.