### PR TITLE
Minor refactorings in entitypermissionmap creation

### DIFF
--- a/DataGateway.Service/Authorization/AuthorizationResolver.cs
+++ b/DataGateway.Service/Authorization/AuthorizationResolver.cs
@@ -219,6 +219,8 @@ namespace Azure.DataGateway.Service.Authorization
                         }
                         else
                         {
+                            // If not a string, the actionObj is expected to be an object that can be deserialised into Action object.
+                            // We will put validation checks later to make sure this is the case.
                             Action? actionObj = JsonSerializer.Deserialize<Action>(actionElement.ToString(), RuntimeConfig.GetDeserializationOptions());
                             if (actionObj is not null)
                             {


### PR DESCRIPTION
Some minor refactoring for better code format. Essentially:

1. using `is` instead of `==`.
2. Replacing `else if` with just an `else` when we are sure of the cases that may arise.