### PR TITLE
Keep using ports 5001/5000 for running the service

### DIFF
--- a/DataGateway.Service/Properties/launchSettings.json
+++ b/DataGateway.Service/Properties/launchSettings.json
@@ -25,7 +25,7 @@
         "ASPNETCORE_ENVIRONMENT": "MsSql"
       },
       "dotnetRunMessages": "true",
-      "applicationUrl": "https://localhost:5011;http://localhost:5010"
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     },
     "Development": {
       "commandName": "Project",


### PR DESCRIPTION
Reverts the ports where the DataGateway Service is running to 5001/5000 in `Properties/lauchSetting.json`.