### PR TITLE
Track Newtonsoft json package version

### DIFF
--- a/DataGateway.Service.GraphQLBuilder/Azure.DataGateway.Service.GraphQLBuilder.csproj
+++ b/DataGateway.Service.GraphQLBuilder/Azure.DataGateway.Service.GraphQLBuilder.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="HotChocolate" Version="$(HotChocolateVersion)" />
     <PackageReference Include="Humanizer" Version="$(HumanizerVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
 
 </Project>

--- a/DataGateway.Service.Tests/Azure.DataGateway.Service.Tests.csproj
+++ b/DataGateway.Service.Tests/Azure.DataGateway.Service.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="HotChocolate" Version="$(HotChocolateVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="$(SystemIOAbstractionsVersion)" />
   </ItemGroup>
 

--- a/DataGateway.Service/Azure.DataGateway.Service.csproj
+++ b/DataGateway.Service/Azure.DataGateway.Service.csproj
@@ -75,7 +75,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ConfigVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.6" />
     <PackageReference Include="MySqlConnector" Version="$(MySQLVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="Npgsql" Version="$(PostgresVersion)" />
     <PackageReference Include="Microsoft.OData.Edm" Version="$(ODataVersion)" />
     <PackageReference Include="Microsoft.OData.Core" Version="$(ODataVersion)" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,5 +15,6 @@
     <NetCoreAutorizationVersion>3.1.4</NetCoreAutorizationVersion>
     <HumanizerVersion>2.14.1</HumanizerVersion>
     <SystemIOAbstractionsVersion>17.0.4</SystemIOAbstractionsVersion>
+    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
The compliance build failed because of lower Newtonsoft.json package version. The fix is to override with higher package vertion and abstract the version number.
```Newtonsoft.json 12.0.3``` is being referenced by ```HotChocolate.Utilities```, which is being referenced by ```HotChocolate.Types```, which is eventually being brought in by ```HotChocolate``` package 12.8.2.
