### PR TITLE
Fix the path for config file in cosmos docker compose

### DIFF
--- a/docker-compose-cosmos.yml
+++ b/docker-compose-cosmos.yml
@@ -5,5 +5,5 @@ services:
     ports:
       - "5000:5000"
     volumes:
-      - "./src/hawaii-config.Cosmos.json:/App/hawaii-config.json"
-      - "./src/schema.gql:/App/schema.gql"
+      - "./src/Service/hawaii-config.Cosmos.json:/App/hawaii-config.json"
+      - "./src/Service/schema.gql:/App/schema.gql"


### PR DESCRIPTION
## What is the change?
The previous PR #673 to rename the paths missed the path for this docker compose file for cosmos. This change is to fix up the path.