### PR TITLE
Fix up the dab config schema

### DIFF
--- a/schemas/dab.draft-01.schema.json
+++ b/schemas/dab.draft-01.schema.json
@@ -31,14 +31,25 @@
     },
     "cosmos": {
       "type": "object",
-      "description": "Azure CosmosDb related settings",
+      "description": "Azure Cosmos DB related settings",
       "properties": {
-        "set-session-context": {
-          "type": "boolean",
-          "default": true,
-          "description": "Inject JWT claims into session context"
+        "database": {
+          "type": "string",
+          "description": "Name of the database"
+        },
+        "container": {
+          "description": "Name of the container",
+          "type": "string"
+        },
+        "schema": {
+          "description": "Path to the GraphQL schema file",
+          "type": "string"
         }
-      }
+      },
+      "required": [
+        "database",
+        "schema"
+      ]
     },
     "runtime": {
       "type": "object",
@@ -58,16 +69,9 @@
           "type": "object",
           "description": "Global GraphQL endpoint configuration",
           "properties": {
-            "enabled": {
-              "default": true,
-              "type": "boolean"
-            },
             "path": {
               "default": "/graphql",
               "type": "string"
-            },
-            "allow-introspection": {
-              "type": "boolean"
             }
           }
         },
@@ -78,6 +82,7 @@
             "mode": {
               "description": "Set if running in Development or Production mode",
               "type": "string",
+              "default": "production",
               "enum": [
                 "production",
                 "development"
@@ -105,6 +110,11 @@
             "authentication": {
               "type": "object",
               "properties": {
+                "provider": {
+                  "type": "string",
+                  "description": "The name of authentication provider",
+                  "default": "StaticWebApps"
+                },
                 "jwt": {
                   "type": "object",
                   "properties": {
@@ -132,24 +142,6 @@
             "source": {
               "type": "string",
               "description": "The object in the backend database that is mapped to the entity"
-            },
-            "rest": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "route": {
-                      "$ref": "#/$defs/singular-plural"
-                    }
-                  },
-                  "required": [
-                    "route"
-                  ]
-                }
-              ]
             },
             "graphql": {
               "oneOf": [
@@ -218,9 +210,6 @@
                                   "type": "object",
                                   "description": "Define item-level security policy",
                                   "properties": {
-                                    "request": {
-                                      "type": "string"
-                                    },
                                     "database": {
                                       "type": "string"
                                     }
@@ -272,10 +261,6 @@
                       "type": "string",
                       "description": "The database object used for supporting the M:N relationship"
                     },
-                    "linking.entity": {
-                      "type": "string",
-                      "description": "The entity used for supporting the M:N relationship"
-                    },
                     "linking.source.fields": {
                       "type": "array",
                       "items": {
@@ -290,17 +275,9 @@
                     }
                   },
                   "required": [
+                    "cardinality",
                     "target.entity"
                   ]
-                }
-              }
-            },
-            "mappings": {
-              "type": "object",
-              "description": "Define mappings between database fields and GraphQL and REST fields",
-              "patternProperties": {
-                "^.*$": {
-                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
## What is the change?
This PR is to update the JSON config schema to reflect only those properties that are supported as of now before release M1.5.

### Properties that have been **removed**:
1) Entity level `rest` property. This is because interpretation of `singular`, `plural` is not yet clear
2) `mappings` property. Even though we added support for this in REST, column-level aliasing support for GraphQL is not yet supported. 
3) `mssql` section to support session context.
4) `policy.request` is removed since we dont support request level authorization policies. Only `database` policy is supported.
5) `entities.relationships.linking.entity` is not required anymore since its an edge case scenario the specs no longer mandate.
The default behavior of the following properties is supported. Haven't added support for disabling them when they would be set to `false`.
6) global graphql setting of `allow-introspection`. Currently we always allow introspection by default. 
7) global graphql setting of  `enabled`. Its enabled by default.
8) global rest setting of `enabled` since rest is enabled by default for `mssql`, `postgresql` and `mysql`.

### Properties that have been **added**:
1)  `provider` property to `authentication` config to indicate what kind of provider it is with the default value being `StaticWebApps`. Other example values are `AppService`, `AzureAD`
2) `cosmos` section to provide `database`, path to `schema` of graphql, and optionally a `container` name.

Note: `entities.relationships.cardinality` is a required property.