### PR TITLE
Fix the version of binaries within the nuget package

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -77,7 +77,8 @@ steps:
   inputs:
     command: custom
     custom: pack
-    arguments: '../src/Cli/src/Cli.csproj -p:Version=$(dabVersion) -o $(Build.ArtifactStagingDirectory)/nupkg'
+    projects: '**/Cli.csproj'
+    arguments: '-p:Version=$(dabVersion) -o $(Build.ArtifactStagingDirectory)/nupkg'
 
 # This task will authenticate and publish the NuGet Package to internal feed
 # To release a new version update the VersionPrefix in Hawaii.Cli.csproj file.


### PR DESCRIPTION
## Why this change?
- Installed `dab` via the published nuget package obtained in the artifacts of the build pipeline.
but the version was `1.0.0`
![image](https://user-images.githubusercontent.com/3513779/184467362-be9ab5ee-3d8e-41c2-b899-ec3b1c1f503a.png)
- Further investigation showed that even though the nuget package itself had the correct version, the binaries inside it still have the wrong version.
![image](https://user-images.githubusercontent.com/3513779/184466997-ec342e7e-3d54-4500-9d2d-66c89c7414bb.png)
- The binaries inside the `cli-XXX.zip` file have the correct version as do the binaries published under the `cli` folder. 

## What is the change?
- The change specifies a `custom` command of `pack`(even though it exists as a standard command) for the DotNetCoreCLI task in the build pipeline so that we can explicitly pass the version argument to `dotnet` ensuring the binaries inside the nuget package get the desired version. 
This solution provided by: https://stackoverflow.com/questions/42797993/package-version-is-always-1-0-0-with-dotnet-pack

## Testing
Triggered build with the fix and verify the binaries inside the nuget are correct version: https://msdata.visualstudio.com/CosmosDB/_build/results?buildId=69565162&view=artifacts&pathAsName=false&type=publishedArtifacts
![image](https://user-images.githubusercontent.com/3513779/184467261-f095a057-8e02-46ef-85de-b4ed44b21c8c.png)

Also verified after installing:

```
D:\DataGateway>dotnet tool install -g --add-source ./ dab --version 0.0.23-69565162
You can invoke the tool using the following command: dab
Tool 'dab' (version '0.0.23-69565162') was successfully installed.

D:\DataGateway>dab --version
dab 0.0.23-69565162
```
