### PR TITLE
Increment patch automatically with `seed=6` for M1.5 based on `build.reason`

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -15,7 +15,7 @@ variables:
   buildConfiguration: 'Release'
   major: 0
   minor: 1
-  patch: $[counter(variables['build.reason'], 5)]
+  patch: $[counter(variables['build.reason'], 6)]
   publishNugetToFeed: $(isNugetRelease)
 
 steps:


### PR DESCRIPTION
If there is a need to release new bits for M1.5, we need publish with a new patch after the v0.1.5. 
This change is to increment the patch automatically for any new build reasons. 
Major(0) and minor(1) version will remain frozen for M1.5