### PR TITLE
Only display FK Query information when in developer mode

### DIFF
--- a/src/Service/Resolvers/BaseSqlQueryBuilder.cs
+++ b/src/Service/Resolvers/BaseSqlQueryBuilder.cs
@@ -332,7 +332,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         }
 
         /// <inheritdoc />
-        public virtual string BuildForeignKeyInfoQuery(int numberOfParameters)
+        public virtual string BuildForeignKeyInfoQuery(int numberOfParameters, bool developerMode)
         {
             string[] schemaNameParams =
                 CreateParams(kindOfParam: SCHEMA_NAME_PARAM, numberOfParameters);
@@ -374,7 +374,13 @@ FROM
 WHERE
     ReferencingColumnUsage.TABLE_SCHEMA IN (@{tableSchemaParamsForInClause})
     AND ReferencingColumnUsage.TABLE_NAME IN (@{tableNameParamsForInClause})";
-            Console.WriteLine($"Foreign Key Query is : {foreignKeyQuery}");
+
+            // only display foreign key query information in dev mode
+            if (developerMode)
+            {
+                Console.WriteLine($"Foreign Key Query is : {foreignKeyQuery}");
+            }
+
             return foreignKeyQuery;
         }
 

--- a/src/Service/Resolvers/IQueryBuilder.cs
+++ b/src/Service/Resolvers/IQueryBuilder.cs
@@ -48,7 +48,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// Builds the query to obtain foreign key information with the given
         /// number of parameters.
         /// </summary>
-        public string BuildForeignKeyInfoQuery(int numberOfParameters);
+        public string BuildForeignKeyInfoQuery(int numberOfParameters, bool developerMode);
 
         /// <summary>
         /// Adds database specific quotes to string identifier

--- a/src/Service/Resolvers/MySqlQueryBuilder.cs
+++ b/src/Service/Resolvers/MySqlQueryBuilder.cs
@@ -141,7 +141,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         }
 
         /// <inheritdoc />
-        public override string BuildForeignKeyInfoQuery(int numberOfParameters)
+        public override string BuildForeignKeyInfoQuery(int numberOfParameters, bool developerMode)
         {
             string[] databaseNameParams = CreateParams(DATABASE_NAME_PARAM, numberOfParameters);
             string[] tableNameParams = CreateParams(TABLE_NAME_PARAM, numberOfParameters);
@@ -172,7 +172,12 @@ WHERE
     (REFERENCED_TABLE_SCHEMA IN (@{tableSchemaParamsForInClause}) AND
     REFERENCED_TABLE_NAME IN (@{tableNameParamsForInClause}))";
 
-            Console.WriteLine($"Foreign Key Query is : {foreignKeyQuery}");
+            // only display foreign key query information in dev mode
+            if (developerMode)
+            {
+                Console.WriteLine($"Foreign Key Query is : {foreignKeyQuery}");
+            }
+
             return foreignKeyQuery;
         }
 

--- a/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -37,6 +37,8 @@ namespace Azure.DataApiBuilder.Service.Services
 
         private const int NUMBER_OF_RESTRICTIONS = 4;
 
+        protected bool DeveloperMode { get; }
+
         protected string ConnectionString { get; init; }
 
         protected IQueryBuilder SqlQueryBuilder { get; init; }
@@ -70,6 +72,7 @@ namespace Azure.DataApiBuilder.Service.Services
                 entity.TryPopulateSourceFields();
             }
 
+            DeveloperMode = runtimeConfigProvider.IsDeveloperMode();
             ConnectionString = runtimeConfig.ConnectionString;
             EntitiesDataSet = new();
             SqlQueryBuilder = queryBuilder;
@@ -896,7 +899,7 @@ namespace Azure.DataApiBuilder.Service.Services
 
             // Build the query required to get the foreign key information.
             string queryForForeignKeyInfo =
-                ((BaseSqlQueryBuilder)SqlQueryBuilder).BuildForeignKeyInfoQuery(tableNames.Count());
+                ((BaseSqlQueryBuilder)SqlQueryBuilder).BuildForeignKeyInfoQuery(tableNames.Count(), DeveloperMode);
 
             // Build the parameters dictionary for the foreign key info query
             // consisting of all schema names and table names.


### PR DESCRIPTION
We do not want to display the foreign key query information unless the service is started in developer mode. This change adds a developer mode field to the `SqlMetaDataProvider`, which is then passed along to the function that generates the foreign key query. Then, only if we are in developer mode will be write the query information to the log.

This relates to https://github.com/Azure/data-api-builder/issues/730 