### PR TITLE
[Cherry-pick] Improves doc structure for getting-started guide (#769)

### DIFF
--- a/docs/getting-started/getting-started-azure-cosmos-db.md
+++ b/docs/getting-started/getting-started-azure-cosmos-db.md
@@ -4,6 +4,41 @@ Make sure you have read the [Getting Started](getting-started.md) document.
 
 This tutorial assumes that you have already a [Cosmos DB SQL API database account](https://learn.microsoft.com/azure/cosmos-db/sql/create-cosmosdb-resources-portal#create-an-azure-cosmos-db-account) that can be used as a playground.
 
+## Create the database containers
+
+Create the necessary database containers needed to represent Authors and Books.
+
+-   `authors`: Collection containing authors with 'id' as the partition key
+-   `books`: Collection containing books with 'id' as the partition key
+
+Read more about [choosing partition key](https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview#choose-partitionkey) and [data modelling](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/modeling-data)
+
+Once the containers are created, you can import the sample data which are placed in the 'azure-cosmos-db' folder to the respective collections by using the [Data Import Tool](https://docs.microsoft.com/en-us/azure/cosmos-db/import-data#JSON).
+
+## Add Book and Author schema files
+
+We need to expose the books and the authors collections so that they can be used via GraphQL. Cosmos DB, being schema agnostic, requires us to provide the schema definition for the collections. These schema definitions need to be added in the `schema.gql` file.
+
+Start by adding the `author` and `book` schema:
+
+```graphql
+type Author @model {
+    id : ID,
+    first_name : String,
+    middle_name: String,
+    last_name: String,
+    Books: [Book]
+}
+
+type Book @model {
+    id : ID,
+    title : String,
+    Authors: [String]
+}
+```
+
+> **BEST PRACTICE**: It is recommended to use the *singular* form for entities names. For GraphQL, the Data API builder engine will automatically use the correct plural form to generate the final GraphQL schema whenever a *list* of entity items will be returned. More on this behavior in the [GraphQL documentation](./../graphql.md).
+
 ## Get the Cosmos DB Account connection string
 
 You can obtain the connection string by navigating to your Azure Cosmos DB account page's key blade, and select Primary connection string. Copy the value to use in the Data API Builder.
@@ -18,33 +53,57 @@ The connection string looks like,
 AccountEndpoint=AccountEndpoint=https://localhost:8081/;AccountKey=REPLACEME;
 ```
 
-Once you have the connection string, add it to the configuration file you have created before. It will look like the following if you are using Azure Cosmos DB:
+Now that you have all the required pieces in place, it's time to create the configuration file for DAB.
+
+## Creating a configuration file for DAB
+
+The Data API builder for Azure Databases engine needs a [configuration file](../configuration-file.md). There you'll define which database DAB connects to, and which entities are to be exposed by the API, together with their properties.
+
+For this getting started guide you will use DAB CLI to initialize your configuration file. Run the following command:
+
+```bash
+dab init --database-type "cosmos" --graphql-schema schema.gql --cosmos-database PlaygroundDB --connection-string "AccountEndpoint=https://localhost:8081/;AccountKey=REPLACEME;" --host-mode "Development"
+```
+
+The command will generate a config file called `dab-config.json` looking like this:
 
 ```json
-"data-source": {
+{
+  "$schema": "dab.draft-01.schema.json",
+  "data-source": {
     "database-type": "cosmos",
-    "connection-string": "AccountEndpoint=yourEndpoint;AccountKey=REPLACEME"
+    "connection-string": "AccountEndpoint=https://localhost:8081/;AccountKey=REPLACEME;"
+  },
+  "cosmos": {
+    "database": "PlaygroundDB",
+    "schema": "schema.gql"
+  },
+  "runtime": {
+    "rest": {
+      "enabled": false,
+      "path": "/api"
+    },
+    "graphql": {
+      "allow-introspection": true,
+      "enabled": true,
+      "path": "/graphql"
+    },
+    "host": {
+      "mode": "development",
+      "cors": {
+        "origins": [],
+        "allow-credentials": false
+      },
+      "authentication": {
+        "provider": "StaticWebApps"
+      }
+    }
+  },
+  "entities": {}
 }
 ```
 
-and add the relevant database name in the Cosmos DB specific section of the configuration file
-
-```json
- "cosmos": {
-    "database": "PlaygroundDB",
-  }
-```
-
-## Create the database containers
-
-Create the necessary database containers needed to represent Authors and Books.
-
--   `authors`: Collection containing authors with 'id' as the partition key
--   `books`: Collection containing books with 'id' as the partition key
-
-Read more about [choosing partition key](https://learn.microsoft.com/azure/cosmos-db/partitioning-overview#choose-partitionkey) and [data modelling](https://learn.microsoft.com/azure/cosmos-db/sql/modeling-data)
-
-Once the containers are created, you can import the sample data which are placed in the 'azure-cosmos-db' folder to the respective collections by using the [Data Import Tool](https://learn.microsoft.com/azure/cosmos-db/import-data#JSON).
+That's all you need at the moment. Let's work now on defining the entities exposed by the API.
 
 ## Add Book and Author entities
 
@@ -104,33 +163,6 @@ You can also add the `book` entity now, applying the same concepts you just lear
     }
   }
 ```
-## Add Book and Author schema files
-
-We need to expose the books and the authors collections so that they can be used via Graphql. Cosmos DB, being schema agnostic, we need to provide the schema definition for the collections. These schema definitions need to be added in the `schema.gql` file.
-
-Start by adding the `author` and `book` schema:
-
-```graphql
-type Author @model {
-    id : ID,
-    first_name : String,
-    middle_name: String,
-    last_name: String,
-    Books: [Book]
-}
-
-type Book @model {
-    id : ID,
-    title : String,
-    Authors: [String]
-}
-```
-
-Add the above schemas to the `samples/getting-started/azure-cosmos-db` schema.gql file.
-
-That's all you need at the moment. Data API builder is ready to be run.
-
-> **BEST PRACTICE**: It is recommeneded to use the *singular* form for entities names. For GraphQL, the Data API builder engine will automatically use the correct plural form to generate the final GraphQL schema whenever a *list* of entity items will be returned. More on this behaviour in the [GraphQL documentation](./../graphql.md).
 
 ## Start Data API builder for Azure Cosmos DB
 
@@ -149,10 +181,9 @@ Now listening on: https://localhost:5001
 
 The Data API builder engine is running and is ready to accept requests.
 
-
 ## Query the endpoints
 
-Now that the Data API builder engine is running, you can use your favourite REST client (Postman, Insomnia, etc.) to query the GraphQL endpoints.
+Now that the Data API builder engine is running, you can use your favorite REST client (Postman, Insomnia, etc.) to query the GraphQL endpoints.
 
 ### REST Endpoint
 

--- a/docs/getting-started/getting-started-azure-sql.md
+++ b/docs/getting-started/getting-started-azure-sql.md
@@ -4,7 +4,7 @@ Make sure you have read the [Getting Started](getting-started.md) document.
 
 As mentioned before, this tutorial assumes that you already have a SQL Server or an Azure SQL database that can be used as playground.
 
-## Get the database connection string
+### Get the database connection string
 
 There are several ways to get an Azure SQL database connection string. More details here:
 https://learn.microsoft.com/azure/azure-sql/database/connect-query-content-reference-guide?view=azuresql
@@ -23,32 +23,60 @@ Server=localhost;Database=Library;User ID=dab_user;Password=<password>;TrustServ
 
 More details on Azure SQL and SQL Server connection strings can be found here: https://learn.microsoft.com/sql/connect/ado-net/connection-string-syntax
 
-Once you have your connection string, add it to the configuration file you have created before. It will look like the following (if you are using a local SQL Server):
+Now that you have all the required pieces in place, it's time to create the configuration file for DAB.
+
+## Creating a configuration file for DAB
+
+The Data API builder for Azure Databases engine needs a [configuration file](../configuration-file.md). There you'll define which database DAB connects to, and which entities are to be exposed by the API, together with their properties.
+
+For this getting started guide you will use DAB CLI to initialize your configuration file. Run the following command:
+
+```bash
+dab init --database-type "mssql" --connection-string "Server=localhost;Database=PlaygroundDB;User ID=PlaygroundUser;Password=<Password>;TrustServerCertificate=true" --host-mode "Development"
+```
+
+The command will generate a config file called `dab-config.json` looking like this:
 
 ```json
-"data-source": {
+{
+  "$schema": "dab.draft-01.schema.json",
+  "data-source": {
     "database-type": "mssql",
-    "connection-string": "Server=localhost;Database=PlaygroundDB;User ID=PlaygroundUser;Password=<Password>;TrustServerCertificate=true"
+    "connection-string": "Server=localhost;Database=PlaygroundDB;User ID=PlaygroundUser;Password=ReplaceMe;TrustServerCertificate=true"
+  },
+  "mssql": {
+    "set-session-context": true
+  },
+  "runtime": {
+    "rest": {
+      "enabled": true,
+      "path": "/api"
+    },
+    "graphql": {
+      "allow-introspection": true,
+      "enabled": true,
+      "path": "/graphql"
+    },
+    "host": {
+      "mode": "development",
+      "cors": {
+        "origins": [],
+        "allow-credentials": false
+      },
+      "authentication": {
+        "provider": "StaticWebApps"
+      }
+    }
+  },
+  "entities": {}
 }
 ```
 
-if you haven't created your configuration file yet, you can do it right now, for example, below command will generate a config with name `dab-config.json`, use --config otherwise to specify the name:
+As you can see there the `data-source` property specifies that our chosen `database-type` is `mssql`, with the `connection-string` we passed to DAB CLI.
 
-```bash
-dab init --database-type "mssql" --connection-string "Server=localhost;Database=PlaygroundDB;User ID=PlaygroundUser;Password=<Password>;TrustServerCertificate=true"
-```
+>Take a look at the [DAB Configuration File Guide](../configuration-file.md) document to learn more.
 
-if you already have created the configuration file, you can just open it with an editor like VS Code and manually update the `connection-string` and the `database-type` in the `data-source` section.
-
-## Create the database objects
-
-Create the database tables needed to represent Authors, Books and the many-to-many relationship between Authors and Books. You can find the `libray.azure-sql.sql` script in the `azure-sql-db` folder in the GitHub repo. You can use it to create three tables, along with sample data:
-
-- `dbo.authors`: Table containing authors
-- `dbo.books`: Table containing books
-- `dbo.books_authors`: Table associating books with respective authors
-
-Execute the script in the SQL Server or Azure SQL database you decided to use, so that the tables with samples data are created and populated.
+With the configuration file in place, then it's time to start defining which entities you want to expose via the API.
 
 ## Add Book and Author entities
 
@@ -109,7 +137,7 @@ You can also add the `book` entity now, applying the same concepts you just lear
 
 that's all is needed at the moment. Data API builder is ready to be run.
 
-> **BEST PRACTICE**: It is recommeneded to use the *singular* form for entities names. For GraphQL, the Data API builder engine will automatically use the correct plural form to generate the final GraphQL schema whenever a *list* of entity items will be returned. More on this behaviour in the [GraphQL documentation](./../graphql.md).
+> **BEST PRACTICE**: It is recommended to use the *singular* form for entities names. For GraphQL, the Data API builder engine will automatically use the correct plural form to generate the final GraphQL schema whenever a *list* of entity items will be returned. More on this behaviour in the [GraphQL documentation](./../graphql.md).
 
 ## Start Data API builder for Azure SQL Database
 
@@ -136,7 +164,7 @@ you'll be good to go, Data API Builder is up and running, ready to serve your re
 
 ## Query the endpoints
 
-Now that Data API builder engine is running, you can use your favourite REST client (Postman or Insomnia, for example) to query the REST or the GraphQL endpoints.
+Now that Data API builder engine is running, you can use your favorite REST client (Postman or Insomnia, for example) to query the REST or the GraphQL endpoints.
 
 ### REST Endpoint
 
@@ -159,7 +187,7 @@ The following HTTP verbs are supported:
 - `PUT` `PATCH`: update or create an item
 - `DELETE`: delete an item
 
-Whenver you need to access a single item, you can get the item you want by specifying its primary key:
+Whenever you need to access a single item, you can get the item you want by specifying its primary key:
 
 ```
 GET /api/book/id/1000

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -1,6 +1,15 @@
 # Getting started with Data API builder for Azure Databases
 
-Welcome to this guide that will help you get started with Data API builder (DAB) for Azure Databases. First you are going to get it running locally on your machine. Then we will show you how to deploy Data API builder for Azure Databases in an Azure Container Instance. At the end of the tutorial you'll understand what's needed to run Data API builder for Azure Databases both on-prem and on Azure.
+Welcome! In this guide we will help you get started with Data API builder (DAB) for Azure Databases. First you are going to get DAB running locally on your machine. Then you will use DAB to create an API for your application. You will have the option to choose between Azure SQL Database or Azure Cosmos DB as the database backend.
+
+## Use case scenario
+
+In this tutorial we'll be creating the backend API for a small solution that allows end-users to keep track of books in their bookshelf. Therefore, the business entities we'll be dealing with are:
+
+- Books
+- Authors
+
+Both the business entities need a modern endpoint, REST and/or GraphQL, to allow third party developers to build mobile and desktop applications to manage the library catalog. Data API builder is perfect for enabling that modern endpoint support.
 
 ## Prerequisites
 
@@ -14,99 +23,58 @@ You can list the SDKs installed on your machine by using the following command:
 dotnet --list-sdks
 ```
 
-### Azure Database
-
-As the Data API builder for Azure Databases generates REST and GraphQL endpoints for database objects, you need to have a database ready for the tutorial. You can choose either a relational or non-relational database. This getting started guide documents the process to have Data API builder set up for:
-
-- Azure SQL 
-- Azure Cosmos DB
-
 ## Installing DAB CLI
 
-Data API Builder provides a CLI tool to simplify configuration and execution of the engine. A detailed description on how DAB CLI can be installed on your machine can be found here: [Running Data API Builder for Azure Databases using CLI](../running-using-dab-cli.md)
+Data API Builder provides a CLI tool to simplify configuration and execution of the engine. You can install the DAB CLI using [.NET tools](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools):
 
-## Getting to know the configuration file
+- Download the latest version of the package: [dab.<version_number>.nupkg](https://github.com/Azure/data-api-builder/releases/)
+- Navigate to the folder where the package file is downloaded.
 
-The Data API builder for Azure Databases engine needs a [configuration file](../configuration-file.md). There you'll define which database DAB connects to, and which entities are to be exposed, together with their properties.
-
-Let's start with an overview of a basic configuration file, and then we'll move to initializing one using the DAB CLI.
-
-### Overview of configuration file
-
-A basic configuration file looks like the following:
-
-```json
-{
-    "$schema": "../../schemas/dab.draft-01.schema.json",
-    "data-source": {
-        "database-type": "",
-        "connection-string": ""
-    },
-    "runtime": {
-        "host": {
-            "mode": "development"
-        }
-    },
-    "entities": {
-    }
-}
-```
-
-The `$schema` property points to the JSON schema that can be used to validate the configuration file. IDEs like like Visual Studio Code will use this proeperty to provide intellisense and autocomplete features.
-
-In the `data-source` section you have to specify the database type and the connection string to connect to the database containing the objects you want to expose.
-
-`database-type` can be any of the following:
-- `mssql`: for Azure SQL DB, Azure SQL MI or SQL Server
-- `cosmos`: for Azure Cosmos DB (SQL API)
-- `postgresql`: for PostgreSQL
-- `mysql`: for MySQL or MariaDB
-
-Set the value of `database-type` to the database you want to use. For this tutorial we'll be using `mssql` or `cosmos` to showcase DAB's support for both relational and non-relational databases.
-
-Once you have chosen the database you want to connect to, you will need to provide the connection string in the `connection-string` property. This is a standard ADO.NET connection string. You can get it from the Azure Portal, for instance. 
-
-The `runtime` section is telling Data API builder to run in `development` mode. This means database errors will be surfaced and returned with full detail. This is great for development, but can be a security risk when running in production: that's why switching to `production` mode will disable this debug feature.
-
-The last property is `entities`. You'll leave it empty for now. This property will contain all the objects you want to be exposed as REST or GraphQL endpoints.
-
-### Initialize the configuration file
-
-Initializing a configuration file can be done with the Data API builder CLI as well: 
+then, to install this tool globally, use:
 
 ```bash
-dab init --database-type "<database-type>" --connection-string "<connection-string>"
+dotnet tool install -g --add-source ./ dab --version <version_number>
 ```
 
-where for `database-type` and `connection-string` you can use any of the values described in the [Overview of configuration file](#overview-of-configuration-file) section above. If you don't know the connection string, no worries, we'll take care of that later, in one of the database-specific Getting Started documents we have created for you.
+> **ATTENTION**: if you are running on Linux or MacOS, you may need to add .NET global tools to your PATH to call `dab` directly. Once installed run:
+> `export PATH=$PATH:~/.dotnet/tools`
 
-## The sample scenario
+## Verifying the installation
 
-In this tutorial we'll be creating the backend API for a small solution that allows end-users to keep track of books in their library. Therefore, the business entities we'll be dealing with are
+Installing the package will make the `dab` command available on your development machine. To validate your installation, you can run the following command:
 
-- Books
-- Authors
+```bash
+dab --version
+```
 
-Both the business entities need a modern endpoint, REST and/or GraphQL, to allow third party developers to build mobile and desktop applications to manage the library catalog. Data API builder is perfect for enabling that modern endpoint support.
+which should output 
 
-## Configure the Entities
+```bash
+dab 0.1.5
+```
 
-Depending if you want to use Azure SQL or Cosmos DB, continue to the appropriate link:
+Where `0.1.5` should match your version of DAB CLI.
+
+>For detailed instructions on how to Install DAB CLI look here: [Running Data API Builder for Azure Databases using CLI](../running-using-dab-cli.md)
+
+## Azure Database
+
+As the Data API builder for Azure Databases generates REST and GraphQL endpoints for database objects, you need to have a database ready for the tutorial. You can choose either a relational or non-relational database. This getting started guide documents the process to set up Data API builder for Azure SQL or Azure Cosmos DB.
+
+It's time for you to choose which database you want to use, so you can continue the getting started guide from there:
 
 - [Getting Started with Data API builder for Azure SQL](./getting-started-azure-sql.md)
 - [Getting Started with Data API builder for with Azure Cosmos DB](./getting-started-azure-cosmos-db.md)
 
-And then proceed to the "Next Steps" to go even further
-
-## Next Steps
+## Further reading
 
 ### Running Data API Builder using Docker
 
-You can use Docker to run the Data API Builder on your machine. Instructions are availabe here: [Running Data API Builder for Azure Databases using a container](../running-using-a-container.md)
+You can use Docker to run the Data API Builder on your machine. Instructions are available here: [Running Data API Builder for Azure Databases using a container](../running-using-a-container.md)
 
 ### Using Data API Builder CLI to build the configuration file
 
-Instead of creating the configuration file manually, you can take advantage of the CLI [Getting started with Data API Builder (`dab`) CLI](../getting-started/getting-started-dab-cli.md): 
+Data API Builder comes with a full CLI to help you run common tasks [Getting started with Data API Builder (`dab`) CLI](../getting-started/getting-started-dab-cli.md): 
 
 ### Deploy on Azure
 


### PR DESCRIPTION
## Why make this change?

This PR is a cherry pick of this [commit](https://github.com/Azure/data-api-builder/commit/d088496bb63de73dacb2e6c246116f1ce8bb8acf) from the release/M1.5 branch. It is required to keep our documentation consistent.

---------------------**Original PR description** -------------------------------
The fix streamlines the getting started guide with the goal of getting users from zero to success as quick as possible. This keeps the tutorial focused on the user implementing the proposed Library use case.

- The preferred path for users is to use `dab` CLI to start the configuration file. Details about the config file are only given when needed.
- Database backend choice (AzureSQL/CosmosDB) is given a the end of the first part (getting-started.md)
- Once the proper connection string is obtained, the user runs `dab` and generates their config file
- Details about CLI options, config file schema, docker options, etc., are left to their respective files
- Document flow removes almost all branching to other docs, unless needed. Goal is to keep the user focused in the task at hand

* Update docs/getting-started/getting-started-azure-cosmos-db.md

Co-authored-by: Sean Leonard <sean.leonard@microsoft.com>

* Apply suggestions from code review

Co-authored-by: Sean Leonard <sean.leonard@microsoft.com>

* fixes Cosmos DB connection string

* Update docs/getting-started/getting-started-azure-cosmos-db.md

Co-authored-by: Sean Leonard <sean.leonard@microsoft.com>

* Update docs/getting-started/getting-started-azure-sql.md

Co-authored-by: Aniruddh Munde <anmunde@microsoft.com>

Co-authored-by: Sean Leonard <sean.leonard@microsoft.com>
Co-authored-by: Aniruddh Munde <anmunde@microsoft.com>
