### PR TITLE
Bugfix: db/container name to titlecase while mapping

### DIFF
--- a/src/Service.Tests/Unittests/CosmosSqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/CosmosSqlMetadataProviderUnitTests.cs
@@ -1,0 +1,31 @@
+using Azure.DataApiBuilder.Service.Configurations;
+using Azure.DataApiBuilder.Service.Services.MetadataProviders;
+using Azure.DataApiBuilder.Service.Tests.CosmosTests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Azure.DataApiBuilder.Service.Tests.UnitTests
+{
+    /// <summary>
+    /// Unit testing for the CosmosMetadataProvider
+    /// </summary>
+    [TestClass, TestCategory(TestCategory.COSMOS)]
+    public class CosmosSqlMetadataProviderUnitTests : TestBase
+    {
+        RuntimeConfigProvider _runtimeConfigProvider;
+
+        /// <summary>
+        /// Make sure lower case container name would not result in not finding the entity.
+        /// </summary>
+        [DataTestMethod]
+        public void TestGetDatabaseConfig()
+        {
+            _runtimeConfigProvider = TestHelper.GetRuntimeConfigProvider(CosmosTestHelper.ConfigPath);
+            CosmosSqlMetadataProvider cosmosSqlMetadataProvider = new(_runtimeConfigProvider, null);
+
+            string name = cosmosSqlMetadataProvider.GetDatabaseObjectName("planet");
+            Assert.AreEqual("planet", name);
+
+        }
+
+    }
+}

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config;
@@ -47,7 +48,7 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
         /// <inheritdoc />
         public string GetDatabaseObjectName(string entityName)
         {
-            Entity entity = _entities[entityName];
+            Entity entity = _entities[CultureInfo.CurrentCulture.TextInfo.ToTitleCase(entityName)];
 
             string entitySource = entity.GetSourceName();
 
@@ -72,7 +73,7 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
         /// <inheritdoc />
         public string GetSchemaName(string entityName)
         {
-            Entity entity = _entities[entityName];
+            Entity entity = _entities[CultureInfo.CurrentCulture.TextInfo.ToTitleCase(entityName)];
 
             string entitySource = entity.GetSourceName();
 


### PR DESCRIPTION
…solve to the entity name which is in TitleCase

## Why make this change?
Entities are unable to map to database/container names when the container/database names are in lowercase. Adding this fix to address that issue.

## How was this tested?

- [ ] Integration Tests
- [x] Unit Tests
