### PR TITLE
Patch #810

### DIFF
--- a/src/Service.Tests/SqlTests/GraphQLSupportedTypesTests/GraphQLSupportedTypesTestsBase.cs
+++ b/src/Service.Tests/SqlTests/GraphQLSupportedTypesTests/GraphQLSupportedTypesTestsBase.cs
@@ -246,8 +246,8 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLSupportedTypesTests
         [DataRow(BOOLEAN_TYPE, true)]
         [DataRow(DATETIME_TYPE, "1999-01-08 10:23:54+8:00")]
         [DataRow(BYTEARRAY_TYPE, "V2hhdGNodSBkb2luZyBkZWNvZGluZyBvdXIgdGVzdCBiYXNlNjQgc3RyaW5ncz8=")]
-        [DataRow(GUID_TYPE, "\"3a1483a5-9ac2-4998-bcf3-78a28078c6ac\"")]
-        [DataRow(GUID_TYPE, "null")]
+        [DataRow(GUID_TYPE, "3a1483a5-9ac2-4998-bcf3-78a28078c6ac")]
+        [DataRow(GUID_TYPE, null)]
         public async Task UpdateTypeColumnWithArgument(string type, object value)
         {
             if (!IsSupportedType(type))

--- a/src/Service/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
@@ -239,7 +239,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                 "Decimal" => decimal.Parse(param),
                 "Boolean" => bool.Parse(param),
                 "DateTime" => DateTimeOffset.Parse(param),
-                "Guid" => param is null ? Guid.Parse(param) : null,
+                "Guid" => Guid.Parse(param),
                 _ => throw new NotSupportedException($"{systemType.Name} is not supported")
             };
         }


### PR DESCRIPTION
## Why make this change?

- There was a bug in the inserting/updating uuid-s. Fixed that.
- Thanks to @ayush3797 for catching this.

## What is this change?

- Removes the unnecessary inline if since the parameter of the function cannot be null (first time around my linter was not working properly so I overlooked that detail), and fixes parameterized test's parameters.

## How was this tested?

- [x] Integration Tests

## Sample Request(s)

```gql
updateSupportedType(id: 1, item: {guid_types: "3a1483a5-9ac2-4998-bcf3-78a28078c6ac"})
{
	guid_types
}
```
