### PR TITLE
Run OnConfigChangesAsync synchronously

### DIFF
--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -246,9 +246,9 @@ namespace Azure.DataApiBuilder.Service
             }
             else
             {
-                runtimeConfigProvider.RuntimeConfigLoaded += async (sender, newConfig) =>
+                runtimeConfigProvider.RuntimeConfigLoaded += (sender, newConfig) =>
                 {
-                    isRuntimeReady = await PerformOnConfigChangeAsync(app);
+                    isRuntimeReady = PerformOnConfigChangeAsync(app).Result;
                 };
             }
 


### PR DESCRIPTION
## Why make this change?
When running the hosted version, since the config is loaded asynchronously, we return before we're done loading the config causing some requests to arrive before the engine is ready and resulting in 503 error codes.

closes #848 

## What is this change?
Call .Result on OnConfigChangesAsync.

## How was this tested?

- [x] Ran locally and verified that initial requests no longer return 503s.