### PR TITLE
updating stored-procedure design doc

### DIFF
--- a/docs/internals/StoredProcedureDesignDoc.md
+++ b/docs/internals/StoredProcedureDesignDoc.md
@@ -256,7 +256,7 @@ Implementation was segmented into 5 main sections:
 
 ### `SqlQueryEngine.cs` and `SqlMutationEngine.cs`
 > - `ExecuteListAsync` is called where we create an object of `SqlExecuteStructure` and calls `ExecuteAsync(SqlExecuteStructure)`.
-> - We format the result as list of JsonDocument. If the user has no read permission, it will return an empty list.
+> - We format the result as list of JsonElement. If the user has no read permission, it will return an empty list.
 
 > ### Example 
 > 1. Query With param as id


### PR DESCRIPTION
## Why make this change?
- It contains updating the design doc to understand the changes that are required for implementing stored-procedure for graphql
- It also helps understand the rationale for certain assumptions that were made.

## What is this change?

- Updating the doc file to add high level change required in different classes/methods to support stored-procedure for graphQL.
  - Links to relevant documentation: 
  - - https://github.com/Azure/data-api-builder/issues/869
  - - https://github.com/Azure/data-api-builder/blob/a9a56dbcc3778bbe227dabdb64e7b61b3d25672f/docs/StoredProcedureDesignDoc.md

## NOTE:
the doc contains images that might not be shown correctly on the **Files changed** tab. To view the images correctly head over to the branch file: https://github.com/Azure/data-api-builder/blob/dev/abhishekkuma/graphql-support-for-stored-procedure-doc/docs/internals/StoredProcedureDesignDoc.md
