### PR TITLE
Log entity name for rest path, not source name

### DIFF
--- a/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -78,7 +78,7 @@ namespace Azure.DataApiBuilder.Service.Services
                 entity.Value.TryPopulateSourceFields();
                 if (runtimeConfigProvider.GetRuntimeConfiguration().RestGlobalSettings.Enabled)
                 {
-                    _logger.LogInformation($"{entity.Key} path: {runtimeConfigProvider.RestPath}/{entity.Value.SourceName}");
+                    _logger.LogInformation($"{entity.Key} path: {runtimeConfigProvider.RestPath}/{entity.Key}");
                 }
                 else
                 {


### PR DESCRIPTION
## Why make this change?

We recently added logging that captures the rest path for each entity, but this change used the source name, paths rely on entity name.

## What is this change?

In the `SqlMetadataProvider` constructor we use the entity name instead of the source name.
## How was this tested?

Manually verified the logging updated to capture correct paths.

## Sample Request(s)

Start engine as normal, view output window.
