### PR TITLE
Upgrade Sql Client to 4.1.1

### DIFF
--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -257,7 +257,6 @@ namespace Azure.DataApiBuilder.Service
             {
                 // Config provided before starting the engine.
                 isRuntimeReady = PerformOnConfigChangeAsync(app).Result;
-                Console.WriteLine($"CONNECTION STRING = {runtimeConfigProvider.GetRuntimeConfiguration().ConnectionString}");
                 if (_logger is not null && runtimeConfigProvider.RuntimeConfigPath is not null)
                 {
                     _logger.LogInformation($"Loading config file: {runtimeConfigProvider.RuntimeConfigPath!.ConfigFileName}");


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/911

Sql Client 3.0 is out of support, so we upgrade to 4.1.1

## What is this change?

In `Directory.Build.Props` we change the Sql Version to 4.1.1

## How was this tested?

Ran against current test suite.

## Sample Request(s)

Start and run engine as normal.
