### PR TITLE
Update minor version for release

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   major: 0
-  minor: 3
+  minor: 4
   # Maintain a separate patch value between CI and PR runs.
   # The counter is reset when the minor version is updated.
   patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 0)]


### PR DESCRIPTION
## Why make this change?

- So, that the changes after the 0.3 dab release are versioned as 0.4.x

## What is this change?

- updating the minor version in build-pipeline

