### PR TITLE
Adding query filter tests for second level inner object in json

### DIFF
--- a/src/Service.Tests/CosmosTests/CosmosTestHelper.cs
+++ b/src/Service.Tests/CosmosTests/CosmosTestHelper.cs
@@ -43,7 +43,11 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
                     name = "planet character",
                     type = "Mars",
                     homePlanet = 1,
-                    primaryFunction = "test function"
+                    primaryFunction = "test function",
+                    star = new
+                    {
+                        name = name + "_star"
+                    }
                 }
             };
         }

--- a/src/Service.Tests/CosmosTests/QueryFilterTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryFilterTests.cs
@@ -566,6 +566,9 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
                                 name
                                 homePlanet
                                 primaryFunction
+                                star{
+                                   name
+                                }
                             }
                     }
                  }
@@ -594,12 +597,45 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
                                 name
                                 homePlanet
                                 primaryFunction
+                                star{
+                                   name
+                                }
                             }
                     }
                  }
             }";
 
             string dbQuery = "SELECT top 1 c.id, c.name, c.character FROM c where c.character.name = \"planet character\" and c.name=\"Endor\"";
+            await ExecuteAndValidateResult(_graphQLQueryName, gqlQuery, dbQuery);
+        }
+
+        /// <summary>
+        /// Test filters on nested object
+        /// </summary>
+        [TestMethod]
+        public async Task TestFilterOnInnerNestedFields()
+        {
+            string gqlQuery = @"{
+                planets(first: 1, " + QueryBuilder.FILTER_FIELD_NAME + @" : {character : {star : {name : {eq : ""Endor_star""}}}})
+                { 
+                    items {
+                        id
+                        name
+                        character {
+                                id
+                                type
+                                name
+                                homePlanet
+                                primaryFunction
+                                star{
+                                    name
+                                }
+                            }
+                    }
+                 }
+            }";
+
+            string dbQuery = "SELECT top 1 c.id, c.name, c.character FROM c where c.character.star.name = \"Endor_star\"";
             await ExecuteAndValidateResult(_graphQLQueryName, gqlQuery, dbQuery);
         }
 

--- a/src/Service.Tests/CosmosTests/TestBase.cs
+++ b/src/Service.Tests/CosmosTests/TestBase.cs
@@ -29,7 +29,8 @@ type Character @model(name:""Character"") {
     name : String,
     type: String,
     homePlanet: Int,
-    primaryFunction: String
+    primaryFunction: String,
+    star: Star
 }
 
 type Planet @model(name:""Planet"") {

--- a/src/Service/schema.gql
+++ b/src/Service/schema.gql
@@ -3,7 +3,8 @@ type Character @model(name:"Character") {
     name : String,
     type: String,
     homePlanet: Int,
-    primaryFunction: String
+    primaryFunction: String,
+    star: Star
 }
 
 type Planet @model(name:"Planet"){


### PR DESCRIPTION
## Why make this change?
Adding additional test for filtering on inner object json in relation to #880 

## What is this change?
Test addition where we filter on nested inner object.

ex:
```
{
    "id": "Endor",
    "name": "Endor",
    "character": {
        "name": "earth char",
        "age": 37445,
        "star": {
            "name": "Endor_star"
        }
    }
}
```
`planets(filter: {character:{star: name: {eq: "Endor_star"}}})`

`select * from c where c.character.star.name= "Endor_star"`

## How was this tested?

- [x] Integration Tests
- [ ] Unit Tests

## Sample Request(s)

