### PR TITLE
Upgrade `Newtonsoft.Json` to 13.0.2

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -27,7 +27,7 @@
       <PackageVersion Include="MSTest.TestAdapter" Version="2.2.10" />
       <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />
       <PackageVersion Include="MySqlConnector" Version="2.1.5" />
-      <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
       <PackageVersion Include="Npgsql" Version="5.0.10" />
       <PackageVersion Include="Polly" Version="7.2.3" />
       <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />


### PR DESCRIPTION
## Why make this change?

- Component governance detected a high severity security alert while doing static analysis. This PR is to fix that alert and unblock pipeline merges

_

> _______________________________________________________________________________________________________________________________________________ 
> [INFO] |Security Alerts                                                                                                                                | 
> [INFO] |_______________________________________________________________________________________________________________________________________________| 
> [INFO] |Alert title                             |Affected component                      |Severity                      |Due date                      | 
> [INFO] |________________________________________|________________________________________|______________________________|______________________________| 
> [INFO] |GHSA-5crp-9r3c-p9vr                     |Newtonsoft.Json 13.0.1                  |High                          |                              | 
> [INFO] |________________________________________|________________________________________|______________________________|______________________________| 
> [INFO]  
> ##[error]Component Governance failed due to the presence of 1 security alerts at or above 'Medium' severity. Microsoft’s Open Source policy requires that all high and critical security vulnerabilities found by this task be addressed by upgrading vulnerable components. Vulnerabilities in indirect dependencies should be addressed by upgrading the root dependency.

## What is this change?

- Upgrade the version of `Newtonsoft.Json` to 13.0.2