### PR TITLE
Skip generation of multiple config files along with build

### DIFF
--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -46,7 +46,7 @@ steps:
   inputs:
     command: build
     projects: '**/*.csproj'
-    arguments: '-p:generateConfigFile=Cosmos --configuration $(buildConfiguration)' # Update this to match your need
+    arguments: '-p:generateConfigFileForDbType=Cosmos --configuration $(buildConfiguration)' # Update this to match your need
 
 - task: FileTransform@1.206.0
   displayName: 'Generate dab-config.Cosmos.json'

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
     inputs:
       command: build
       projects: '**/*.csproj'
-      arguments: '-p:generateConfigFile=MsSql --configuration $(buildConfiguration)' # Update this to match your need
+      arguments: '-p:generateConfigFileForDbType=MsSql --configuration $(buildConfiguration)' # Update this to match your need
 
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.MsSql.json'
@@ -134,7 +134,7 @@ jobs:
     inputs:
       command: build
       projects: '**/*.csproj'
-      arguments: '-p:generateConfigFile=MsSql --configuration $(buildConfiguration)' # Update this to match your need
+      arguments: '-p:generateConfigFileForDbType=MsSql --configuration $(buildConfiguration)' # Update this to match your need
     
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.MsSql.json'

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
     inputs:
       command: build
       projects: '**/*.csproj'
-      arguments: '-p:generateConfigFile=MySql --configuration $(buildConfiguration)' # Update this to match your need
+      arguments: '-p:generateConfigFileForDbType=MySql --configuration $(buildConfiguration)' # Update this to match your need
 
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.MySql.json'

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
     inputs:
       command: build
       projects: '**/*.csproj'
-      arguments: '-p:generateConfigFile=PostgreSql --configuration $(buildConfiguration)' # Update this to match your need
+      arguments: '-p:generateConfigFileForDbType=PostgreSql --configuration $(buildConfiguration)' # Update this to match your need
 
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.PostgreSql.json'

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -232,7 +232,7 @@ The following steps outline an alternative way of generating config files to ass
 
 1. The **ConfigGenerators** directory contains text files with DAB commands for each database type.
 2. Based on your choice of database, in the respective text file, update the **connection-string** property of the **init** command.
-3. Execute the command `dotnet build -p:generateConfigFile=<database_type>` in the directory `data-api-builder\src` to build the project and generate the config file that can be used when starting DAB. The config file will be generated in the directory `data-api-builder\src\Service`. `MsSql`, `PostgreSql`,`Cosmos` and `MySql` are the values that can be used with `generateConfigFile`. Only the config file for the specified database type will be generated.
+3. Execute the command `dotnet build -p:generateConfigFileForDbType=<database_type>` in the directory `data-api-builder\src` to build the project and generate the config file that can be used when starting DAB. The config file will be generated in the directory `data-api-builder\src\Service`. `MsSql`, `PostgreSql`,`Cosmos` and `MySql` are the values that can be used with `generateConfigFileForDbType`. Only the config file for the specified database type will be generated.
 4. DAB can be started using one of the various methods outlined in this document.
 
 #### Which configuration file is used?

--- a/src/Cli/src/Cli.csproj
+++ b/src/Cli/src/Cli.csproj
@@ -39,8 +39,8 @@
   </ItemGroup>
 
   <Target Name="GenerateConfigFiles" AfterTargets="PostBuildEvent">
-      <Exec Command="powershell.exe -command ..\..\..\ConfigGenerators\configGenerator.ps1 $(generateConfigFile) " Condition=" '$(OS)' == 'Windows_NT' And '$(generateConfigFile)' != '' " />
-      <Exec Command="bash ../../../ConfigGenerators/configGenerator.sh $(generateConfigFile) " Condition=" '$(OS)' != 'Windows_NT' And '$(generateConfigFile)' != '' " />
+      <Exec Command="powershell.exe -command ..\..\..\ConfigGenerators\configGenerator.ps1 $(generateConfigFileForDbType) " Condition=" '$(OS)' == 'Windows_NT' And '$(generateConfigFileForDbType)' != '' " />
+      <Exec Command="bash ../../../ConfigGenerators/configGenerator.sh $(generateConfigFileForDbType) " Condition=" '$(OS)' != 'Windows_NT' And '$(generateConfigFileForDbType)' != '' " />
       <Copy SourceFiles="@(ConfigFiles)" DestinationFolder="..\..\out\tests\$(TargetFramework)" />
   </Target>
 


### PR DESCRIPTION
## Why make this change?

-  Closes #1015 
  -  At the moment, in all the integration testing pipelines, the command `dotnet build -p:generateConfigFiles=true` is used to generate the config files. 
  -  This command generates the config files for all the database types (MsSql, MySql, PostgreSql and Cosmos).    
  -  This is unnecessary as only one of the config files gets utilized during a given pipeline run i.e. in the `MsSql` pipeline, it would be sufficient to generate only the config file for MsSql database type. Likewise, for other pipelines. Additionally, generating the config files for all database types leads to longer execution times for the pipeline runs.
 
## What is this change?

- `generateConfigFiles` property is re-named to `generateConfigFileForDbType`. 
- `generateConfigFileForDbType` property accepts the **database type** (instead of `true/false`) and generates the config file for only that particular database. 
- All the integration testing pipelines are updated to specify the database type in the build step
- The docs are updated with the necessary instructions 

## How was this tested?

- [x] Existing Unit tests and Integration tests

## Sample Request(s)

- N/A
