### PR TITLE
Update minor version back to 4 for patch release

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   minor: 4
   # Maintain a separate patch value between CI and PR runs.
   # The counter is reset when the minor version is updated.
-  patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 11)]
+  patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 0)]
   isReleaseBuild: $(isNugetRelease)
   additionalProperties.version: 'https://dataapibuilder.azureedge.net/schemas/v$(major).$(minor).$(patch)-alpha/dab.draft.schema.json'
 


### PR DESCRIPTION
## Why make this change?
Since, next release will be patch release, I'm reverting minor version back to 4 (last released minor version).
No change in patch is required (new version generated will be of higher version than 0.4.10)
![image](https://user-images.githubusercontent.com/102276754/207768218-6fba3ad9-8c24-4eda-8de0-4dd6ce6c30e8.png)


## What is this change?
- minor version changed to 4.

### NOTE:
Once the patch release is done. minor version should be updated to 5.
