### PR TITLE
Replacing missed console statements to Ilogger in CLI

### DIFF
--- a/src/Cli/src/ConfigGenerator.cs
+++ b/src/Cli/src/ConfigGenerator.cs
@@ -184,7 +184,7 @@ namespace Cli
             PermissionSetting[]? permissionSettings = ParsePermission(options.Permissions, policy, field, options.SourceType);
             if (permissionSettings is null)
             {
-                Console.Error.WriteLine("Please add permission in the following format. --permissions \"<<role>>:<<actions>>\"");
+                _logger.LogError("Please add permission in the following format. --permissions \"<<role>>:<<actions>>\"");
                 return false;
             }
 

--- a/src/Cli/src/Utils.cs
+++ b/src/Cli/src/Utils.cs
@@ -114,7 +114,7 @@ namespace Cli
                 }
                 else
                 {
-                    Console.Error.WriteLine($"Invalid operation Name: {operationName}.");
+                    _logger.LogError($"Invalid operation Name: {operationName}.");
                     return false;
                 }
             }
@@ -673,7 +673,7 @@ namespace Cli
                 || !TryGetOperationName(operations.First(), out Operation operationName)
                 || Operation.All.Equals(operationName))
             {
-                Console.Error.WriteLine("Stored Procedure supports only 1 CRUD operation.");
+                _logger.LogError("Stored Procedure supports only 1 CRUD operation.");
                 return false;
             }
 
@@ -696,7 +696,7 @@ namespace Cli
             PermissionOperation? action = JsonSerializer.Deserialize<PermissionOperation>(operationJson);
             if (action is null)
             {
-                Console.Error.WriteLine($"Failed to parse the operation: {operation}.");
+                _logger.LogError($"Failed to parse the operation: {operation}.");
                 operationName = Operation.None;
                 return false;
             }

--- a/src/Cli/test/EndToEndTests.cs
+++ b/src/Cli/test/EndToEndTests.cs
@@ -163,7 +163,6 @@ public class EndToEndTests
         Assert.AreEqual(1, runtimeConfig.Entities.Count()); // 1 new entity added
         Assert.IsTrue(runtimeConfig.Entities.ContainsKey("book"));
         Entity entity = runtimeConfig.Entities["book"];
-        Console.WriteLine(JsonSerializer.Serialize(entity));
         Assert.IsNull(entity.Rest);
         Assert.IsNull(entity.GraphQL);
         Assert.AreEqual(1, entity.Permissions.Length);


### PR DESCRIPTION
## Why make this change?

- to be consistent with the rest of the Logging methodology. 

## What is this change?

- Replacing missed console statements to Ilogger in CLI, as part of #870 

## How was this tested?

- This is just a refactoring change. Existing tests are enough. 

