### PR TITLE
Allow comments in config file

### DIFF
--- a/src/Cli/src/Utils.cs
+++ b/src/Cli/src/Utils.cs
@@ -267,6 +267,9 @@ namespace Cli
                 WriteIndented = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 PropertyNamingPolicy = new LowerCaseNamingPolicy(),
+                // As of .NET Core 7, JsonDocument and JsonSerializer only support skipping or disallowing 
+                // of comments; they do not support loading them. If we set JsonCommentHandling.Allow for either,
+                // it will throw an exception.
                 ReadCommentHandling = JsonCommentHandling.Skip
             };
 

--- a/src/Config/RuntimeConfig.cs
+++ b/src/Config/RuntimeConfig.cs
@@ -69,6 +69,9 @@ namespace Azure.DataApiBuilder.Config
         public readonly static JsonSerializerOptions SerializerOptions = new()
         {
             PropertyNameCaseInsensitive = true,
+            // As of .NET Core 7, JsonDocument and JsonSerializer only support skipping or disallowing 
+            // of comments; they do not support loading them. If we set JsonCommentHandling.Allow for either,
+            // it will throw an exception.
             ReadCommentHandling = JsonCommentHandling.Skip,
             Converters =
                 {

--- a/src/Config/RuntimeConfigPath.cs
+++ b/src/Config/RuntimeConfigPath.cs
@@ -37,7 +37,9 @@ namespace Azure.DataApiBuilder.Config
             Utf8JsonReader reader = new(jsonData: Encoding.UTF8.GetBytes(json),
                                         options: new()
                                         {
-                                            // Allow comments in config file.
+                                            // As of .NET Core 7, JsonDocument and JsonSerializer only support skipping or disallowing 
+                                            // of comments; they do not support loading them. If we set JsonCommentHandling.Allow for either,
+                                            // it will throw an exception.
                                             CommentHandling = JsonCommentHandling.Skip
                                         });
             MemoryStream stream = new();

--- a/src/Service.Tests/Unittests/RuntimeConfigPathUnitTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigPathUnitTests.cs
@@ -72,7 +72,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
-        /// Method to validate that comments are allowed in config file (and are ignored during deserialization).
+        /// Method to validate that comments are skipped in config file (and are ignored during deserialization).
         /// </summary>
         [TestMethod]
         public void CheckCommentParsingInConfigFile()


### PR DESCRIPTION
## Why make this change?
To support comments in config file.

## What is this change?
While deserialization of config file, ignored the comments using JsonCommentHandling.Skip option.

## How was this tested?
- [x] Unit Tests