### PR TITLE
Updating json schema for Stored Procedure

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -405,7 +405,6 @@
           "if": {
             "properties": {
               "source": {
-                "type": "object",
                 "properties": {
                   "type": {
                     "const": "stored-procedure"


### PR DESCRIPTION
## Why make this change?
To update draft schema to include latest additions to stored procedures as per this issue: https://github.com/Azure/data-api-builder/issues/1095

## What is this change?
1. Additional action `execute` is added for action.
2. A field `operation` is added to `graphql` section, `method` to `rest` section. These properties will define the nature of action on the stored procedure.

## Additional change
1. The type for `set-session-context` property was corrected from string to boolean.
2. Adding back the `mappings` section defined [here](https://github.com/Azure/project-hawaii/blob/480ba5be0b4dba424e7c7d1f018a5d8ef9ed6dc1/playground/hawaii.draft-02.schema.json#L343).
## How was this tested?
No tests required, just schema updates.