### PR TITLE
Update JSON schema from `method` to `methods` for REST configuration

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -278,7 +278,7 @@
                     "path": {
                       "type": "string"
                     },
-                    "method": {
+                    "methods": {
                       "type": "array",
                       "items": {
                         "type": "string",
@@ -300,7 +300,7 @@
                     },
                     {
                       "required": [
-                        "method"
+                        "methods"
                       ]
                     }
                   ]


### PR DESCRIPTION
## Why make this change?
Revises two keywords from #1116 which was responsible for updating the JSON draft schema to include latest additions to stored procedures as per this issue: https://github.com/Azure/data-api-builder/issues/1095

## What is this change?
1. For an entity's REST configuration, updates the stored procedure specific field `method` to `methods` to reflect RFC #1095 