### PR TITLE
Update using DAB Cli with loglevel information

### DIFF
--- a/docs/running-using-dab-cli.md
+++ b/docs/running-using-dab-cli.md
@@ -68,7 +68,7 @@ This will log the information as follows:
   - the generated queries sent to the database (Level: Debug)
 
 - Internal behavior
-  - view which queries are generated (any query, not only those necessarily related to a request) and sent to the database (Level: Debug)
+  - view which queries are generated (any query, not just those necessarily related to a request) and sent to the database (Level: Debug)
 
 
 ## Get started using `dab` CLI


### PR DESCRIPTION
## Why make this change?

Updates https://github.com/Azure/data-api-builder/blob/main/docs/running-using-dab-cli.md#run-engine-using-dab-cli

to include information on how to start the service using the Cli with a provided log level.

## What is this change?

Adds description to the documentation to describe how to use the DAB Cli with log level specified.

## How was this tested?

N/A

## Sample Request(s)

N/A