### PR TITLE
Add project url property to nuspec

### DIFF
--- a/src/Cli/src/Cli.csproj
+++ b/src/Cli/src/Cli.csproj
@@ -16,8 +16,8 @@
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <RepositoryUrl>https://github.com/Azure/data-api-builder</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <ProjectUrl>https://go.microsoft.com/fwlink/?linkid=2224253</ProjectUrl>
     <PackageTags>microsoft rest graphql api azure sql mssql mysql pgsql postgresql azure-sql sqlserver nosql cosmosdb dataApiBuilder</PackageTags>
     <AssemblyName>Microsoft.DataApiBuilder</AssemblyName>
     <Description>Data API builder for Azure Databases provides modern REST and GraphQL endpoints to your Azure Databases.</Description>


### PR DESCRIPTION
## Why make this change?

- For publishing a public Microsoft nuget package, the `projectUrl` property is mandatory. More details of this property [here](https://learn.microsoft.com/en-us/nuget/reference/nuspec#projecturl) 

## What is the change?
- The `projectUrl` has following requirements:

> The Project URL must be a valid team or product URL, and it can be an FWLink. This must be a permalink that will never be deprecated. This is typically your product's marketing page where users can go to understand more about the product/package.

- We don't have a public marketing page (yet), neither is our repository public, the only public URL is the manifest file/schema file. Created a FWLINK so it could be edited later on to point to our actual project page eventually, once that's public. 
- Currently, this FWLINK points to the manifest file to minimize the number of times we need to update it (since if it were to point to the schema file link, we would need to update it for each release)