### PR TITLE
Rename to PackageProjectUrl property

### DIFF
--- a/src/Cli/src/Cli.csproj
+++ b/src/Cli/src/Cli.csproj
@@ -17,7 +17,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
-    <ProjectUrl>https://go.microsoft.com/fwlink/?linkid=2224253</ProjectUrl>
+    <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2224253</PackageProjectUrl>
     <PackageTags>microsoft rest graphql api azure sql mssql mysql pgsql postgresql azure-sql sqlserver nosql cosmosdb dataApiBuilder</PackageTags>
     <AssemblyName>Microsoft.DataApiBuilder</AssemblyName>
     <Description>Data API builder for Azure Databases provides modern REST and GraphQL endpoints to your Azure Databases.</Description>


### PR DESCRIPTION
## Why make this change?

- Property names are different for a nuspec file v/s a msbuild proj file. The projectUrl property we need is actually called `PackageProjectUrl` when specifyed in the .csproj as per [this](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices#package-metadata)

## What is this change?

- Rename the property to `PackageProjectUrl`

## How was this tested?

- Looked at the nuget package from the build to ensure the projecturl property was present