### PR TITLE
Add nuget badge to repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Data API builder for Azure Databases
 
+[![NuGet Package](https://img.shields.io/nuget/v/microsoft.dataapibuilder.svg?color=success)](https://www.nuget.org/packages/Microsoft.DataApiBuilder)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 Latest version of Data API builder is  **0.5.0** [What's new?](./docs/whats-new.md#version-050)


### PR DESCRIPTION
## Why make this change?

To see a badge like this: 
![image](https://user-images.githubusercontent.com/3513779/218647084-341cde7c-a3b6-4b37-aec7-77c9e40599e5.png)

## What is this change?

- Adds the nuget badge and hyperlinks to the nuget.org package
