### PR TITLE
Decrementing minor version due to patch release

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -25,7 +25,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   major: 0
-  minor: 6
+  minor: 5
   # Maintain a separate patch value between CI and PR runs.
   # The counter is reset when the minor version is updated.
   patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 0)]


### PR DESCRIPTION
## Why make this change?

- Since, this release branch is used for performing a patch release for the `Jan2023` release, the minor version number is made the same as `Jan2023` release (which had minor version ~ `5`). Typically, after a release, the minor version number is incremented in the `main` branch, so need to decrement to keep it same as the previous release.

## What is this change?

- `minor` variable is updated in the `build-pipeline.yml` file

## How was this tested?

- N/A

## Sample Request(s)

- N/A