### PR TITLE
Incrementing back the minor version number

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -25,7 +25,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   major: 0
-  minor: 5
+  minor: 6
   # Maintain a separate patch value between CI and PR runs.
   # The counter is reset when the minor version is updated.
   patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 0)]


### PR DESCRIPTION
## Why make this change?

- Follow-up PR for [#1271](https://github.com/Azure/data-api-builder/pull/1271)
- Increments the minor version back to `6`

## What is this change?

- `minor` variable is incremented in the `build-pipeline`

## How was this tested?

- N/A

## Sample Request(s)

- N/A