### PR TITLE
Revert minor version 

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -25,7 +25,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   major: 0
-  minor: 6
+  minor: 5
   # Maintain a separate patch value between CI and PR runs.
   # The counter is reset when the minor version is updated.
   patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 0)]


### PR DESCRIPTION
## Why make this change?

We are doing a second patch hence making this change to get the minor version back to 5.

## What is this change?

This reverts commit fa7b37558acf66bfea0afad41267e119f4ab081f.
