### PR TITLE
Fix expected path for built binaries for code signing

### DIFF
--- a/.pipelines/templates/code-signing.yml
+++ b/.pipelines/templates/code-signing.yml
@@ -18,7 +18,7 @@ steps:
 - ${{ if eq(parameters.signNuget, false) }}:
   - task: EsrpCodeSigning@1
     displayName: 'Code Signing Microsoft code'
-    # condition: and(succeeded())
+    condition: and(succeeded(), eq(variables['isReleaseBuild'], 'true'))
     inputs:
       ConnectedServiceName: 'ESRP Official Codesigning'
       FolderPath: ${{ parameters.path }}
@@ -53,7 +53,7 @@ steps:
 
   - task: EsrpCodeSigning@1
     displayName: 'Code Signing OSS and Third party'
-    # condition: and(succeeded())
+    condition: and(succeeded(), eq(variables['isReleaseBuild'], 'true'))
     inputs:
       ConnectedServiceName: 'ESRP Official Codesigning'
       FolderPath: ${{ parameters.path }}
@@ -90,7 +90,7 @@ steps:
 - ${{ if eq(parameters.signNuget, true) }}:
   - task: EsrpCodeSigning@1
     displayName: 'Code Signing Nuget package'
-    # condition: and(succeeded())
+    condition: and(succeeded(), eq(variables['isReleaseBuild'], 'true'))
     inputs:
       ConnectedServiceName: 'ESRP Official Codesigning'
       FolderPath: ${{ parameters.path }}


### PR DESCRIPTION
## Why make this change?

- The PR #1241 fixed our folder structure of the output binaries and in the process of making cli and engine paths consistent removed the `buildConfiguration` from the output path. 
- The code signing task still depended the binaries to be in the previous path. We didn't catch this before since a new release was not attempted earlier to recognize we may hit this issue. 

## What is this change?

- Modify the path where the code signing task looks for the binaries.