### PR TITLE
Fix hyperlink to whats new in 0.5.34

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -12,9 +12,9 @@ Details on how to install the latest version are here: [Installing DAB CLI](./ge
 
 The full list of release notes for this version is available here: [version 0.5.34 release notes](https://github.com/Azure/data-api-builder/releases/tag/v0.5.34)
 
-- [Honor REST and GraphQL enabled flag at runtime level](#honor-rest-and-graphql-enabled-flag-at-runtime-level)
-- [Add Correlation ID to request logs](#add-correlation-id-to-request-logs)
-- [Wildcard Operation Support for Stored Procedures in Engine and CLI](#wildcard-operation-support-for-stored-procedures-in-engine-and-cli)
+- [Honor REST and GraphQL enabled flag at runtime level](./whats-new-0.5.34.md#honor-rest-and-graphql-enabled-flag-at-runtime-level)
+- [Add Correlation ID to request logs](./whats-new-0.5.34.md#add-correlation-id-to-request-logs)
+- [Wildcard Operation Support for Stored Procedures in Engine and CLI](./whats-new-0.5.34.md#wildcard-operation-support-for-stored-procedures-in-engine-and-cli)
 
 ## Version 0.5.32
 


### PR DESCRIPTION
## Why make this change?

Fixes the hyperlinks for the features in whats new in 0.5.34