### PR TITLE
Fix the docker run command in docs

### DIFF
--- a/docs/running-using-a-container.md
+++ b/docs/running-using-a-container.md
@@ -3,7 +3,7 @@
 With Docker, you can run Data API builder using a container from `mcr.microsoft.com/azure-databases/data-api-builder`:
 
 ```sh
-docker run -it -v <configuration-file>:/App/<configuration-file> -p 5000:5000 pull mcr.microsoft.com/azure-databases/data-api-builder:<tag> --ConfigFileName <configuration-file>
+docker run -it -v <configuration-file>:/App/<configuration-file> -p 5000:5000 mcr.microsoft.com/azure-databases/data-api-builder:<tag> --ConfigFileName <configuration-file>
 ```
 
 The proceeding command makes the following assumptions:
@@ -13,7 +13,7 @@ The proceeding command makes the following assumptions:
 - You want to use the latest release which can be identified from the [Releases](https://github.com/Azure/data-api-builder/releases) page. For Example, If you would like to use the image with the tag `0.5.*`, run the following command:
 
 ```bash
-docker run -it -v "c:\data-api-builder\samples:/App/samples" -p 5000:5000 pull mcr.microsoft.com/azure-databases/data-api-builder:0.5.* --ConfigFileName ./samples/my-sample-dab-config.json
+docker run -it -v "c:\data-api-builder\samples:/App/samples" -p 5000:5000 mcr.microsoft.com/azure-databases/data-api-builder:0.5.* --ConfigFileName ./samples/my-sample-dab-config.json
 ```
 
 You may also use one of the provided Docker compose files, available in the `docker` folder:


### PR DESCRIPTION
## Why make this change?

- The docker command in the docs has an incorrect `pull` verb where the image name is expected. 
- With the incorrect command, we see the following error message:

> 
> `Unable to find image 'pull:latest' locally
> docker: Error response from daemon: pull access denied for pull, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
> See 'docker run --help'.`

## What is this change?

- remove the incorrect verb so the correct image gets pulled.

## How was this tested?

- Manually tested on a fresh machine, by running the fixed command to verify the correct image is downloaded and the engine is successfully running.

```
PS > docker run -it -v "c:\Users\anmunde\Documents:/App/samples" -p 5000:5000 mcr.microsoft.com/azure-databases/data-api-builder:0.5.34 --ConfigFileName ./samples/dab.storedproc.json     
Unable to find image 'mcr.microsoft.com/azure-databases/data-api-builder:0.5.34' locally
0.5.34: Pulling from azure-databases/data-api-builder
3f9582a2cbe7: Pull complete
80b88e0117ce: Pull complete
2d43258c565c: Pull complete
9ab259e76745: Pull complete
144ef4f6c4b8: Pull complete
08c6d9bfa585: Pull complete
Digest: sha256:75f1877b20af094d8b024cce64ddd4739ff2007e118564face72e0fb3d417788
Status: Downloaded newer image for mcr.microsoft.com/azure-databases/data-api-builder:0.5.34
Starting the runtime engine...
```