### PR TITLE
Fix expected path for built binaries for code signing

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -132,7 +132,7 @@ steps:
   parameters:
     # This is the path that will be used for packing nuget package.
     # We will need to sign the binaries in this location.
-    path: '$(Build.SourcesDirectory)/src/out/cli/$(buildConfiguration)/net6.0/publish' 
+    path: '$(Build.SourcesDirectory)/src/out/cli/net6.0/publish' 
 
 # Create nuget package after the binaries are signed. So that the binaries inside nuget package are signed.
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
Cherry picked fix from https://github.com/Azure/data-api-builder/pull/1302.
------------------------------
## Why make this change?

- The PR #1241 fixed our folder structure of the output binaries and in the process of making cli and engine paths consistent removed the `buildConfiguration` from the output path. 
- The code signing task still depended the binaries to be in the previous path. We didn't catch this before since a new release was not attempted earlier to recognize we may hit this issue. 

## What is this change?

- Modify the path where the code signing task looks for the binaries.