### PR TITLE
Generate notice file only when releasing

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -116,12 +116,14 @@ steps:
 - task: notice@0
   # This will generate the NOTICE.txt for distribution
   displayName: Generate NOTICE file
+  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
   inputs:
     outputfile: $(Build.SourcesDirectory)/NOTICE.txt
     outputformat: text
 
 - task: PowerShell@2
   displayName: "Add Additional Licenses to NOTICE file"
+  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
   inputs:
     targetType: 'filePath'
     filePath: $(System.DefaultWorkingDirectory)/scripts/notice-generation.ps1


### PR DESCRIPTION
## Why make this change?

The component governance api for notice file generation times out or fails flakily. We dont need to generate the notice file unless we are releasing the bits. 

## What is this change?

- Precondition the notice generation and modification tasks for `isReleaseBuild, true`
- Note, component governance is still enabled as a separate task to detect any vulnerabilities.