### PR TITLE
Passing exception through to the logger rather than stringifying it early.

### DIFF
--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -626,8 +626,7 @@ namespace Azure.DataApiBuilder.Service
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Unable to complete runtime " +
-                    $"initialization operations due to: \n{ex}");
+                _logger.LogError(ex, $"Unable to complete runtime initialization. Refer to exception for error details.");
                 return false;
             }
         }


### PR DESCRIPTION
Small change to improve the error message when it goes to the logs and the exception received.