### PR TITLE
Disable changes in `docs` triggering builds

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -15,7 +15,7 @@ trigger:
     - release/*
   paths:
     exclude:
-    - docs
+    - docs/*
 
 pool:
   vmImage: 'ubuntu-latest' # examples of other options: 'macOS-10.15', 'windows-2019'


### PR DESCRIPTION
## Why make this change?

- `docs` changes dont require builds. This is an attempt to exclude changes to any files within `docs` folder to trigger pipeline builds
