### PR TITLE
Force Allow User Variable in MySQL connection string

### DIFF
--- a/config-generators/mysql-commands.txt
+++ b/config-generators/mysql-commands.txt
@@ -1,4 +1,4 @@
-init --config "dab-config.MySql.json" --database-type mysql --connection-string "server=localhost;database=datagatewaytest;Allow User Variables=true;uid=root;pwd=REPLACEME" --host-mode Development --cors-origin "http://localhost:5000"
+init --config "dab-config.MySql.json" --database-type mysql --connection-string "server=localhost;database=datagatewaytest;uid=root;pwd=REPLACEME" --host-mode Development --cors-origin "http://localhost:5000"
 add Publisher --config "dab-config.MySql.json" --source publishers --permissions "anonymous:read"
 add Stock --config "dab-config.MySql.json" --source stocks --permissions "anonymous:create,read,update"
 add Book --config "dab-config.MySql.json" --source books --permissions "anonymous:create,read,update,delete" --graphql "book:books"

--- a/src/Service.Tests/Unittests/RuntimeConfigPathUnitTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigPathUnitTests.cs
@@ -225,7 +225,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
   },
   ""data-source"": {
     ""database-type"": """ + reps[index % reps.Length] + @""",
-    ""connection-string"": ""server=dataapibuilder;database=" + reps[++index % reps.Length] + @";uid=" + reps[++index % reps.Length] + @";Password=" + reps[++index % reps.Length] + @";Allow User Variables=true"",
+    ""connection-string"": ""server=dataapibuilder;database=" + reps[++index % reps.Length] + @";uid=" + reps[++index % reps.Length] + @";Password=" + reps[++index % reps.Length] + @";"",
     ""resolver-config-file"": """ + reps[++index % reps.Length] + @"""
   },
   ""runtime"": {

--- a/src/Service/Resolvers/MySqlQueryExecutor.cs
+++ b/src/Service/Resolvers/MySqlQueryExecutor.cs
@@ -61,6 +61,9 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             _attemptToSetAccessToken =
                 ShouldManagedIdentityAccessBeAttempted();
 
+            // Force always allow user variables
+            ConnectionStringBuilder.AllowUserVariables = true;
+
             if (runtimeConfigProvider.IsLateConfigured)
             {
                 ConnectionStringBuilder.SslMode = MySqlSslMode.VerifyFull;


### PR DESCRIPTION
## Why make this change?

In order to support the standard mysql connection string which doesn't specify allow user variable, including Static Website.

## What is this change?

Override AllowUserVariables in connection string to true. This remove the requirement that the user have to give "Allow User Variable" in the connection string.

## How was this tested?

- [x] Integration Tests
- [x] Unit Tests

