### PR TITLE
Update docs - provide `Allow User Variables=true` in MySql connection string docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Package](https://img.shields.io/nuget/v/microsoft.dataapibuilder.svg?color=success)](https://www.nuget.org/packages/Microsoft.DataApiBuilder)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Latest version of Data API builder is **0.5.34** [What's new?](./docs/whats-new.md#version-0534)
+Latest version of Data API builder is **0.5.35** [What's new?](./docs/whats-new.md#version-0535)
 
 ## About
 

--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -92,7 +92,7 @@ https://github.com/Azure/data-api-builder/releases/download/v0.3.7-alpha/dab.dra
 
 If there are no suffix, then simply ignore it, for example:
 ```txt
-https://github.com/Azure/data-api-builder/releases/download/v0.5.34/dab.draft.schema.json
+https://github.com/Azure/data-api-builder/releases/download/v0.5.35/dab.draft.schema.json
 ```
 
 the **latest** version of the schema is always available at

--- a/docs/getting-started/getting-started-azure-mysql-db.md
+++ b/docs/getting-started/getting-started-azure-mysql-db.md
@@ -11,12 +11,12 @@ For Data API builder, the format used for a MySQL connection is shown below base
 1. If MySQL server has SSL enabled, use the ADO.NET connection string format with SSL mode as required. If using an Azure MySQL Database, remember to download and install the [public SSL certificate](https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem) in the **Trusted Root certification authorities store** on the client machine using **certmgr.msc** Management Console on your local Windows system. If using an Azure cloud service like Azure App Service, you can copy the certificate to a folder on the App Service file system and add the argument **SslCa** using the full certificate path as shown below.
 
    ```
-   Server=<server-address>;Database=<database-name>;User ID=<username>;Password=<password>;Sslmode=Required;SslCa=<path-to-certificate>";
+   Server=<server-address>;Database=<database-name>;User ID=<username>;Password=<password>;Sslmode=Required;SslCa=<path-to-certificate>;Allow User Variables=true;
    ```
 
 2. If MySQL does not have SSL enabled, you can use the ADO.NET connection string format without the SSL mode parameter
    ```
-   Server=<server-address>;Database=<database-name>;User ID=<username>;Password=<password>;
+   Server=<server-address>;Database=<database-name>;User ID=<username>;Password=<password>;Allow User Variables=true;
    ```
 
 ## Create the database objects

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,5 +1,6 @@
 # What's New in Data API builder
 
+- [Version 0.5.35](#version-035)
 - [Version 0.5.34](#version-0534)
 - [Version 0.5.32](#version-0532)
 - [Version 0.5.0](#version-050)
@@ -7,6 +8,11 @@
 - [Version 0.3.7](#version-037)
 
 Details on how to install the latest version are here: [Installing DAB CLI](./getting-started/getting-started.md#installing-dab-cli)
+
+## Version 0.5.35
+
+- Force `Allow User Variables=true` for MySql connections fixing PUT/PATCH requests
+- Improve mapped column handling for REST pagination and NextLink creation fixes
 
 ## Version 0.5.34
 

--- a/samples/basic-empty-dab-config.json
+++ b/samples/basic-empty-dab-config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://github.com/Azure/data-api-builder/releases/download/v0.5.34/dab.draft.schema.json",
+    "$schema": "https://github.com/Azure/data-api-builder/releases/download/v0.5.35/dab.draft.schema.json",
     "data-source": {
         "database-type": "",
         "connection-string": ""


### PR DESCRIPTION
## Why make this change?

- Fix docs to provide correct connection string properties required for PUT/PATCH requests in MySql
- Updates with the latest release number 0.5.35