### PR TITLE
Fix serialization issue for config

### DIFF
--- a/src/Cli.Tests/InitTests.cs
+++ b/src/Cli.Tests/InitTests.cs
@@ -279,7 +279,7 @@ namespace Cli.Tests
             Assert.AreEqual(expectedResult, ConfigGenerator.TryCreateRuntimeConfig(options, out _));
         }
 
-                /// <summary>
+        /// <summary>
         /// Test to verify creation of initial config with special characters
         /// such as [!,@,#,$,%,^,&,*, ,(,)] in connection-string.
         /// </summary>

--- a/src/Cli.Tests/InitTests.cs
+++ b/src/Cli.Tests/InitTests.cs
@@ -279,6 +279,46 @@ namespace Cli.Tests
             Assert.AreEqual(expectedResult, ConfigGenerator.TryCreateRuntimeConfig(options, out _));
         }
 
+                /// <summary>
+        /// Test to verify creation of initial config with special characters
+        /// such as [!,@,#,$,%,^,&,*, ,(,)] in connection-string.
+        /// </summary>
+        [TestMethod]
+        public void TestSpecialCharactersInConnectionString()
+        {
+            InitOptions options = new(
+                databaseType: DatabaseType.mssql,
+                connectionString: "A!string@with#some$special%characters^to&check*proper(serialization)including space.",
+                cosmosNoSqlDatabase: null,
+                cosmosNoSqlContainer: null,
+                graphQLSchemaPath: null,
+                setSessionContext: false,
+                hostMode: HostModeType.Production,
+                corsOrigin: null,
+                authenticationProvider: EasyAuthType.StaticWebApps.ToString(),
+                config: TEST_RUNTIME_CONFIG_FILE);
+
+            _basicRuntimeConfig =
+            @"{" +
+                @"""$schema"": """ + DAB_DRAFT_SCHEMA_TEST_PATH + @"""" + "," +
+                @"""data-source"": {
+                    ""database-type"": ""mssql"",
+                    ""connection-string"": ""A!string@with#some$special%characters^to&check*proper(serialization)including space."",
+                    ""options"":{
+                        ""set-session-context"": false
+                    }
+                },
+                ""entities"": {}
+            }";
+
+            // Adding runtime settings to the above basic config
+            string expectedRuntimeConfig = AddPropertiesToJson(
+                _basicRuntimeConfig,
+                GetDefaultTestRuntimeSettingString()
+            );
+            RunTest(options, expectedRuntimeConfig);
+        }
+        
         /// <summary>
         /// Test to verify that an error is thrown when user tries to
         /// initialize a config with a file name that already exists.

--- a/src/Cli.Tests/InitTests.cs
+++ b/src/Cli.Tests/InitTests.cs
@@ -318,7 +318,7 @@ namespace Cli.Tests
             );
             RunTest(options, expectedRuntimeConfig);
         }
-        
+
         /// <summary>
         /// Test to verify that an error is thrown when user tries to
         /// initialize a config with a file name that already exists.

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -7,7 +7,6 @@ using System.Reflection;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.Unicode;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Humanizer;
@@ -261,6 +260,7 @@ namespace Cli
 
         /// <summary>
         /// Returns the Serialization option used to convert objects into JSON.
+        /// Not escaping any special unicode characters.
         /// Ignoring properties with null values.
         /// Keeping all the keys in lowercase.
         /// </summary>
@@ -268,7 +268,7 @@ namespace Cli
         {
             JsonSerializerOptions? options = new()
             {
-                Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 WriteIndented = true,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 PropertyNamingPolicy = new LowerCaseNamingPolicy(),


### PR DESCRIPTION
## Why make this change?

- Closes #1321
  - special character like '&' is escaped during serialization.

## What is this change?

- Updated the Encoder used in the config serialization.
- Now using [`UnsafeRelaxedJsonEscaping`](https://learn.microsoft.com/en-us/dotnet/api/system.text.encodings.web.javascriptencoder.unsaferelaxedjsonescaping?view=net-7.0#system-text-encodings-web-javascriptencoder-unsaferelaxedjsonescaping), it does not escape HTML-sensitive characters such as <, >, &. Since we do not want any kind of change during string serialization, it's the best we can use.
- It also allows [UnicodeRanges.All](https://learn.microsoft.com/en-us/dotnet/api/system.text.unicode.unicoderanges.all?view=net-7.0#system-text-unicode-unicoderanges-all) to go through unescaped. Hence, it doesn't regress our existing changes.

## How was this tested?
- [x] Unit Tests
- I created a new user in Azure SQL with a password containing special characters such as [!@#$%^&*() ], and i was able to start the engine succesfully.

## NOTE:
Since the config file is json and it is storing connection-string as string,there are still some characters that can't be used like single quotes `'` or double quotes `"` , or a backslash `\` as password.