### PR TITLE
Validates Non-Empty request body for REST Find APIs

### DIFF
--- a/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
@@ -1712,6 +1712,10 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
             );
         }
 
+        /// <summary>
+        /// Validates that REST Find APIs executed with a non-empty request body are
+        /// returned a HTTP BadRequest response as the request body is irrelevant for GET requests.
+        /// </summary>
         [TestMethod]
         public async Task FindApiTestWithNonEmptyRequestBody()
         {

--- a/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
@@ -1712,6 +1712,27 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
             );
         }
 
+        [TestMethod]
+        public async Task FindApiTestWithNonEmptyRequestBody()
+        {
+            string requestBody = @"
+            {
+                ""title"": ""New Book"",
+                ""publisher_id"": 1234
+            }";
+
+            await SetupAndRunRestApiTest(
+                primaryKeyRoute: "id/1",
+                queryString: string.Empty,
+                requestBody: requestBody,
+                entityNameOrPath: _integrationEntityName,
+                sqlQuery: string.Empty,
+                exceptionExpected: true,
+                expectedErrorMessage: "The GET request is invalid since it contains a request body",
+                expectedStatusCode: HttpStatusCode.BadRequest
+                );
+        }
+
         #endregion
     }
 }

--- a/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
@@ -1732,7 +1732,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
                 entityNameOrPath: _integrationEntityName,
                 sqlQuery: string.Empty,
                 exceptionExpected: true,
-                expectedErrorMessage: "The GET request is invalid since it contains a request body",
+                expectedErrorMessage: "The GET request is invalid since it contains a non-empty request body",
                 expectedStatusCode: HttpStatusCode.BadRequest
                 );
         }

--- a/src/Service/Services/RequestValidator.cs
+++ b/src/Service/Services/RequestValidator.cs
@@ -530,5 +530,25 @@ namespace Azure.DataApiBuilder.Service.Services
 
             return firstAsUint;
         }
+
+        /// <summary>
+        /// Validates that the request body is empty for REST Find APIs as the details present
+        /// in the request body are irrelevant for FIND APIs.
+        /// </summary>
+        /// <param name="operationType">Type of the REST operation.</param>
+        /// <param name="requestBody">Request body assosciated with the REST request.</param>
+        /// <exception cref="DataApiBuilderException">Thrown when a read request is performed with
+        /// non-empty request body.</exception>
+        public static void ValidateEmptyRequestBodyForFindApi(Config.Operation operationType, string requestBody)
+        {
+            if (operationType is Config.Operation.Read && !string.IsNullOrEmpty(requestBody))
+            {
+                throw new DataApiBuilderException(
+                    message: "The GET request is invalid since it contains a request body",
+                    statusCode: HttpStatusCode.BadRequest,
+                    subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
+            }
+        }
+
     }
 }

--- a/src/Service/Services/RequestValidator.cs
+++ b/src/Service/Services/RequestValidator.cs
@@ -544,7 +544,7 @@ namespace Azure.DataApiBuilder.Service.Services
             if (operationType is Config.Operation.Read && !string.IsNullOrEmpty(requestBody))
             {
                 throw new DataApiBuilderException(
-                    message: "The GET request is invalid since it contains a request body",
+                    message: "The GET request is invalid since it contains a non-empty request body",
                     statusCode: HttpStatusCode.BadRequest,
                     subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
             }

--- a/src/Service/Services/RestService.cs
+++ b/src/Service/Services/RestService.cs
@@ -84,6 +84,8 @@ namespace Azure.DataApiBuilder.Service.Services
                 requestBody = await reader.ReadToEndAsync();
             }
 
+            RequestValidator.ValidateEmptyRequestBodyForFindApi(operationType, requestBody);
+
             RestRequestContext context;
 
             // If request has resolved to a stored procedure entity, initialize and validate appropriate request context


### PR DESCRIPTION
## Why make this change?

- Closes #1404 
  - It is possible to send details in the request body for REST GET requests. The details present in the request body is ignored and the request is served using the details present in the URI 
![image](https://user-images.githubusercontent.com/11196553/229561273-bc6dfdce-89af-433b-8cc6-77892c9cce7b.png)

  - Better way to handle such requests could be to return a BadRequest response.

## What is this change?

- For REST Find APIs, the request body is validated to see if it is empty. If the request body is non-empty a HTTP BadRequest response with the error message: `The GET request is invalid since it contains a non-empty request body` is returned  

## How was this tested?

- [x] Integration Tests
- [x] Manual Tests

## Sample Request(s)

![image](https://user-images.githubusercontent.com/11196553/229562960-d1898d98-6b7b-45a0-a4a4-8482ed07ac45.png)

