### PR TITLE
Remove unused code path when constructing SqlQueryStructure for Find API requests

### DIFF
--- a/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
@@ -1098,6 +1098,47 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
            );
         }
 
+        /// <summary>
+        /// Validates that Find API requests ignore predicates present in the request body
+        /// </summary>
+        [TestMethod]
+        public async Task FindApiTestWithPredicatesInRequestBody()
+        {
+            string requestBody = @"
+            {
+                ""$select"": ""id,title""
+            }";
+
+            await SetupAndRunRestApiTest(
+                primaryKeyRoute: "id/2",
+                queryString: string.Empty,
+                requestBody: requestBody,
+                entityNameOrPath: _integrationEntityName,
+                sqlQuery: GetQuery(nameof(FindByIdTest))
+            );
+        }
+
+        /// <summary>
+        /// Validates that Find API request ignores the predicates present in the request body
+        /// and considers only the predicates present in the URI for constructing the response.
+        /// </summary>
+        [TestMethod]
+        public async Task FindApiTestWithPredicatesInUriAndRequestBody()
+        {
+            string requestBody = @"
+            {
+                ""$filter"": ""id ge 4""
+            }";
+
+            await SetupAndRunRestApiTest(
+                primaryKeyRoute: string.Empty,
+                queryString: "?$filter=id le 4",
+                requestBody: requestBody,
+                entityNameOrPath: _integrationEntityName,
+                sqlQuery: GetQuery("FindTestWithFilterQueryOneLeFilter")
+            );
+        }
+
         #endregion
 
         #region Negative Tests

--- a/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
@@ -1099,22 +1099,22 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
         }
 
         /// <summary>
-        /// Validates that Find API requests ignore predicates present in the request body
+        /// Validates that Find API request ignores predicates present in the request body
         /// </summary>
         [TestMethod]
         public async Task FindApiTestWithPredicatesInRequestBody()
         {
             string requestBody = @"
             {
-                ""$select"": ""id,title""
+                ""$filter"": ""id le 4""
             }";
 
             await SetupAndRunRestApiTest(
-                primaryKeyRoute: "id/2",
+                primaryKeyRoute: string.Empty,
                 queryString: string.Empty,
                 requestBody: requestBody,
                 entityNameOrPath: _integrationEntityName,
-                sqlQuery: GetQuery(nameof(FindByIdTest))
+                sqlQuery: GetQuery("FindTestWithQueryStringAllFields")
             );
         }
 

--- a/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/FindApiTestBase.cs
@@ -1165,6 +1165,32 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
         }
 
         /// <summary>
+        /// Validates that parameters of a SP sent through the request body are ignored and
+        /// results in a 400 Bad Request due to missing required parameters. 
+        /// </summary>
+        [TestMethod]
+        public virtual async Task FindApiTestForSPWithRequiredParamsInRequestBody()
+        {
+            string requestBody = @"
+            {
+                ""id"": 1
+            }";
+
+            await SetupAndRunRestApiTest(
+                primaryKeyRoute: string.Empty,
+                queryString: string.Empty,
+                requestBody: requestBody,
+                entityNameOrPath: _integrationProcedureFindOne_EntityName,
+                sqlQuery: string.Empty,
+                operationType: Config.Operation.Execute,
+                restHttpVerb: Config.RestMethod.Get,
+                exceptionExpected: true,
+                expectedErrorMessage: $"Invalid request. Missing required procedure parameters: id for entity: {_integrationProcedureFindOne_EntityName}",
+                expectedStatusCode: HttpStatusCode.BadRequest
+                );
+        }
+
+        /// <summary>
         /// Tests the REST Api for Find operations on a stored procedure missing a required parameter
         /// Expect a 400 Bad Request to be returned
         /// </summary>

--- a/src/Service.Tests/SqlTests/RestApiTests/Find/MySqlFindApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/MySqlFindApiTests.cs
@@ -904,5 +904,11 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
             throw new NotImplementedException();
         }
 
+        [TestMethod]
+        [Ignore]
+        public override Task FindApiTestForSPWithRequiredParamsInRequestBody()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Service.Tests/SqlTests/RestApiTests/Find/PostgreSqlFindApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/PostgreSqlFindApiTests.cs
@@ -883,6 +883,13 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
             throw new NotImplementedException();
         }
 
+        [TestMethod]
+        [Ignore]
+        public override Task FindApiTestForSPWithRequiredParamsInRequestBody()
+        {
+            throw new NotImplementedException();
+        }
+
         public override string GetDefaultSchema()
         {
             return DEFAULT_SCHEMA;

--- a/src/Service/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
@@ -124,18 +124,8 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// </summary>
         public Type GetColumnSystemType(string columnName)
         {
-            if (GetUnderlyingSourceDefinition().Columns.TryGetValue(columnName, out ColumnDefinition? column))
-            {
-                return column.SystemType;
-            }
-            else
-            {
-                throw new DataApiBuilderException(
-                    message: $"{columnName} is not a valid column of {DatabaseObject.Name}",
-                    statusCode: HttpStatusCode.BadRequest,
-                    subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest
-                    );
-            }
+            GetUnderlyingSourceDefinition().Columns.TryGetValue(columnName, out ColumnDefinition? column);
+            return column!.SystemType;
         }
 
         /// <summary>

--- a/src/Service/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
@@ -124,8 +124,18 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// </summary>
         public Type GetColumnSystemType(string columnName)
         {
-            GetUnderlyingSourceDefinition().Columns.TryGetValue(columnName, out ColumnDefinition? column);
-            return column!.SystemType;
+            if (GetUnderlyingSourceDefinition().Columns.TryGetValue(columnName, out ColumnDefinition? column))
+            {
+                return column.SystemType;
+            }
+            else
+            {
+                throw new DataApiBuilderException(
+                    message: $"{columnName} is not a valid column of {DatabaseObject.Name}",
+                    statusCode: HttpStatusCode.BadRequest,
+                    subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest
+                    );
+            }
         }
 
         /// <summary>

--- a/src/Service/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -153,13 +153,6 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                                             value: predicate.Value);
             }
 
-            foreach (KeyValuePair<string, object?> predicate in context.FieldValuePairsInBody)
-            {
-                sqlMetadataProvider.TryGetBackingColumn(EntityName, predicate.Key, out string? backingColumn);
-                PopulateParamsAndPredicates(backingColumn: backingColumn!,
-                                            value: predicate.Value!);
-            }
-
             // context.OrderByClauseOfBackingColumns will lack SourceAlias because it is created in RequestParser
             // which may be called for any type of operation. To avoid coupling the OrderByClauseOfBackingColumns
             // to only Find, we populate the SourceAlias in this constructor where we know we have a Find operation.

--- a/src/Service/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -493,7 +493,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// <param name="backingColumn">string represents the backing column of the field.</param>
         /// <param name="value">The value associated with a given field.</param>
         /// <param name="op">The predicate operation representing the comparison between field and value.</param>
-        private void PopulateParamsAndPredicates(string field, string backingColumn, object value, PredicateOperation op = PredicateOperation.Equal)
+        private void PopulateParamsAndPredicates(string field, string backingColumn, object? value, PredicateOperation op = PredicateOperation.Equal)
         {
             try
             {


### PR DESCRIPTION
## Why make this change?

-  Closes #1387 
  - Some code blocks present in `SqlQueryStructure` and `BaseSqlQueryStructure` classes don't get executed because of the request validations we have in place. Such code blocks are removed.

## What is this change?
-  `context.FieldValuePairsInBody` is always empty in `SqlQueryStructure`. So, the logic of populating predicates and params by iterating through `context.FieldValuePairsInBody` is removed.
- Added tests for GET requests with non-empty request body to validate that only predicates specified in the URI is considered for constructing the response. 

## How was this tested?

- [x] Integration Tests
- [x] Unit Tests
