### PR TITLE
Removes pattern for symbols package from Nuget publish steps  (#1414)

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -211,7 +211,7 @@ steps:
   inputs:
     command: 'push'
     feedsToUse: 'select'
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;$(Build.ArtifactStagingDirectory)/**/*.snupkg'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
     nuGetFeedType: 'internal'
     publishVstsFeed: CosmosDB/DataApiBuilder
     versioningScheme: 'off'
@@ -222,7 +222,7 @@ steps:
   condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
   inputs:
     command: push
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;$(Build.ArtifactStagingDirectory)/**/*.snupkg'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
     nuGetFeedType: external
     publishFeedCredentials: Microsoft.DataApiBuilder
 


### PR DESCRIPTION
Cheery picking changes from : https://github.com/Azure/data-api-builder/pull/1414

## Why make this change?

The Nuget push command publishes both the primary Nuget and symbols package just for the pattern `*.nupkg`. When the pattern for symbols package `*.snupkg` is added, it tries to push the symbols package again which fails as Nuget.org considers this a duplicate package.

## What is this change?
Removing the pattern for symbols package from the publish tasks

