### PR TITLE
Database Policy not yet supported for insert via put/patch for mssql

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Package](https://img.shields.io/nuget/v/microsoft.dataapibuilder.svg?color=success)](https://www.nuget.org/packages/Microsoft.DataApiBuilder)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Latest version of Data API builder is **0.5.35** [What's new?](./docs/whats-new.md#version-0535)
+Latest version of Data API builder is **0.6.13** [What's new?](./docs/whats-new.md#version-0613)
 
 ## About
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -8,6 +8,7 @@
 
 - Table with triggers error out on UPDATE. [Issue #452](https://github.com/Azure/data-api-builder/issues/452)
 - JSON data is escaped in the response. [Issue #444](https://github.com/Azure/data-api-builder/issues/444)
+- Database policies for insert via PUT/PATCH operations in REST are not yet supported. [Issue #1370](https://github.com/Azure/data-api-builder/issues/1370)
 
 ## MySQL 
 


### PR DESCRIPTION
Database Policy not yet supported for insert via put/patch for mssql.
Fix README with latest version number