### PR TITLE
Update dab-cli docs

### DIFF
--- a/docs/dab-cli.md
+++ b/docs/dab-cli.md
@@ -46,9 +46,9 @@ Initializes the runtime configuration for the Data API builder runtime engine. I
 | **--host-mode** | false   | production   | Specify the Host mode - development or production   |
 | **--cors-origin** | false   | ""   | Specify the list of allowed origins.   |
 | **--auth.provider** | false   | StaticWebApps   | Specify the Identity Provider.   |
-| **--rest.path** | false   | /api   | Specify the REST endpoint's default prefix.   |
+| **--rest.path** | false   | /api   | Specify the REST endpoint's prefix.   |
 | **--rest.disabled** | false   | false   | Disables REST endpoint for all entities.   |
-| **--graphql.path** | false   | /graphql   | Specify the GraphQL endpoint's default prefix.   |
+| **--graphql.path** | false   | /graphql   | Specify the GraphQL endpoint's prefix.   |
 | **--graphql.disabled** | false   | false   | Disables GraphQL endpoint for all entities.   |
 | **--auth.audience** | false   | -   | Identifies the recipients that the JWT is intended for.   |
 | **--auth.issuer** | false   | -   | Specify the party that issued the JWT token.   |
@@ -98,6 +98,20 @@ Update the properties of any database entity in the configuration file.
 | **--linking.target.fields** | false   | -   | Database fields in the linking object to connect to the related item in the target entity. Comma separated fields.  |
 | **--relationship.fields** | false   | -   | Specify fields to be used for mapping the entities. Example: `--relationship.fields "id:book_id"`. Here `id` represents column from sourceEntity, while `book_id` from targetEntity. Foreign keys are required between the underlying sources if not specified.  |
 | **-m, --map** | false   | -   | Specify mappings between database fields and GraphQL and REST fields. format: --map "backendName1:exposedName1,backendName2:exposedName2,...".   |
+
+### **`export`**
+Export the GraphQL schema as a file and save to disk.
+
+**Syntax**: `dab export [options]`
+
+**Example**: `dab export --graphql -o ./schemas`
+
+| Options | Required    | Default Value    | Description |
+| :---   | :--- | :--- | :--- |
+| **--graphql** | false   | false   | Export GraphQL schema.   |
+| **-o, --output** | true   | -   | Specify the directory to save the schema file.   |
+| **-g, --graphql-schema-file** | false   | schema.graphql   | Specify the name of the Graphql schema file.   |
+| **-c, --config** | false   | dab-config.json   | Path to config file.   |
 
 ### **`start`**
 Start the runtime engine with the provided configuration file for serving REST and GraphQL requests.

--- a/docs/dab-cli.md
+++ b/docs/dab-cli.md
@@ -100,7 +100,7 @@ Update the properties of any database entity in the configuration file.
 | **-m, --map** | false   | -   | Specify mappings between database fields and GraphQL and REST fields. format: --map "backendName1:exposedName1,backendName2:exposedName2,...".   |
 
 ### **`export`**
-Export the GraphQL schema as a file and save to disk.
+Export the required schema as a file and save to disk based on the options.
 
 **Syntax**: `dab export [options]`
 

--- a/docs/dab-cli.md
+++ b/docs/dab-cli.md
@@ -47,6 +47,9 @@ Initializes the runtime configuration for the Data API builder runtime engine. I
 | **--cors-origin** | false   | ""   | Specify the list of allowed origins.   |
 | **--auth.provider** | false   | StaticWebApps   | Specify the Identity Provider.   |
 | **--rest.path** | false   | /api   | Specify the REST endpoint's default prefix.   |
+| **--rest.disabled** | false   | false   | Disables REST endpoint for all entities.   |
+| **--graphql.path** | false   | /graphql   | Specify the GraphQL endpoint's default prefix.   |
+| **--graphql.disabled** | false   | false   | Disables GraphQL endpoint for all entities.   |
 | **--auth.audience** | false   | -   | Identifies the recipients that the JWT is intended for.   |
 | **--auth.issuer** | false   | -   | Specify the party that issued the JWT token.   |
 | **-c, --config** | false   | dab-config.json   | Path to config file.   |


### PR DESCRIPTION

## Why make this change?

- Improving Docs

## What is this change?

- Updating dab-cli command docs with the runtime settings option to configure graphql path/disable rest/graphql
- Adding info on the new `export` command

