### PR TITLE
Address filter access deny issue for Cosmos

### DIFF
--- a/src/Service.Tests/CosmosTests/TestBase.cs
+++ b/src/Service.Tests/CosmosTests/TestBase.cs
@@ -79,7 +79,7 @@ type Moon @model(name:""Moon"") @authorize(policy: ""Crater"") {
                 It.IsAny<string>(),
                 It.IsAny<Config.Operation>(),
                 It.IsAny<IEnumerable<string>>()
-                )).Returns(true);
+                )).Returns(false);
 
             _application = new WebApplicationFactory<Startup>()
                 .WithWebHostBuilder(builder =>

--- a/src/Service/Models/GraphQLFilterParsers.cs
+++ b/src/Service/Models/GraphQLFilterParsers.cs
@@ -141,11 +141,12 @@ namespace Azure.DataApiBuilder.Service.Models
                         relationshipField = false;
                     }
 
-                    // Only perform field (column) authorization when the field is not a relationship field.
+                    // Only perform field (column) authorization when the field is not a relationship field and when the database type is not Cosmos DB.
+                    // Currently Cosmos DB doesn't support field level authorization.
                     // Due to the recursive behavior of SqlExistsQueryStructure compilation, the column authorization
                     // check only occurs when access to the column's owner entity is confirmed.
-                    if (!relationshipField)
-                    {
+                    if (!relationshipField && _metadataProvider.GetDatabaseType() is not DatabaseType.cosmosdb_nosql)
+                        {
                         string targetEntity = queryStructure.EntityName;
 
                         bool columnAccessPermitted = queryStructure.AuthorizationResolver.AreColumnsAllowedForOperation(

--- a/src/Service/Models/GraphQLFilterParsers.cs
+++ b/src/Service/Models/GraphQLFilterParsers.cs
@@ -146,7 +146,7 @@ namespace Azure.DataApiBuilder.Service.Models
                     // Due to the recursive behavior of SqlExistsQueryStructure compilation, the column authorization
                     // check only occurs when access to the column's owner entity is confirmed.
                     if (!relationshipField && _metadataProvider.GetDatabaseType() is not DatabaseType.cosmosdb_nosql)
-                        {
+                    {
                         string targetEntity = queryStructure.EntityName;
 
                         bool columnAccessPermitted = queryStructure.AuthorizationResolver.AreColumnsAllowedForOperation(

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -170,7 +170,8 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
 
         public bool TryGetExposedColumnName(string entityName, string field, out string? name)
         {
-            throw new NotImplementedException();
+            name = field;
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Why make this change?

- Closes this issue referenced here https://github.com/Azure/data-api-builder/discussions/1423. Additional issue related to this change https://github.com/Azure/data-api-builder/issues/597
  - Cosmos DB currently doesn't support field level authorization, it's expected that we are not honoring ```operationToColumnMap.Excluded``` and ```operationToColumnMap.Included``` and by introducing field level auth check into the ```GQLFilterParser```  [recent update](https://github.com/Azure/data-api-builder/pull/1407) results the issue that we are seeing.
  - Cosmos have tests to exercise the filter parser, the reason the tests didn't catch this issue is because the changes here [added lines](https://github.com/Azure/data-api-builder/blob/1431ffc8c11bcd80f62d51c0c0fd6f15383b147a/src/Service.Tests/CosmosTests/TestBase.cs#L77-L82) that's added in this PR [recent update](https://github.com/Azure/data-api-builder/pull/1407), this mocks up the field auth check to always return true for all Cosmos filter tests. 
  - ```CosmosMetadataProvider``` does not translate a field wild card (*) or list of hardcoded include columns to the list of AllowedFields in the engine's ```AuthorizationResolver``` currently, but we can add a pass through to the ```TryGetExposedColumnName``` as suggested so it doesn't throw a ```NotImplementedException``` when user accidently passed in the fields settings in the Cosmos configuration file.

## What is this change?

- Address this by skipping the field auth check inside of the GQLFilterParser when the database type is Cosmos

## How was this tested?

- [ x ] Integration Tests
- [ x ] Unit Tests

## Sample Request(s)

```json
query planets {
  planets (filter: {id: {eq: 1000}}) {
    items {
      id
    }
  }
}
```
