### PR TITLE
RFC: Support Optional and OUTPUT Parameters for MSSQL Stored Procedures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ dab-config.*.json
 
 # Local-Only files
 .env
+
+# Dab
+dab-config.json

--- a/Nuget.config
+++ b/Nuget.config
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />
     <add key="data-api-builder_PublicPackages" value="https://msdata.pkgs.visualstudio.com/CosmosDB/_packaging/data-api-builder_PublicPackages/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/config-generators/mssql-commands.txt
+++ b/config-generators/mssql-commands.txt
@@ -167,6 +167,8 @@ update Comic --config "dab-config.MsSql.json" --permissions "TestNestedFilterOne
 update Comic --config "dab-config.MsSql.json" --permissions "TestNestedFilterOneMany_EntityReadForbidden:create,update,delete"
 update Stock --config "dab-config.MsSql.json" --permissions "TestNestedFilterFieldIsNull_ColumnForbidden:read"
 update Stock --config "dab-config.MsSql.json" --permissions "TestNestedFilterFieldIsNull_EntityReadForbidden:read"
+update Stock --config "dab-config.MsSql.json" --permissions "database_policy_tester:update" --policy-database "@item.pieceid ne 1"
+update Stock --config "dab-config.MsSql.json" --permissions "database_policy_tester:create" --policy-database "@item.pieceid ne 6 and @item.piecesAvailable gt 0"
 update series --config "dab-config.MsSql.json" --permissions "TestNestedFilterManyOne_ColumnForbidden:read" --fields.exclude "name"
 update series --config "dab-config.MsSql.json" --permissions "TestNestedFilterManyOne_EntityReadForbidden:create,update,delete"
 update series --config "dab-config.MsSql.json" --permissions "TestNestedFilterOneMany_ColumnForbidden:read"

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -22,4 +22,4 @@
 ## PostgreSQL
 
 - Entities backed by Stored Procedures are not yet supported. [Issue #1023](https://github.com/Azure/data-api-builder/issues/1023)
-- Database policies for insert via PUT/PATCH/POST operations in REST are not yet supported. [Issue #1372](https://github.com/Azure/data-api-builder/issues/1372), [Issue #1334](https://github.com/Azure/data-api-builder/issues/1334)
+- Database policies for PUT/PATCH/POST operations in REST are not yet supported. [Issue #1372](https://github.com/Azure/data-api-builder/issues/1372), [Issue #1334](https://github.com/Azure/data-api-builder/issues/1334)

--- a/src/Config/DatabaseObject.cs
+++ b/src/Config/DatabaseObject.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Data;
+
 namespace Azure.DataApiBuilder.Config
 {
     /// <summary>
@@ -98,6 +100,39 @@ namespace Azure.DataApiBuilder.Config
         public StoredProcedureDefinition StoredProcedureDefinition { get; set; } = null!;
     }
 
+    public interface IFieldDefinition {
+        public Type SystemType { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a Database Parameter Definition
+    /// </summary>
+    public class ParameterDefinition
+    {
+        public Type SystemType { get; set; } = null!;
+        
+        public bool HasConfigDefault { get; set; }
+        
+        public object? ConfigDefaultValue { get; set; }
+        
+        /// <summary>
+        /// The direction of the parameter. If null, it is assumed to be Input.
+        /// </summary>
+        public ParameterDirection? Direction { get; set; }
+        
+        /// <summary>
+        /// Whether the parameter is an output parameter.
+        /// </summary>
+        public bool IsOutput
+        {
+            get
+            {
+                return this.Direction == System.Data.ParameterDirection.Output
+                    || this.Direction == System.Data.ParameterDirection.InputOutput;
+            }
+        }
+    }
+
     public class StoredProcedureDefinition : SourceDefinition
     {
         /// <summary>
@@ -105,13 +140,6 @@ namespace Azure.DataApiBuilder.Config
         /// Key: parameter name, Value: ParameterDefinition object
         /// </summary>
         public Dictionary<string, ParameterDefinition> Parameters { get; set; } = new();
-    }
-
-    public class ParameterDefinition
-    {
-        public Type SystemType { get; set; } = null!;
-        public bool HasConfigDefault { get; set; }
-        public object? ConfigDefaultValue { get; set; }
     }
 
     /// <summary>

--- a/src/Config/DatabaseObject.cs
+++ b/src/Config/DatabaseObject.cs
@@ -110,21 +110,34 @@ namespace Azure.DataApiBuilder.Config
     /// </summary>
     public class ParameterDefinition : IFieldDefinition
     {
+        /// <summary>
+        /// The CLR type of the parameter. This is used to determine the type of the parameter in the generated code.
+        /// </summary>
         public Type SystemType { get; set; } = null!;
         
+        /// <summary>
+        /// Whether this parameter has a default defined in `dab-config.json`.
+        /// </summary>
         public bool HasConfigDefault { get; set; }
         
+        /// <summary>
+        /// If this parameter has a default defined, this is the value of the default.
+        /// </summary>
         public object? ConfigDefaultValue { get; set; }
 
-        public bool IsNullable { get; set; }
-        
         /// <summary>
-        /// The direction of the parameter. If null, it is assumed to be Input.
+        /// Whether this parameter is optional. If it is optional, it does not need to be defined in the config.
+        /// This only applies to MSSQL Stored Procedure parameters, as MySQL does not currently support optional parameters.
         /// </summary>
-        public ParameterDirection? Direction { get; set; }
+        public bool IsOptional { get; set; }
         
         /// <summary>
-        /// Whether the parameter is an output parameter.
+        /// The direction of the parameter. Assumed to be Input by default.
+        /// </summary>
+        public ParameterDirection Direction { get; set; } = ParameterDirection.Input;
+        
+        /// <summary>
+        /// Whether this parameter is an output parameter or not.
         /// </summary>
         public bool IsOutput
         {

--- a/src/Config/DatabaseObject.cs
+++ b/src/Config/DatabaseObject.cs
@@ -102,18 +102,21 @@ namespace Azure.DataApiBuilder.Config
 
     public interface IFieldDefinition {
         public Type SystemType { get; set; }
+        public bool IsNullable { get; set; }
     }
 
     /// <summary>
     /// Represents a Database Parameter Definition
     /// </summary>
-    public class ParameterDefinition
+    public class ParameterDefinition : IFieldDefinition
     {
         public Type SystemType { get; set; } = null!;
         
         public bool HasConfigDefault { get; set; }
         
         public object? ConfigDefaultValue { get; set; }
+
+        public bool IsNullable { get; set; }
         
         /// <summary>
         /// The direction of the parameter. If null, it is assumed to be Input.
@@ -200,7 +203,7 @@ namespace Azure.DataApiBuilder.Config
             = new(StringComparer.InvariantCultureIgnoreCase);
     }
 
-    public class ColumnDefinition
+    public class ColumnDefinition : IFieldDefinition
     {
         /// <summary>
         /// The database type of this column mapped to the SystemType.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,13 +17,14 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.14" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.14" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.20.0" />
-      <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
+    <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageVersion Include="Microsoft.OData.Edm" Version="7.12.5" />
     <PackageVersion Include="Microsoft.OData.Core" Version="7.12.5" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.3" />
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageVersion Include="MSTest.TestFramework" Version="2.2.10" />

--- a/src/Service.GraphQLBuilder/GraphQLNaming.cs
+++ b/src/Service.GraphQLBuilder/GraphQLNaming.cs
@@ -265,5 +265,15 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
             string preformattedField = $"execute{GetDefinedSingularName(entityName, entity)}";
             return FormatNameForField(preformattedField);
         }
+
+        /// <summary>
+        /// Generates the Result type name to be included in the generated GraphQL schema for a stored procedure.
+        /// </summary>
+        /// <param name="entityName">Name of the entity.</param>
+        /// <returns>Name to be used for the stored procedure GraphQL field.</returns>
+        public static string GenerateStoredProcedureGraphQLResultObjectName(string entityName, Entity entity)
+        {
+            return $"Execute{GetDefinedSingularName(entityName, entity)}Result";
+        }
     }
 }

--- a/src/Service.GraphQLBuilder/Queries/QueryBuilder.cs
+++ b/src/Service.GraphQLBuilder/Queries/QueryBuilder.cs
@@ -23,6 +23,9 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Queries
         public const string ORDER_BY_FIELD_NAME = "orderBy";
         public const string PARTITION_KEY_FIELD_NAME = "_partitionKeyValue";
         public const string ID_FIELD_NAME = "id";
+        public const string EXECUTE_RESULT_OBJECT_TYPE_PREFIX = "Execute";
+        public const string EXECUTE_RESULT_OBJECT_TYPE_SUFFIX = "Result";
+        public const string EXECUTE_RESULT_FIELD_NAME = "resultSet";
 
         /// <summary>
         /// Creates a DocumentNode containing FieldDefinitionNodes representing the FindByPK and FindAll queries
@@ -231,6 +234,12 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Queries
         public static bool IsPaginationType(ObjectType objectType)
         {
             return objectType.Name.Value.EndsWith(PAGINATION_OBJECT_TYPE_SUFFIX);
+        }
+
+        public static bool IsExecuteResultType(ObjectType objectType)
+        {
+            var value = objectType.Name.Value;
+            return value.StartsWith(EXECUTE_RESULT_OBJECT_TYPE_PREFIX) && value.EndsWith(EXECUTE_RESULT_OBJECT_TYPE_SUFFIX);
         }
 
         public static bool IsPaginationType(NamedTypeNode objectType)

--- a/src/Service.Tests/SqlTests/RestApiTests/Patch/MsSqlPatchApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Patch/MsSqlPatchApiTests.cs
@@ -91,6 +91,22 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Patch
                 $"FOR JSON PATH, INCLUDE_NULL_VALUES, WITHOUT_ARRAY_WRAPPER"
             },
             {
+                "PatchOneUpdateWithDatabasePolicy",
+                $"SELECT [categoryid], [pieceid], [categoryName],[piecesAvailable]," +
+                $"[piecesRequired] FROM { _Composite_NonAutoGenPK_TableName } " +
+                $"WHERE [categoryid] = 100 AND [pieceid] = 99 AND [categoryName] = 'Historical' " +
+                $"AND [piecesAvailable]= 4 AND [piecesRequired] = 0 AND [pieceid] != 1 " +
+                $"FOR JSON PATH, INCLUDE_NULL_VALUES, WITHOUT_ARRAY_WRAPPER"
+            },
+            {
+                "PatchOneInsertWithDatabasePolicy",
+                $"SELECT [categoryid], [pieceid], [categoryName],[piecesAvailable]," +
+                $"[piecesRequired] FROM { _Composite_NonAutoGenPK_TableName } " +
+                $"WHERE [categoryid] = 0 AND [pieceid] = 7 AND [categoryName] = 'SciFi' " +
+                $"AND [piecesAvailable]= 4 AND [piecesRequired] = 0 AND ([pieceid] != 6 AND [piecesAvailable] > 0) " +
+                $"FOR JSON PATH, INCLUDE_NULL_VALUES, WITHOUT_ARRAY_WRAPPER"
+            },
+            {
                 "PatchOne_Update_Default_Test",
                 $"SELECT [id], [book_id], [content] FROM { _tableWithCompositePrimaryKey } " +
                 $"WHERE id = 567 AND [book_id] = 1 AND [content] = 'That''s a great book' " +

--- a/src/Service.Tests/SqlTests/RestApiTests/Patch/MySqlPatchApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Patch/MySqlPatchApiTests.cs
@@ -217,6 +217,13 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Patch
         {
             throw new NotImplementedException();
         }
+
+        [TestMethod]
+        [Ignore]
+        public override Task PatchOneWithDatabasePolicy()
+        {
+            throw new NotImplementedException();
+        }
         #endregion
 
         #region Test Fixture Setup

--- a/src/Service.Tests/SqlTests/RestApiTests/Patch/PatchApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Patch/PatchApiTestBase.cs
@@ -609,9 +609,9 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Patch
                     operationType: Config.Operation.UpsertIncremental,
                     requestBody: requestBody,
                     exceptionExpected: true,
-                    expectedErrorMessage: $"Cannot perform INSERT and could not find {_foreignKeyEntityName} with primary key <id: 1234> to perform UPDATE on.",
-                    expectedStatusCode: HttpStatusCode.NotFound,
-                    expectedSubStatusCode: DataApiBuilderException.SubStatusCodes.EntityNotFound.ToString(),
+                    expectedErrorMessage: $"Authorization Failure: Access Not Allowed.",
+                    expectedStatusCode: HttpStatusCode.Forbidden,
+                    expectedSubStatusCode: DataApiBuilderException.SubStatusCodes.AuthorizationCheckFailed.ToString(),
                     clientRoleHeader: "database_policy_tester"
                     );
 

--- a/src/Service.Tests/SqlTests/RestApiTests/Patch/PostgreSqlPatchApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Patch/PostgreSqlPatchApiTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -206,6 +207,13 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Patch
         }
 
         #region overridden tests
+
+        [TestMethod]
+        [Ignore]
+        public override Task PatchOneUpdateInAccessibleRowWithDatabasePolicy()
+        {
+            throw new NotImplementedException();
+        }
 
         #endregion
 

--- a/src/Service.Tests/SqlTests/RestApiTests/Patch/PostgreSqlPatchApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Patch/PostgreSqlPatchApiTests.cs
@@ -215,6 +215,12 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Patch
             throw new NotImplementedException();
         }
 
+        [TestMethod]
+        [Ignore]
+        public override Task PatchOneWithDatabasePolicy()
+        {
+            throw new NotImplementedException();
+        }
         #endregion
 
         #region Test Fixture Setup

--- a/src/Service.Tests/SqlTests/RestApiTests/Put/MySqlPutApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Put/MySqlPutApiTests.cs
@@ -293,6 +293,12 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Put
             throw new NotImplementedException();
         }
 
+        [TestMethod]
+        [Ignore]
+        public override Task PutOneInsertInTableWithFieldsInDbPolicyNotPresentInBody()
+        {
+            throw new NotImplementedException();
+        }
         #endregion
 
         #region Test Fixture Setup

--- a/src/Service.Tests/SqlTests/RestApiTests/Put/MySqlPutApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Put/MySqlPutApiTests.cs
@@ -286,6 +286,13 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Put
             throw new NotImplementedException();
         }
 
+        [TestMethod]
+        [Ignore]
+        public override Task PutOneWithUnsatisfiedDatabasePolicy()
+        {
+            throw new NotImplementedException();
+        }
+
         #endregion
 
         #region Test Fixture Setup

--- a/src/Service.Tests/SqlTests/RestApiTests/Put/PostgreSqlPutApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Put/PostgreSqlPutApiTests.cs
@@ -330,6 +330,13 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Put
         {
             throw new NotImplementedException();
         }
+
+        [TestMethod]
+        [Ignore]
+        public override Task PutOneInsertInTableWithFieldsInDbPolicyNotPresentInBody()
+        {
+            throw new NotImplementedException();
+        }
         #endregion
 
         [TestCleanup]

--- a/src/Service.Tests/SqlTests/RestApiTests/Put/PostgreSqlPutApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Put/PostgreSqlPutApiTests.cs
@@ -323,6 +323,13 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Put
         {
             throw new NotImplementedException();
         }
+
+        [TestMethod]
+        [Ignore]
+        public override Task PutOneWithUnsatisfiedDatabasePolicy()
+        {
+            throw new NotImplementedException();
+        }
         #endregion
 
         [TestCleanup]

--- a/src/Service.Tests/SqlTests/RestApiTests/Put/PostgreSqlPutApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Put/PostgreSqlPutApiTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -312,6 +313,16 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Put
             await InitializeTestFixture(context);
         }
 
+        #endregion
+
+        #region overridden tests
+
+        [TestMethod]
+        [Ignore]
+        public override Task PutOneUpdateAccessibleRowWithDatabasePolicy()
+        {
+            throw new NotImplementedException();
+        }
         #endregion
 
         [TestCleanup]

--- a/src/Service.Tests/SqlTests/RestApiTests/Put/PutApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Put/PutApiTestBase.cs
@@ -885,6 +885,32 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Put
                     clientRoleHeader: "database_policy_tester"
                     );
         }
+
+        /// <summary>
+        /// Test to validate failure of a request when one or more fields referenced in the database policy for create operation are not provided in the request body.
+        /// </summary>
+        [TestMethod]
+        public virtual async Task PutOneInsertInTableWithFieldsInDbPolicyNotPresentInBody()
+        {
+            string requestBody = @"
+            {
+                ""categoryName"":""SciFi""
+            }";
+
+            await SetupAndRunRestApiTest(
+                primaryKeyRoute: "categoryid/100/pieceid/99",
+                queryString: string.Empty,
+                entityNameOrPath: _Composite_NonAutoGenPK_EntityPath,
+                sqlQuery: string.Empty,
+                operationType: Config.Operation.Upsert,
+                exceptionExpected: true,
+                requestBody: requestBody,
+                clientRoleHeader: "database_policy_tester",
+                expectedErrorMessage: "One or more fields referenced by the database policy are not present in the request.",
+                expectedStatusCode: HttpStatusCode.BadRequest,
+                expectedSubStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest.ToString()
+                );
+        }
         #endregion
     }
 }

--- a/src/Service.Tests/dab-config.MsSql.json
+++ b/src/Service.Tests/dab-config.MsSql.json
@@ -254,6 +254,23 @@
           "actions": [
             "read"
           ]
+        },
+        {
+          "role": "database_policy_tester",
+          "actions": [
+            {
+              "action": "Create",
+              "policy": {
+                "database": "@item.pieceid ne 6 and @item.piecesAvailable gt 0"
+              }
+            },
+            {
+              "action": "Update",
+              "policy": {
+                "database": "@item.pieceid ne 1"
+              }
+            }
+          ]
         }
       ],
       "relationships": {

--- a/src/Service/Configurations/RuntimeConfigValidator.cs
+++ b/src/Service/Configurations/RuntimeConfigValidator.cs
@@ -779,11 +779,10 @@ namespace Azure.DataApiBuilder.Service.Configurations
                     entity.GraphQL is not null && !(entity.GraphQL is bool graphQLEnabled && !graphQLEnabled))
                 {
                     DatabaseObject dbObject = sqlMetadataProvider.EntityToDatabaseObject[entityName];
-                    StoredProcedureRequestContext sqRequestContext = new(
-                                                                            entityName,
-                                                                            dbObject,
-                                                                            JsonSerializer.SerializeToElement(entity.Parameters),
-                                                                            Config.Operation.All);
+                    StoredProcedureRequestContext sqRequestContext = new(entityName,
+                                                                         dbObject,
+                                                                         JsonSerializer.SerializeToElement(entity.Parameters),
+                                                                         Config.Operation.All);
                     try
                     {
                         RequestValidator.ValidateStoredProcedureRequestContext(sqRequestContext, sqlMetadataProvider);

--- a/src/Service/Models/DbResultSet.cs
+++ b/src/Service/Models/DbResultSet.cs
@@ -13,8 +13,8 @@ namespace Azure.DataApiBuilder.Service.Models
         public DbResultSet(
             Dictionary<string, object> resultProperties)
         {
-            this.Rows = new();
-            this.ResultProperties = resultProperties;
+            Rows = new();
+            ResultProperties = resultProperties;
         }
 
         /// <summary>

--- a/src/Service/Resolvers/BaseSqlQueryBuilder.cs
+++ b/src/Service/Resolvers/BaseSqlQueryBuilder.cs
@@ -24,6 +24,11 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         public const string TABLE_NAME_PARAM = "tableName";
 
         /// <summary>
+        /// Predicate added to the query when no valid predicates exist.
+        /// </summary>
+        public const string BASE_PREDICATE = "1 = 1";
+
+        /// <summary>
         /// Adds database specific quotes to string identifier
         /// </summary>
         public abstract string QuoteIdentifier(string ident);
@@ -32,7 +37,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         public virtual string Build(BaseSqlQueryStructure structure)
         {
             string predicates = new(JoinPredicateStrings(
-                       structure.DbPolicyPredicates,
+                       structure.DbPolicyPredicatesForOperations[Config.Operation.Read],
                        Build(structure.Predicates)));
 
             string query = $"SELECT 1 " +
@@ -370,7 +375,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
 
             if (!validPredicates.Any())
             {
-                return "1 = 1";
+                return BASE_PREDICATE;
             }
 
             return string.Join(" AND ", validPredicates);

--- a/src/Service/Resolvers/CosmosQueryStructure.cs
+++ b/src/Service/Resolvers/CosmosQueryStructure.cs
@@ -97,7 +97,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
 
             if (IsPaginated)
             {
-                FieldNode? fieldNode = ExtractItemsQueryField(selection.SyntaxNode);
+                FieldNode? fieldNode = FindFieldNodeByName(selection.SyntaxNode, QueryBuilder.PAGINATION_FIELD_NAME);
 
                 if (fieldNode is not null)
                 {

--- a/src/Service/Resolvers/IQueryBuilder.cs
+++ b/src/Service/Resolvers/IQueryBuilder.cs
@@ -65,6 +65,13 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         public string BuildStoredProcedureResultDetailsQuery(string databaseObjectName);
 
         /// <summary>
+        /// Builds a query to obtain the definition of the provided stored-procedure.
+        /// </summary>
+        /// <param name="databaseObjectName">Name of stored-procedure</param>
+        /// <returns>A query to get the Definition details for the provided stored procedure.</returns>
+        public string BuildStoredProcedureDefinitionQuery(string databaseObjectName);
+
+        /// <summary>
         /// Adds database specific quotes to string identifier
         /// </summary>
         public string QuoteIdentifier(string identifier);

--- a/src/Service/Resolvers/IQueryExecutor.cs
+++ b/src/Service/Resolvers/IQueryExecutor.cs
@@ -47,6 +47,18 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             List<string>? args = null);
 
         /// <summary>
+        /// Extracts the rows from the given DbDataReader to populate
+        /// the JsonObject to be returned.
+        /// </summary>
+        /// <param name="dbDataReader">A DbDataReader.</param>
+        /// <param name="args">List of string arguments if any.</param>
+        /// <returns>A JsonObject with a ResultSet property containing each element corresponding to the row (ColumnName : columnValue)
+        /// in the dbDataReader and Key Value properties pertaining to OUTPUT parameters.</returns>
+        public Task<JsonObject> GetJsonObjectAsync(
+            DbDataReader dbDataReader,
+            List<string>? args = null);
+
+        /// <summary>
         /// Extracts the rows from the given DbDataReader to deserialize into
         /// a Json object of type TResult to be returned.
         /// </summary>

--- a/src/Service/Resolvers/IQueryExecutor.cs
+++ b/src/Service/Resolvers/IQueryExecutor.cs
@@ -78,7 +78,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// <returns>Single row read from DbDataReader.
         /// If the first result set is being returned, DbResultSet.ResultProperties dictionary has
         /// the property "IsFirstResultSet" set to true.</returns>
-        public Task<DbResultSet> GetMultipleResultSetsIfAnyAsync(
+        public abstract Task<DbResultSet> GetMultipleResultSetsIfAnyAsync(
                 DbDataReader dbDataReader,
                 List<string>? args = null);
 

--- a/src/Service/Resolvers/IQueryExecutor.cs
+++ b/src/Service/Resolvers/IQueryExecutor.cs
@@ -77,7 +77,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// <param name="args">The arguments to this handler - args[0] = primary key in pretty format, args[1] = entity name.</param>
         /// <returns>Single row read from DbDataReader.
         /// If the first result set is being returned, DbResultSet.ResultProperties dictionary has
-        /// the property "IsFirstResultSet" set to true.</returns>
+        /// the property "IsUpdateResultSet" set to true.</returns>
         public abstract Task<DbResultSet> GetMultipleResultSetsIfAnyAsync(
                 DbDataReader dbDataReader,
                 List<string>? args = null);

--- a/src/Service/Resolvers/IQueryExecutor.cs
+++ b/src/Service/Resolvers/IQueryExecutor.cs
@@ -69,9 +69,9 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                 List<string>? args = null);
 
         /// <summary>
-        /// Extracts first result set and returns it immediately if it has > 0 rows.
-        /// If no rows, tries to get the subsequent result set if any.
-        /// Throws an exception if the second result is null as well.
+        /// Extracts the result set corresponding to the operation (update/insert) being executed.
+        /// For PgSql,MySql, returns the first result set (among the two for update/insert) having non-zero affected rows.
+        /// For MsSql, returns the only result set having non-zero affected rows which corresponds to either update/insert operation.
         /// </summary>
         /// <param name="dbDataReader">A DbDataReader.</param>
         /// <param name="args">The arguments to this handler - args[0] = primary key in pretty format, args[1] = entity name.</param>

--- a/src/Service/Resolvers/MsSqlQueryBuilder.cs
+++ b/src/Service/Resolvers/MsSqlQueryBuilder.cs
@@ -110,29 +110,79 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// <returns></returns>
         public string Build(SqlUpsertQueryStructure structure)
         {
-            string updatePredicates = JoinPredicateStrings(Build(structure.Predicates), structure.DbPolicyPredicatesForOperations[Config.Operation.Update]);
-            string insertPredicates = JoinPredicateStrings(structure.DbPolicyPredicatesForOperations[Config.Operation.Create]);
+            string tableName = $"{QuoteIdentifier(structure.DatabaseObject.SchemaName)}.{QuoteIdentifier(structure.DatabaseObject.Name)}";
+            string pkPredicates = JoinPredicateStrings(Build(structure.Predicates));
+            string updatePredicates = JoinPredicateStrings(pkPredicates, structure.DbPolicyPredicatesForOperations[Config.Operation.Update]);
+            string updateOperations = Build(structure.UpdateOperations, ", ");
+            string outputColumns = MakeOutputColumns(structure.OutputColumns, OutputQualifier.Inserted);
+            string queryToGetCountOfRecordWithPK = $"SELECT COUNT(*) as cnt_rows_to_update FROM {tableName} WHERE {pkPredicates}";
             if (structure.IsFallbackToUpdate)
             {
-                return $"UPDATE {QuoteIdentifier(structure.DatabaseObject.SchemaName)}.{QuoteIdentifier(structure.DatabaseObject.Name)} " +
-                    $"SET {Build(structure.UpdateOperations, ", ")} " +
-                    $"OUTPUT {MakeOutputColumns(structure.OutputColumns, OutputQualifier.Inserted)} " +
-                    $"WHERE {updatePredicates};";
+                return $"SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;" +
+                    $"BEGIN TRANSACTION;" +
+                    $"DECLARE @ROWS_TO_UPDATE int;" +
+                    $"SET @ROWS_TO_UPDATE = ({queryToGetCountOfRecordWithPK}); " +
+                    $"{queryToGetCountOfRecordWithPK};" +
+                    $"IF @ROWS_TO_UPDATE = 1 " +
+                    $"UPDATE {tableName} " +
+                    $"SET {updateOperations} " +
+                    $"OUTPUT {outputColumns} " +
+                    $"WHERE {updatePredicates};" +
+                    $"COMMIT TRANSACTION";
+                /*return $"UPDATE {tableName} " +
+                   $"SET {updateOperations} " +
+                   $"OUTPUT {outputColumns} " +
+                   $"WHERE {updatePredicates};";*/
             }
             else
             {
-                return $"SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;BEGIN TRANSACTION; UPDATE {QuoteIdentifier(structure.DatabaseObject.SchemaName)}.{QuoteIdentifier(structure.DatabaseObject.Name)} " +
-                    $"WITH(UPDLOCK) SET {Build(structure.UpdateOperations, ", ")} " +
-                    $"OUTPUT {MakeOutputColumns(structure.OutputColumns, OutputQualifier.Inserted)} " +
-                    $"WHERE {updatePredicates} " +
-                    $"IF @@ROWCOUNT = 0 " +
-                    $"BEGIN; " +
-                    $"INSERT INTO {QuoteIdentifier(structure.DatabaseObject.SchemaName)}.{QuoteIdentifier(structure.DatabaseObject.Name)} ({Build(structure.InsertColumns)}) " +
-                    $"OUTPUT {MakeOutputColumns(structure.OutputColumns, OutputQualifier.Inserted)} " +
-                    $"VALUES ({string.Join(", ", structure.Values)}) " +
-                    $"END; COMMIT TRANSACTION";
-            }
+                // Columns which are assigned some value in the PUT/PATCH request.
+                string insertColumns = Build(structure.InsertColumns);
 
+                // Predicates added by virtue of database policy for create operation.
+                string createPredicates = JoinPredicateStrings(structure.DbPolicyPredicatesForOperations[Config.Operation.Create]);
+
+                // Final query to be executed for the given PUT/PATCH operation.
+                StringBuilder upsertQuery = new(
+                    $"SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;" +
+                    $"BEGIN TRANSACTION;" +
+                    $"DECLARE @ROWS_TO_UPDATE int;" +
+                    $"SET @ROWS_TO_UPDATE = ({queryToGetCountOfRecordWithPK}); " +
+                    $"{queryToGetCountOfRecordWithPK};");
+
+                // Query to update record (if there exists one corresponding to given PK).
+                StringBuilder updateQuery = new(
+                    $"IF @ROWS_TO_UPDATE = 1" +
+                    $"UPDATE {tableName} WITH(UPDLOCK) " +
+                    $"SET {updateOperations} " +
+                    $"OUTPUT {outputColumns} " +
+                    $"WHERE {updatePredicates};");
+
+                // Append the update query to upsert query.
+                upsertQuery.Append( updateQuery );
+
+                // Append the conditional to check if the insert query is to be executed or not.
+                // Insert is only attempted when no record exists corresponding to given PK.
+                upsertQuery.Append("ELSE ");
+
+                // Query to insert record (if there exists none corresponding to given PK).
+                StringBuilder insertQuery = new($"INSERT INTO {tableName} ({insertColumns}) OUTPUT {outputColumns}");
+                
+                string fetchColumnValuesQuery = BASE_PREDICATE.Equals(createPredicates) ?
+                    $"VALUES({string.Join(", ", structure.Values)});" :
+                    $"SELECT {insertColumns} FROM (VALUES({string.Join(", ", structure.Values)})) T({insertColumns}) WHERE {createPredicates};";
+
+                // Append the values to be inserted to the insertQuery.
+                insertQuery.Append(fetchColumnValuesQuery);
+
+                // Append the insert query to the upsert query.
+                upsertQuery.Append(insertQuery.ToString());
+
+                // Commit the transaction.
+                upsertQuery.Append("COMMIT TRANSACTION");
+
+                return upsertQuery.ToString();
+            }
         }
 
         /// <summary>

--- a/src/Service/Resolvers/MsSqlQueryBuilder.cs
+++ b/src/Service/Resolvers/MsSqlQueryBuilder.cs
@@ -68,7 +68,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             string insertColumns = Build(structure.InsertColumns);
             string insertIntoStatementPrefix = $"INSERT INTO {QuoteIdentifier(structure.DatabaseObject.SchemaName)}.{QuoteIdentifier(structure.DatabaseObject.Name)} ({insertColumns}) " +
                 $"OUTPUT {MakeOutputColumns(structure.OutputColumns, OutputQualifier.Inserted)} ";
-            string values = predicates.Equals(BASE_PREDICATE)?
+            string values = predicates.Equals(BASE_PREDICATE) ?
                 $"VALUES ({string.Join(", ", structure.Values)});" : $"SELECT {insertColumns} FROM (VALUES({string.Join(", ", structure.Values)})) T({insertColumns}) WHERE {predicates};";
             StringBuilder insertQuery = new(insertIntoStatementPrefix);
             return insertQuery.Append(values).ToString();
@@ -160,7 +160,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
 
                 // Query to insert record (if there exists none for given PK).
                 StringBuilder insertQuery = new($"INSERT INTO {tableName} ({insertColumns}) OUTPUT {outputColumns}");
-                
+
                 string fetchColumnValuesQuery = BASE_PREDICATE.Equals(createPredicates) ?
                     $"VALUES({string.Join(", ", structure.Values)});" :
                     $"SELECT {insertColumns} FROM (VALUES({string.Join(", ", structure.Values)})) T({insertColumns}) WHERE {createPredicates};";

--- a/src/Service/Resolvers/MsSqlQueryBuilder.cs
+++ b/src/Service/Resolvers/MsSqlQueryBuilder.cs
@@ -267,5 +267,10 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                             "WHERE is_hidden is not NULL AND is_hidden = 0";
             return query;
         }
+
+        public string BuildStoredProcedureDefinitionQuery(string databaseObjectName)
+        {
+            return $"SELECT OBJECT_DEFINITION(OBJECT_ID('{databaseObjectName}')) AS ProcedureDefinition;";
+        }
     }
 }

--- a/src/Service/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Service/Resolvers/MsSqlQueryExecutor.cs
@@ -204,7 +204,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         {
             // From the first result set, we get the count(0/1) of records with given PK.
             DbResultSet resultSetWithCountOfRowsWithGivenPk = await ExtractResultSetFromDbDataReader(dbDataReader);
-            int numOfRecordsWithGivenPK = (int)resultSetWithCountOfRowsWithGivenPk.Rows.FirstOrDefault()!.Columns["cnt_rows_to_update"]!;
+            int numOfRecordsWithGivenPK = (int)resultSetWithCountOfRowsWithGivenPk.Rows.FirstOrDefault()!.Columns[MsSqlQueryBuilder.COUNT_ROWS_WITH_GIVEN_PK]!;
 
             // The result set which holds the records returned as a result of the executed update/insert operation.
             DbResultSet? dbResultSet = await dbDataReader.NextResultAsync() ? await ExtractResultSetFromDbDataReader(dbDataReader) : null;
@@ -225,7 +225,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
 
             }
 
-            if (numOfRecordsWithGivenPK == 1) // This indicates that we attempted an update operation.
+            if (numOfRecordsWithGivenPK == 1) // This indicates that a record existed with given PK and we attempted an update operation.
             {
                 if (dbResultSet.Rows.Count == 0)
                 {

--- a/src/Service/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Service/Resolvers/MsSqlQueryExecutor.cs
@@ -206,7 +206,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             DbResultSet resultSetWithCountOfRowsWithGivenPk = await ExtractResultSetFromDbDataReader(dbDataReader);
             int numOfRecordsWithGivenPK = (int)resultSetWithCountOfRowsWithGivenPk.Rows.FirstOrDefault()!.Columns[MsSqlQueryBuilder.COUNT_ROWS_WITH_GIVEN_PK]!;
 
-            // The result set which holds the records returned as a result of the executed update/insert operation.
+            // The second result set holds the records returned as a result of the executed update/insert operation.
             DbResultSet? dbResultSet = await dbDataReader.NextResultAsync() ? await ExtractResultSetFromDbDataReader(dbDataReader) : null;
 
             if (dbResultSet is null)

--- a/src/Service/Resolvers/MySqlQueryBuilder.cs
+++ b/src/Service/Resolvers/MySqlQueryBuilder.cs
@@ -330,5 +330,10 @@ WHERE
         {
             throw new NotImplementedException();
         }
+
+        public string BuildStoredProcedureDefinitionQuery(string databaseObjectName)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Service/Resolvers/MySqlQueryBuilder.cs
+++ b/src/Service/Resolvers/MySqlQueryBuilder.cs
@@ -35,7 +35,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             fromSql += string.Join("", structure.JoinQueries.Select(x => $" LEFT OUTER JOIN LATERAL ({Build(x.Value)}) AS {QuoteIdentifier(x.Key)} ON TRUE"));
 
             string predicates = JoinPredicateStrings(
-                                    structure.DbPolicyPredicates,
+                                    structure.DbPolicyPredicatesForOperations[Config.Operation.Read],
                                     structure.FilterPredicates,
                                     Build(structure.Predicates),
                                     Build(structure.PaginationMetadata.PaginationPredicate));
@@ -81,7 +81,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             (string sets, string updates, string select) = MakeStoreUpdatePK(structure.AllColumns(),
                                                                              structure.OutputColumns);
             string predicates = JoinPredicateStrings(
-                       structure.DbPolicyPredicates,
+                       structure.DbPolicyPredicatesForOperations[Config.Operation.Update],
                        Build(structure.Predicates));
 
             return sets + ";\n" +
@@ -97,7 +97,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         public string Build(SqlDeleteStructure structure)
         {
             string predicates = JoinPredicateStrings(
-                    structure.DbPolicyPredicates,
+                    structure.DbPolicyPredicatesForOperations[Config.Operation.Delete],
                     Build(structure.Predicates));
 
             return $"DELETE FROM {QuoteIdentifier(structure.DatabaseObject.Name)} " +

--- a/src/Service/Resolvers/PostgresQueryBuilder.cs
+++ b/src/Service/Resolvers/PostgresQueryBuilder.cs
@@ -226,5 +226,10 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         {
             throw new NotImplementedException();
         }
+
+        public string BuildStoredProcedureDefinitionQuery(string databaseObjectName)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Service/Resolvers/PostgresQueryBuilder.cs
+++ b/src/Service/Resolvers/PostgresQueryBuilder.cs
@@ -36,7 +36,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             fromSql += string.Join("", structure.JoinQueries.Select(x => $" LEFT OUTER JOIN LATERAL ({Build(x.Value)}) AS {QuoteIdentifier(x.Key)} ON TRUE"));
 
             string predicates = JoinPredicateStrings(
-                                    structure.DbPolicyPredicates,
+                                    structure.DbPolicyPredicatesForOperations[Config.Operation.Read],
                                     structure.FilterPredicates,
                                     Build(structure.Predicates),
                                     Build(structure.PaginationMetadata.PaginationPredicate));
@@ -78,7 +78,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         public string Build(SqlUpdateStructure structure)
         {
             string predicates = JoinPredicateStrings(
-                                   structure.DbPolicyPredicates,
+                                   structure.DbPolicyPredicatesForOperations[Config.Operation.Update],
                                    Build(structure.Predicates));
 
             return $"UPDATE {QuoteIdentifier(structure.DatabaseObject.SchemaName)}.{QuoteIdentifier(structure.DatabaseObject.Name)} " +
@@ -91,7 +91,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         public string Build(SqlDeleteStructure structure)
         {
             string predicates = JoinPredicateStrings(
-                       structure.DbPolicyPredicates,
+                       structure.DbPolicyPredicatesForOperations[Config.Operation.Delete],
                        Build(structure.Predicates));
 
             return $"DELETE FROM {QuoteIdentifier(structure.DatabaseObject.SchemaName)}.{QuoteIdentifier(structure.DatabaseObject.Name)} " +
@@ -110,10 +110,10 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         {
             // https://stackoverflow.com/questions/42668720/check-if-postgres-query-inserted-or-updated-via-upsert
             // relying on xmax to detect insert vs update breaks for views
-            string predicates = JoinPredicateStrings(Build(structure.Predicates), structure.DbPolicyPredicates);
+            string updatePredicates = JoinPredicateStrings(Build(structure.Predicates), structure.DbPolicyPredicatesForOperations[Config.Operation.Update]);
             string updateQuery = $"UPDATE {QuoteIdentifier(structure.DatabaseObject.SchemaName)}.{QuoteIdentifier(structure.DatabaseObject.Name)} " +
                 $"SET {Build(structure.UpdateOperations, ", ")} " +
-                $"WHERE {predicates} " +
+                $"WHERE {updatePredicates} " +
                 $"RETURNING {Build(structure.OutputColumns)}, '{UPDATE_UPSERT}' AS {UPSERT_IDENTIFIER_COLUMN_NAME}";
 
             if (structure.IsFallbackToUpdate)

--- a/src/Service/Resolvers/QueryExecutor.cs
+++ b/src/Service/Resolvers/QueryExecutor.cs
@@ -179,14 +179,15 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                 }
             }
 
+            TResult? result = default(TResult);
             try
             {
-                // await cmd.ExecuteNonQueryAsync();
-                // return null;
-                using DbDataReader dbDataReader = await cmd.ExecuteReaderAsync(CommandBehavior.CloseConnection);
-                if (dataReaderHandler is not null && dbDataReader is not null)
+                using (var dbDataReader = await cmd.ExecuteReaderAsync(CommandBehavior.CloseConnection))
                 {
-                    return await dataReaderHandler(dbDataReader, args);
+                    if (dataReaderHandler is not null && dbDataReader is not null)
+                    {
+                        result = await dataReaderHandler(dbDataReader, args);
+                    }
                 }
 
                 if (parameters is not null && result is JsonObject jsonObjectResult)
@@ -199,6 +200,8 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                         }
                     }
                 }
+
+                return result;
             }
             catch (DbException e)
             {

--- a/src/Service/Resolvers/QueryExecutor.cs
+++ b/src/Service/Resolvers/QueryExecutor.cs
@@ -315,7 +315,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// <inheritdoc />
         /// <Note>This function is a DbDataReader handler of type
         /// Func<DbDataReader, List<string>?, Task<TResult?>></Note>
-        public async Task<DbResultSet> GetMultipleResultSetsIfAnyAsync(
+        public virtual async Task<DbResultSet> GetMultipleResultSetsIfAnyAsync(
             DbDataReader dbDataReader, List<string>? args = null)
         {
             DbResultSet dbResultSet
@@ -327,7 +327,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             /// result set #2: result of the INSERT operation.
             if (dbResultSet.Rows.Count > 0 && dbResultSet.Rows.FirstOrDefault()!.Columns.Count > 0)
             {
-                dbResultSet.ResultProperties.Add(SqlMutationEngine.IS_FIRST_RESULT_SET, true);
+                dbResultSet.ResultProperties.Add(SqlMutationEngine.IS_UPDATE_RESULT_SET, true);
                 return dbResultSet;
             }
             else if (await dbDataReader.NextResultAsync())

--- a/src/Service/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
@@ -44,7 +44,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// DbPolicyPredicates is a string that represents the filter portion of our query
         /// in the WHERE Clause added by virtue of the database policy.
         /// </summary>
-        public string? DbPolicyPredicates { get; set; }
+        public Dictionary<Config.Operation, string?> DbPolicyPredicatesForOperations { get; set; } = new();
 
         /// <summary>
         /// Collection of all the fields referenced in the database policy for create action.
@@ -472,12 +472,18 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// <param name="dbPolicyClause">FilterClause from processed runtime configuration permissions Policy:Database</param>
         /// <param name="operation">CRUD operation for which the database policy predicates are to be evaluated.</param>
         /// <exception cref="DataApiBuilderException">Thrown when the OData visitor traversal fails. Possibly due to malformed clause.</exception>
-        public void ProcessOdataClause(FilterClause dbPolicyClause, Config.Operation operation)
+        public void ProcessOdataClause(FilterClause? dbPolicyClause, Config.Operation operation)
         {
+            if (dbPolicyClause is null)
+            {
+                DbPolicyPredicatesForOperations[operation] = null;
+                return;
+            }
+
             ODataASTVisitor visitor = new(this, MetadataProvider, operation);
             try
             {
-                DbPolicyPredicates = GetFilterPredicatesFromOdataClause(dbPolicyClause, visitor);
+                DbPolicyPredicatesForOperations[operation] = GetFilterPredicatesFromOdataClause(dbPolicyClause, visitor);
             }
             catch (Exception ex)
             {

--- a/src/Service/Resolvers/Sql Query Structures/SqlExecuteQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/SqlExecuteQueryStructure.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Linq;
 using System.Net;
 using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config;
@@ -12,15 +14,68 @@ using Azure.DataApiBuilder.Service.Services;
 
 namespace Azure.DataApiBuilder.Service.Resolvers
 {
+    /// <summary>
+    /// Defines a parameter for an EXECUTE stored procedure call.
+    /// </summary>
+    public class SqlExecuteParameter
+    {
+        /// <summary>
+        /// The name of the parameter
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The engine-generated referencing parameters (e.g. @param0, @param1...)
+        /// </summary>
+        public object? Value { get; set; }
+
+        /// <summary>
+        /// The direction of the parameter (e.g. Input, Output, InputOutput)
+        /// </summary>
+        public ParameterDirection Direction { get; set; }
+
+        /// <summary>
+        /// Whether the parameter is an output parameter.
+        /// </summary>
+        public bool IsOutput
+        {
+            get
+            {
+                return this.Direction == System.Data.ParameterDirection.Output
+                    || this.Direction == System.Data.ParameterDirection.InputOutput;
+            }
+        }
+
+        /// <summary>
+        /// Constructs a parameter with the given name and direction.
+        /// </summary>
+        /// <param name="value">The engine-generated referencing parameters (e.g. @param0, @param1...)/param>
+        /// <param name="direction">The direction of the parameter (e.g. Input, Output, InputOutput)</param>
+        public SqlExecuteParameter(string name, object? value, ParameterDirection direction)
+        {
+            Name = name;
+            Value = value;
+            Direction = direction;
+        }
+    }
+
     ///<summary>
     /// Wraps all the required data and logic to write a SQL EXECUTE query
     ///</summary>
     public class SqlExecuteStructure : BaseSqlQueryStructure
     {
         // Holds the final, resolved parameters that will be passed when building the execute stored procedure query
-        // Keys are the stored procedure arguments (e.g. @id, @username...)
-        // Values are the engine-generated referencing parameters (e.g. @param0, @param1...)
+        // Keys are the user-generated procedure parameter names
         public Dictionary<string, object> ProcedureParameters { get; set; }
+
+        // Whether this SqlExecuteQueryStructure has any OUTPUT parameters.
+        public bool HasOutputParameters
+        {
+            get
+            {
+                return Parameters.Values.Any(p => p is SqlExecuteParameter executeParameter && executeParameter.IsOutput);
+            }
+        }
 
         /// <summary>
         /// Constructs a structure with all needed components to build an EXECUTE stored procedure call
@@ -40,6 +95,8 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             ProcedureParameters = new();
             foreach ((string paramKey, ParameterDefinition paramDefinition) in storedProcedureDefinition.Parameters)
             {
+                var parameterDirection = paramDefinition.Direction ?? ParameterDirection.Input;
+
                 // Populate with request param if able
                 if (requestParams.TryGetValue(paramKey, out object? requestParamValue))
                 {
@@ -48,7 +105,16 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                     if (requestParamValue is not null)
                     {
                         Type systemType = GetUnderlyingStoredProcedureDefinition().Parameters[paramKey].SystemType!;
-                        parametrizedName = MakeParamWithValue(GetParamAsSystemType(requestParamValue.ToString()!, paramKey, systemType));
+                        parametrizedName = MakeParamWithValue(
+                            new SqlExecuteParameter(
+                                paramKey,
+                                GetParamAsSystemType(
+                                    requestParamValue.ToString()!,
+                                    paramKey,
+                                    systemType
+                                ), parameterDirection
+                            )
+                        );
                     }
                     else
                     {
@@ -62,7 +128,13 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                     // Fill with default value from runtime config
                     if (paramDefinition.HasConfigDefault)
                     {
-                        string parameterizedName = MakeParamWithValue(paramDefinition.ConfigDefaultValue);
+                        string parameterizedName = MakeParamWithValue(
+                            new SqlExecuteParameter(
+                                paramKey,
+                                paramDefinition.ConfigDefaultValue,
+                                parameterDirection
+                            )
+                        );
                         ProcedureParameters.Add(paramKey, $"{parameterizedName}");
                     }
                     else

--- a/src/Service/Resolvers/Sql Query Structures/SqlExecuteQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/SqlExecuteQueryStructure.cs
@@ -95,7 +95,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             ProcedureParameters = new();
             foreach ((string paramKey, ParameterDefinition paramDefinition) in storedProcedureDefinition.Parameters)
             {
-                var parameterDirection = paramDefinition.Direction ?? ParameterDirection.Input;
+                var parameterDirection = paramDefinition.Direction;
 
                 // Populate with request param if able
                 if (requestParams.TryGetValue(paramKey, out object? requestParamValue))
@@ -125,25 +125,28 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                 }
                 else
                 {
-                    // Fill with default value from runtime config
-                    if (paramDefinition.HasConfigDefault)
+                    if (!paramDefinition.IsOptional)
                     {
-                        string parameterizedName = MakeParamWithValue(
-                            new SqlExecuteParameter(
-                                paramKey,
-                                paramDefinition.ConfigDefaultValue,
-                                parameterDirection
-                            )
-                        );
-                        ProcedureParameters.Add(paramKey, $"{parameterizedName}");
-                    }
-                    else
-                    {
-                        // In case required parameters not found in request and no default specified in config
-                        // Should already be handled in the request validation step
-                        throw new DataApiBuilderException(message: $"Did not provide all procedure params, missing: \"{paramKey}\"",
-                            statusCode: HttpStatusCode.BadRequest,
-                            subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
+                        // Fill with default value from runtime config
+                        if (paramDefinition.HasConfigDefault)
+                        {
+                            string parameterizedName = MakeParamWithValue(
+                                new SqlExecuteParameter(
+                                    paramKey,
+                                    paramDefinition.ConfigDefaultValue,
+                                    parameterDirection
+                                )
+                            );
+                            ProcedureParameters.Add(paramKey, $"{parameterizedName}");
+                        }
+                        else
+                        {
+                            // In case required parameters not found in request and no default specified in config
+                            // Should already be handled in the request validation step
+                            throw new DataApiBuilderException(message: $"Did not provide all procedure params, missing: \"{paramKey}\"",
+                                statusCode: HttpStatusCode.BadRequest,
+                                subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
+                        }
                     }
                 }
             }

--- a/src/Service/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -284,10 +284,10 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                     ProcessPaginationFields(queryField.SelectionSet.Selections);
 
                     // override schemaField and queryField with the schemaField and queryField of *Connection.items
-                    queryField = ExtractItemsQueryField(queryField);
+                    queryField = FindFieldNodeByName(queryField, QueryBuilder.PAGINATION_FIELD_NAME);
                 }
 
-                schemaField = ExtractItemsSchemaField(schemaField);
+                schemaField = GetFieldFromUnderlyingEntityType(schemaField, QueryBuilder.PAGINATION_FIELD_NAME);
 
                 outputType = schemaField.Type;
                 _underlyingFieldType = GraphQLUtils.UnderlyingGraphQLEntityType(outputType);
@@ -303,6 +303,20 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                 //      items do not have a matching subquery so the line of code below is
                 //      required to build a pagination metadata chain matching the json result
                 PaginationMetadata.Subqueries.Add(QueryBuilder.PAGINATION_FIELD_NAME, PaginationMetadata.MakeEmptyPaginationMetadata());
+            }
+
+            if(QueryBuilder.IsExecuteResultType(_underlyingFieldType))
+            {
+                if (queryField != null && queryField.SelectionSet != null)
+                {
+                    // override schemaField and queryField with the schemaField and queryField of ExecuteResult.ResultSet
+                    queryField = FindFieldNodeByName(queryField, QueryBuilder.EXECUTE_RESULT_FIELD_NAME);
+                }
+
+                schemaField = GetFieldFromUnderlyingEntityType(schemaField, QueryBuilder.EXECUTE_RESULT_FIELD_NAME);
+
+                outputType = schemaField.Type;
+                _underlyingFieldType = GraphQLUtils.UnderlyingGraphQLEntityType(outputType);
             }
 
             EntityName = _underlyingFieldType.Name;

--- a/src/Service/Resolvers/Sql Query Structures/SqlUpsertQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/SqlUpsertQueryStructure.cs
@@ -72,7 +72,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
               authorizationResolver: authorizationResolver,
               gQLFilterParser: gQLFilterParser,
               entityName: entityName,
-              operationType: Config.Operation.Update,
+              operationType: Config.Operation.Upsert,
               httpContext: httpContext)
         {
             UpdateOperations = new();

--- a/src/Service/Resolvers/Sql Query Structures/SqlUpsertQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/SqlUpsertQueryStructure.cs
@@ -92,7 +92,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             {
                 // This indicates that one or more fields referenced in the database policy are not a part of the insert statement.
                 throw new DataApiBuilderException(
-                    message: "One or more fields referenced by the database policy are not present in the request body.",
+                    message: "One or more fields referenced by the database policy are not present in the request.",
                     statusCode: HttpStatusCode.BadRequest,
                     subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
             }

--- a/src/Service/Resolvers/Sql Query Structures/SqlUpsertQueryStructure.cs
+++ b/src/Service/Resolvers/Sql Query Structures/SqlUpsertQueryStructure.cs
@@ -88,6 +88,15 @@ namespace Azure.DataApiBuilder.Service.Resolvers
             // Populates the UpsertQueryStructure with UPDATE and INSERT column:value metadata
             PopulateColumns(mutationParams, sourceDefinition, isIncrementalUpdate: incrementalUpdate);
 
+            if (FieldsReferencedInDbPolicyForCreateAction.Count > 0)
+            {
+                // This indicates that one or more fields referenced in the database policy are not a part of the insert statement.
+                throw new DataApiBuilderException(
+                    message: "One or more fields referenced by the database policy are not present in the request body.",
+                    statusCode: HttpStatusCode.BadRequest,
+                    subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
+            }
+
             if (UpdateOperations.Count == 0)
             {
                 throw new DataApiBuilderException(
@@ -195,6 +204,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         private void PopulateColumnsAndParams(string columnName)
         {
             InsertColumns.Add(columnName);
+            FieldsReferencedInDbPolicyForCreateAction.Remove(columnName);
             string paramName;
             paramName = ColumnToParam[columnName];
             Values.Add($"{paramName}");

--- a/src/Service/Resolvers/SqlMutationEngine.cs
+++ b/src/Service/Resolvers/SqlMutationEngine.cs
@@ -39,7 +39,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         private readonly IAuthorizationResolver _authorizationResolver;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly GQLFilterParser _gQLFilterParser;
-        public const string IS_FIRST_RESULT_SET = "IsFirstResultSet";
+        public const string IS_UPDATE_RESULT_SET = "IsUpdateResultSet";
 
         /// <summary>
         /// Constructor
@@ -301,7 +301,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                     Dictionary<string, object?> resultRow = dbResultSetRow.Columns;
 
                     bool isFirstResultSet = false;
-                    if (upsertOperationResult.ResultProperties.TryGetValue(IS_FIRST_RESULT_SET, out object? isFirstResultSetValue))
+                    if (upsertOperationResult.ResultProperties.TryGetValue(IS_UPDATE_RESULT_SET, out object? isFirstResultSetValue))
                     {
                         isFirstResultSet = Convert.ToBoolean(isFirstResultSetValue);
                     }

--- a/src/Service/Resolvers/SqlMutationEngine.cs
+++ b/src/Service/Resolvers/SqlMutationEngine.cs
@@ -300,15 +300,15 @@ namespace Azure.DataApiBuilder.Service.Resolvers
                 {
                     Dictionary<string, object?> resultRow = dbResultSetRow.Columns;
 
-                    bool isFirstResultSet = false;
-                    if (upsertOperationResult.ResultProperties.TryGetValue(IS_UPDATE_RESULT_SET, out object? isFirstResultSetValue))
+                    bool isUpdateResultSet = false;
+                    if (upsertOperationResult.ResultProperties.TryGetValue(IS_UPDATE_RESULT_SET, out object? isUpdateResultSetValue))
                     {
-                        isFirstResultSet = Convert.ToBoolean(isFirstResultSetValue);
+                        isUpdateResultSet = Convert.ToBoolean(isUpdateResultSetValue);
                     }
 
                     // For MsSql, MySql, if it's not the first result, the upsert resulted in an INSERT operation.
                     // Even if its first result, postgresql may still be an insert op here, if so, return CreatedResult
-                    if (!isFirstResultSet ||
+                    if (!isUpdateResultSet ||
                         (_sqlMetadataProvider.GetDatabaseType() is DatabaseType.postgresql &&
                         PostgresQueryBuilder.IsInsert(resultRow)))
                     {

--- a/src/Service/Services/MetadataProviders/MsSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/MsSqlMetadataProvider.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Data;
 using System.Net;
+using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Service.Configurations;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.Resolvers;
@@ -84,6 +86,26 @@ namespace Azure.DataApiBuilder.Service.Services
                     return typeof(Guid);
                 default:
                     throw new DataApiBuilderException(message: $"Tried to convert unsupported data type: {sqlType}",
+                        statusCode: HttpStatusCode.ServiceUnavailable,
+                        subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
+            }
+        }
+
+        /// <summary>
+        /// Takes a string version of an MS SQL parameter mode and returns its .NET common language runtime (CLR) counterpart.
+        /// </summary>
+        public override ParameterDirection ToParameterDirectionEnum(string parameterDirection)
+        {
+            switch (parameterDirection)
+            {
+                case "IN":
+                    return ParameterDirection.Input;
+                case "OUT":
+                    return ParameterDirection.Output;
+                case "INOUT":
+                    return ParameterDirection.InputOutput;
+                default:
+                    throw new DataApiBuilderException(message: $"Tried to convert unsupported parameter mode: {parameterDirection}",
                         statusCode: HttpStatusCode.ServiceUnavailable,
                         subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
             }

--- a/src/Service/Services/MetadataProviders/MySqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/MySqlMetadataProvider.cs
@@ -120,5 +120,14 @@ namespace Azure.DataApiBuilder.Service.Services
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Takes a string version of a MySql parameter mode and returns its .NET common language runtime (CLR) counterpart
+        /// TODO: For MySql stored procedure support, this needs to be implemented.
+        /// </summary>
+        public override ParameterDirection ToParameterDirectionEnum(string parameterDirection)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Service/Services/MetadataProviders/MySqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/MySqlMetadataProvider.cs
@@ -129,5 +129,14 @@ namespace Azure.DataApiBuilder.Service.Services
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Populates stored procedure parameter nullability.
+        /// TODO: MySQL doesn't seem to allow parameter defaults so not relevant for now.
+        /// </summary>
+        protected override Task PopulateParameterOptionalityForStoredProcedureAsync(string schemaName, string storedProcedureName, StoredProcedureDefinition sourceDefinition)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Service/Services/MetadataProviders/PostgreSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/PostgreSqlMetadataProvider.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Data;
 using System.Net;
+using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Service.Configurations;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.Resolvers;
@@ -70,6 +72,15 @@ namespace Azure.DataApiBuilder.Service.Services
         /// TODO: For PostgreSql stored procedure support, this needs to be implemented.
         /// </summary>
         public override Type SqlToCLRType(string sqlType)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Takes a string version of a PostgreSql parameter mode and returns its .NET common language runtime (CLR) counterpart
+        /// TODO: For PostgreSql stored procedure support, this needs to be implemented.
+        /// </summary>
+        public override ParameterDirection ToParameterDirectionEnum(string parameterDirection)
         {
             throw new NotImplementedException();
         }

--- a/src/Service/Services/MetadataProviders/PostgreSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/PostgreSqlMetadataProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using System.Net;
+using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Service.Configurations;
 using Azure.DataApiBuilder.Service.Exceptions;
@@ -81,6 +82,16 @@ namespace Azure.DataApiBuilder.Service.Services
         /// TODO: For PostgreSql stored procedure support, this needs to be implemented.
         /// </summary>
         public override ParameterDirection ToParameterDirectionEnum(string parameterDirection)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Populates stored procedure parameter nullability.
+        /// TODO: For PostgreSql stored procedure support, this needs to be implemented.
+        /// </summary>
+
+        protected override Task PopulateParameterOptionalityForStoredProcedureAsync(string schemaName, string storedProcedureName, StoredProcedureDefinition sourceDefinition)
         {
             throw new NotImplementedException();
         }

--- a/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -316,6 +316,7 @@ namespace Azure.DataApiBuilder.Service.Services
                     {
                         // row["DATA_TYPE"] has value type string so a direct cast to System.Type is not supported.
                         SystemType = SqlToCLRType((string)row["DATA_TYPE"]),
+                        Direction = ToParameterDirectionEnum((string)row["PARAMETER_MODE"]),
                     }
                 );
             }
@@ -351,6 +352,11 @@ namespace Azure.DataApiBuilder.Service.Services
         /// Takes a string version of a sql data type and returns its .NET common language runtime (CLR) counterpart
         /// </summary>
         public abstract Type SqlToCLRType(string sqlType);
+
+        /// <summary>
+        /// Takes a string version of a sql parameter mode and returns its .NET common language runtime (CLR) counterpart.
+        /// </summary>
+        public abstract ParameterDirection ToParameterDirectionEnum(string parameterDirection);
 
         /// <summary>
         /// Generates the map used to find a given entity based

--- a/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -820,6 +820,11 @@ namespace Azure.DataApiBuilder.Service.Services
                             GetSchemaName(entityName),
                             GetDatabaseObjectName(entityName),
                             GetStoredProcedureDefinition(entityName));
+
+                        await PopulateParameterOptionalityForStoredProcedureAsync(
+                            GetSchemaName(entityName),
+                            GetDatabaseObjectName(entityName),
+                            GetStoredProcedureDefinition(entityName));
                     }
                 }
                 else if (entitySourceType is SourceType.Table)
@@ -881,6 +886,11 @@ namespace Azure.DataApiBuilder.Service.Services
                 storedProcedureDefinition.Columns.TryAdd(resultFieldName, new(resultFieldType) { IsNullable = isResultFieldNullable });
             }
         }
+
+        protected abstract Task PopulateParameterOptionalityForStoredProcedureAsync(
+            string schemaName,
+            string storedProcedureName,
+            StoredProcedureDefinition sourceDefinition);
 
         /// <summary>
         /// Helper method to create params for the query.

--- a/src/Service/Services/RequestValidator.cs
+++ b/src/Service/Services/RequestValidator.cs
@@ -138,13 +138,11 @@ namespace Azure.DataApiBuilder.Service.Services
             HashSet<string> extraFields = new(spRequestCtx.ResolvedParameters.Keys);
             foreach ((string paramKey, ParameterDefinition paramDefinition) in storedProcedureDefinition.Parameters)
             {
-                // If parameter not specified in request OR config
+                // If parameter is not optional and is not specified in request OR config
                 if (!spRequestCtx.ResolvedParameters!.ContainsKey(paramKey)
+                    && !paramDefinition.IsOptional
                     && !paramDefinition.HasConfigDefault)
                 {
-                    // Ideally should check if a default is set in sql, but no easy way to do so - would have to parse procedure's object definition
-                    // See https://docs.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-parameters-transact-sql?view=sql-server-ver16#:~:text=cursor%2Dreference%20parameter.-,has_default_value,-bit
-                    // For SQL Server not populating this metadata for us; MySQL doesn't seem to allow parameter defaults so not relevant. 
                     missingFields.Add(paramKey);
                 }
                 else


### PR DESCRIPTION
## Why make this change?

- Adds support for OUTPUT Stored Procedure parameters from schema generation to data retrieval and return.
- Backwards compatible - if no OUTPUT parameters are defined in the Stored procedure, it will use the legacy `schema.graphql` schema format.
- Adds support for optional Stored Procedure parameters. They can now be excluded from the config if they are optional in the Stored Procedure.
- Fixes several other bugs I encountered.
- Closes #1429 

## What is this change?

Given the following Stored Procedure:

```tsql
CREATE PROCEDURE [dbo].[GetBooks]
    @page INT,
    @pageSize INT,
    @totalBooks INT OUTPUT,
    @totalPages INT OUTPUT
AS
BEGIN
    SET NOCOUNT ON;

    SELECT *
    FROM dbo.Books
    ORDER BY Id
    OFFSET @pageSize * (@page - 1) ROWS
    FETCH NEXT @pageSize ROWS ONLY;

    SELECT @totalBooks = COUNT(*)
    FROM dbo.Books;

    SET @totalPages = CEILING(CAST(@totalBooks AS FLOAT) / @pageSize);
END;
```

Which you can query as follows:

```tsql
DECLARE @totalBooks INT;
DECLARE @totalPages INT;

EXEC dbo.[GetBooks]
    @page = 1,
    @pageSize = 5,
    @totalBooks = @totalBooks OUTPUT,
    @totalPages = @totalPages OUTPUT;

SELECT @totalBooks AS "Total Books";
SELECT @totalPages AS "Total Pages";
```

Giving you results:

![DBResults](https://user-images.githubusercontent.com/578774/232576030-6c5dbd8f-9f79-4ef5-bf7e-64313888bd8a.png)

Running DAB will generate the following schema.graphql:

```graphql
schema {
  query: Query
}

enum OrderBy {
  ASC
  DESC
}

input DefaultValue {
  Byte: Byte
  Short: Short
  Int: Int
  Long: Long
  String: String
  Boolean: Boolean
  Single: Single
  Float: Float
  Decimal: Decimal
  DateTime: DateTime
  ByteArray: ByteArray
}

type GetBooks {
  id: Int!
  title: String!
  year: Int
  pages: Int
}

"Represents the results of the executeGetBooks stored procedure execution."
type ExecuteGetBooksResult {
  "The GetBooks result set from the stored procedure."
  resultSet: [GetBooks!]!
  "The totalBooks InputOutput parameter from the stored procedure."
  totalBooks: Int
  "The totalPages InputOutput parameter from the stored procedure."
  totalPages: Int
}

type Query {
  "Execute Stored-Procedure GetBooks and get results from the database"
  executeGetBooks(page: Int = 1 pageSize: Int = 5 totalBooks: Int = 0 totalPages: Int = 0): ExecuteGetBooksResult!
}

enum ApplyPolicy {
  BEFORE_RESOLVER
  AFTER_RESOLVER
}

"The `Byte` scalar type represents non-fractional whole numeric values. Byte can represent values between 0 and 255."
scalar Byte

"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
scalar Short

"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
scalar Long

"IEEE 754 32 bit float"
scalar Single

"The built-in `Decimal` scalar type."
scalar Decimal

"The `DateTime` scalar represents an ISO-8601 compliant date time type."
scalar DateTime

scalar ByteArray

"The `@oneOf` directive is used within the type system definition language\n to indicate:\n\n - an Input Object is a Oneof Input Object, or\n - an Object Type's Field is a Oneof Field."
directive @oneOf on INPUT_OBJECT

directive @authorize("The name of the authorization policy that determines access to the annotated resource." policy: String "Roles that are allowed to access the annotated resource." roles: [String!] "Defines when when the resolver shall be executed.By default the resolver is executed after the policy has determined that the current user is allowed to access the field." apply: ApplyPolicy! = BEFORE_RESOLVER) repeatable on SCHEMA | OBJECT | FIELD_DEFINITION

"A directive to indicate the type maps to a storable entity not a nested entity."
directive @model("Underlying name of the database entity." name: String) on OBJECT

"A directive to indicate the relationship between two tables"
directive @relationship("The name of the GraphQL type the relationship targets" target: String "The relationship cardinality" cardinality: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION

"A directive to indicate the primary key field of an item."
directive @primaryKey("The underlying database type." databaseType: String) on FIELD_DEFINITION

"The default value to be used when creating an item."
directive @defaultValue(value: DefaultValue) on FIELD_DEFINITION

"Indicates that a field is auto generated by the database."
directive @autoGenerated on FIELD_DEFINITION
```

This more closely follows the pagination-style results where rather than having a “Connected” Type with an “items” property, we instead have an “Execute<STORED_PROC_TYPE>Result” Type with a “resultSet” property, as well as one property per OUTPUT parameter. In the case above we have “totalBooks” and “totalPages” as those were the output parameters to our Stored Procedure. This makes more sense as these OUTPUT parameters are scalar results and not a part of a Stored Procedure’s Result Set.

This can now be queried as follows:

![PostmanResults](https://user-images.githubusercontent.com/578774/232576290-7f6adaa3-f602-47d3-b6ed-2b33732b3058.png)

Additionally, it is backwards-compatible. If we alter the procedure as below:

```tsql
ALTER PROCEDURE [dbo].[GetBooks]
    @page INT,
    @pageSize INT
    -- @totalBooks INT OUTPUT,
    -- @totalPages INT OUTPUT
AS
BEGIN
    SET NOCOUNT ON;
    DECLARE @totalBooks FLOAT;
    DECLARE @totalPages FLOAT;

    SELECT *
    FROM dbo.Books
    ORDER BY Id
    OFFSET @pageSize * (@page - 1) ROWS
    FETCH NEXT @pageSize ROWS ONLY;

    SELECT @totalBooks = COUNT(*)
    FROM dbo.Books;

    SET @totalPages = CEILING(CAST(@totalBooks AS FLOAT) / @pageSize);
END;
```

We can see queries still retrieve the books:

```tsql
-- DECLARE @totalBooks INT;
-- DECLARE @totalPages INT;

EXEC [dbo].[GetBooks]
    @page = 1,
    @pageSize = 5
    -- @totalBooks = @totalBooks OUTPUT,
    -- @totalPages = @totalPages OUTPUT;

-- SELECT @totalBooks AS "Total Books";
-- SELECT @totalPages AS "Total Pages";
```
![BackwardsCompatibleDBResults](https://user-images.githubusercontent.com/578774/232577281-8950af3e-5b76-420d-9c38-bc492cb33530.png)

If there are no output parameters defined in the procedure, I have DAB generate the following schema:

```graphql
schema {
  query: Query
}

enum OrderBy {
  ASC
  DESC
}

input DefaultValue {
  Byte: Byte
  Short: Short
  Int: Int
  Long: Long
  String: String
  Boolean: Boolean
  Single: Single
  Float: Float
  Decimal: Decimal
  DateTime: DateTime
  ByteArray: ByteArray
}

type GetBooks {
  id: Int!
  title: String!
  year: Int
  pages: Int
}

type Query {
  "Execute Stored-Procedure GetBooks and get results from the database"
  executeGetBooks(page: Int = 1 pageSize: Int = 5): [GetBooks!]!
}

enum ApplyPolicy {
  BEFORE_RESOLVER
  AFTER_RESOLVER
}

"The `Byte` scalar type represents non-fractional whole numeric values. Byte can represent values between 0 and 255."
scalar Byte

"The `Short` scalar type represents non-fractional signed whole 16-bit numeric values. Short can represent values between -(2^15) and 2^15 - 1."
scalar Short

"The `Long` scalar type represents non-fractional signed whole 64-bit numeric values. Long can represent values between -(2^63) and 2^63 - 1."
scalar Long

"IEEE 754 32 bit float"
scalar Single

"The built-in `Decimal` scalar type."
scalar Decimal

"The `DateTime` scalar represents an ISO-8601 compliant date time type."
scalar DateTime

scalar ByteArray

"The `@oneOf` directive is used within the type system definition language\n to indicate:\n\n - an Input Object is a Oneof Input Object, or\n - an Object Type's Field is a Oneof Field."
directive @oneOf on INPUT_OBJECT

directive @authorize("The name of the authorization policy that determines access to the annotated resource." policy: String "Roles that are allowed to access the annotated resource." roles: [String!] "Defines when when the resolver shall be executed.By default the resolver is executed after the policy has determined that the current user is allowed to access the field." apply: ApplyPolicy! = BEFORE_RESOLVER) repeatable on SCHEMA | OBJECT | FIELD_DEFINITION

"A directive to indicate the type maps to a storable entity not a nested entity."
directive @model("Underlying name of the database entity." name: String) on OBJECT

"A directive to indicate the relationship between two tables"
directive @relationship("The name of the GraphQL type the relationship targets" target: String "The relationship cardinality" cardinality: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION

"A directive to indicate the primary key field of an item."
directive @primaryKey("The underlying database type." databaseType: String) on FIELD_DEFINITION

"The default value to be used when creating an item."
directive @defaultValue(value: DefaultValue) on FIELD_DEFINITION

"Indicates that a field is auto generated by the database."
directive @autoGenerated on FIELD_DEFINITION
```

Which we can query as we did before introducing OUTPUT parameter directions:

![BackwardsCompatiblePostmanResults](https://user-images.githubusercontent.com/578774/232577631-a57afa91-8f0b-46cd-b42e-ba755b3b1ccc.png)