### PR TITLE
Hot Patch for March Release

### DIFF
--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -300,6 +300,23 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             Assert.AreEqual(HttpStatusCode.BadRequest, postResult.StatusCode);
         }
 
+        [TestMethod("Validates containing field permission in configuration returns a bad request."), TestCategory(TestCategory.COSMOSDBNOSQL)]
+        public async Task TestInvalidConfigurationWithFieldPermission()
+        {
+            TestServer server = new(Program.CreateWebHostFromInMemoryUpdateableConfBuilder(Array.Empty<string>()));
+            HttpClient httpClient = server.CreateClient();
+
+            ConfigurationPostParameters config = GetCosmosConfigurationParameters();
+            config = config with
+            {
+                Configuration = "{\"$schema\":\"dab.draft.schema.json\",\"data-source\":{\"database-type\":\"cosmosdb_nosql\",\"options\":{\"database\":\"graphqldb\",\"schema\":\"schema.gql\"}},\"entities\":{\"Planet\":{\"source\":\"graphqldb.planet\",\"graphql\":{\"type\":{\"singular\":\"Planet\",\"plural\":\"Planets\"}},\"permissions\":[{\"role\":\"anonymous\",\"actions\":[{\"action\":\"read\",\"fields\":{\"include\":[\"*\"],\"exclude\":[]}}]}]}}}"
+            };
+
+            HttpResponseMessage postResult =
+                await httpClient.PostAsync("/configuration", JsonContent.Create(config));
+            Assert.AreEqual(HttpStatusCode.BadRequest, postResult.StatusCode);
+        }
+
         [TestMethod("Validates a failure in one of the config updated handlers returns a bad request."), TestCategory(TestCategory.COSMOSDBNOSQL)]
         public async Task TestSettingFailureConfigurations()
         {

--- a/src/Service.Tests/CosmosTests/TestBase.cs
+++ b/src/Service.Tests/CosmosTests/TestBase.cs
@@ -79,7 +79,7 @@ type Moon @model(name:""Moon"") @authorize(policy: ""Crater"") {
                 It.IsAny<string>(),
                 It.IsAny<Config.Operation>(),
                 It.IsAny<IEnumerable<string>>()
-                )).Returns(true);
+                )).Returns(false);
 
             _application = new WebApplicationFactory<Startup>()
                 .WithWebHostBuilder(builder =>

--- a/src/Service/Models/GraphQLFilterParsers.cs
+++ b/src/Service/Models/GraphQLFilterParsers.cs
@@ -141,11 +141,12 @@ namespace Azure.DataApiBuilder.Service.Models
                         relationshipField = false;
                     }
 
-                    // Only perform field (column) authorization when the field is not a relationship field.
+                    // Only perform field (column) authorization when the field is not a relationship field and when the database type is not Cosmos DB.
+                    // Currently Cosmos DB doesn't support field level authorization.
                     // Due to the recursive behavior of SqlExistsQueryStructure compilation, the column authorization
                     // check only occurs when access to the column's owner entity is confirmed.
-                    if (!relationshipField)
-                    {
+                    if (!relationshipField && _metadataProvider.GetDatabaseType() is not DatabaseType.cosmosdb_nosql)
+                        {
                         string targetEntity = queryStructure.EntityName;
 
                         bool columnAccessPermitted = queryStructure.AuthorizationResolver.AreColumnsAllowedForOperation(

--- a/src/Service/Models/GraphQLFilterParsers.cs
+++ b/src/Service/Models/GraphQLFilterParsers.cs
@@ -146,7 +146,7 @@ namespace Azure.DataApiBuilder.Service.Models
                     // Due to the recursive behavior of SqlExistsQueryStructure compilation, the column authorization
                     // check only occurs when access to the column's owner entity is confirmed.
                     if (!relationshipField && _metadataProvider.GetDatabaseType() is not DatabaseType.cosmosdb_nosql)
-                        {
+                    {
                         string targetEntity = queryStructure.EntityName;
 
                         bool columnAccessPermitted = queryStructure.AuthorizationResolver.AreColumnsAllowedForOperation(

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Service.Configurations;
 using Azure.DataApiBuilder.Service.Exceptions;
@@ -53,7 +55,49 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
                     subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
             }
 
+            foreach(Entity entity in _runtimeConfig.Entities.Values)
+            {
+                CheckFieldPermissionsForEntity(entity);
+            }
+
             _cosmosDb = cosmosDb;
+        }
+
+        public void CheckFieldPermissionsForEntity(Entity entity)
+        {
+            foreach (PermissionSetting permission in entity.Permissions)
+            {
+                string role = permission.Role;
+                RoleMetadata roleToOperation = new();
+                object[] Operations = permission.Operations;
+                foreach (JsonElement operationElement in Operations)
+                {
+                    if (operationElement.ValueKind is JsonValueKind.String)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        // If not a string, the operationObj is expected to be an object that can be deserialized into PermissionOperation
+                        // object.
+                        if (RuntimeConfig.TryGetDeserializedJsonString(operationElement.ToString(), out PermissionOperation? operationObj, null!)
+                            && operationObj is not null)
+                        {
+                            if (operationObj.Fields is null)
+                            {
+                                continue;
+                            }
+                            else
+                            {
+                                throw new DataApiBuilderException(
+                                  message: "Invalid runtime configuration, CosmosDB_NoSql currently doesn't support field level authorization.",
+                                  statusCode: System.Net.HttpStatusCode.BadRequest,
+                                  subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         /// <inheritdoc />

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -81,19 +81,12 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
                         // If not a string, the operationObj is expected to be an object that can be deserialized into PermissionOperation
                         // object.
                         if (RuntimeConfig.TryGetDeserializedJsonString(operationElement.ToString(), out PermissionOperation? operationObj, null!)
-                            && operationObj is not null)
+                            && operationObj is not null && operationObj.Fields is not null)
                         {
-                            if (operationObj.Fields is null)
-                            {
-                                continue;
-                            }
-                            else
-                            {
-                                throw new DataApiBuilderException(
-                                  message: "Invalid runtime configuration, CosmosDB_NoSql currently doesn't support field level authorization.",
-                                  statusCode: System.Net.HttpStatusCode.BadRequest,
-                                  subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
-                            }
+                            throw new DataApiBuilderException(
+                                message: "Invalid runtime configuration, CosmosDB_NoSql currently doesn't support field level authorization.",
+                                statusCode: System.Net.HttpStatusCode.BadRequest,
+                                subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
                         }
                     }
                 }

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -55,7 +55,7 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
                     subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
             }
 
-            foreach(Entity entity in _runtimeConfig.Entities.Values)
+            foreach (Entity entity in _runtimeConfig.Entities.Values)
             {
                 CheckFieldPermissionsForEntity(entity);
             }

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -170,7 +170,8 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
 
         public bool TryGetExposedColumnName(string entityName, string field, out string? name)
         {
-            throw new NotImplementedException();
+            name = field;
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
## Why make this change?

- Closes this issue referenced here https://github.com/Azure/data-api-builder/discussions/1423. Additional issue related to this change https://github.com/Azure/data-api-builder/issues/597
  - Cosmos DB currently doesn't support field level authorization, it's expected that we are not honoring ```operationToColumnMap.Excluded``` and ```operationToColumnMap.Included``` and by introducing field level auth check into the ```GQLFilterParser```  [recent update](https://github.com/Azure/data-api-builder/pull/1407) results the issue that we are seeing.
  - Cosmos have tests to exercise the filter parser, the reason the tests didn't catch this issue is because the changes here [added lines](https://github.com/Azure/data-api-builder/blob/1431ffc8c11bcd80f62d51c0c0fd6f15383b147a/src/Service.Tests/CosmosTests/TestBase.cs#L77-L82) that's added in this PR [recent update](https://github.com/Azure/data-api-builder/pull/1407), this mocks up the field auth check to always return true for all Cosmos filter tests. 
  - ```CosmosMetadataProvider``` does not translate a field wild card (*) or list of hardcoded include columns to the list of AllowedFields in the engine's ```AuthorizationResolver``` currently, but we can add a pass through to the ```TryGetExposedColumnName``` as suggested so it doesn't throw a ```NotImplementedException``` when user accidently passed in the fields settings in the Cosmos configuration file.

## What is this change?

- Address this by skipping the field auth check inside of the GQLFilterParser when the database type is Cosmos

## How was this tested?

- [ x ] Integration Tests
- [ x ] Unit Tests

## Sample Request(s)

```json
query planets {
  planets (filter: {id: {eq: 1000}}) {
    items {
      id
    }
  }
}
```
