### PR TITLE
Users/tarazou/merge hot fix

### DIFF
--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -300,6 +300,23 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             Assert.AreEqual(HttpStatusCode.BadRequest, postResult.StatusCode);
         }
 
+        [TestMethod("Validates containing field permission in configuration returns a bad request."), TestCategory(TestCategory.COSMOSDBNOSQL)]
+        public async Task TestInvalidConfigurationWithFieldPermission()
+        {
+            TestServer server = new(Program.CreateWebHostFromInMemoryUpdateableConfBuilder(Array.Empty<string>()));
+            HttpClient httpClient = server.CreateClient();
+
+            ConfigurationPostParameters config = GetCosmosConfigurationParameters();
+            config = config with
+            {
+                Configuration = "{\"$schema\":\"dab.draft.schema.json\",\"data-source\":{\"database-type\":\"cosmosdb_nosql\",\"options\":{\"database\":\"graphqldb\",\"schema\":\"schema.gql\"}},\"entities\":{\"Planet\":{\"source\":\"graphqldb.planet\",\"graphql\":{\"type\":{\"singular\":\"Planet\",\"plural\":\"Planets\"}},\"permissions\":[{\"role\":\"anonymous\",\"actions\":[{\"action\":\"read\",\"fields\":{\"include\":[\"*\"],\"exclude\":[]}}]}]}}}"
+            };
+
+            HttpResponseMessage postResult =
+                await httpClient.PostAsync("/configuration", JsonContent.Create(config));
+            Assert.AreEqual(HttpStatusCode.BadRequest, postResult.StatusCode);
+        }
+
         [TestMethod("Validates a failure in one of the config updated handlers returns a bad request."), TestCategory(TestCategory.COSMOSDBNOSQL)]
         public async Task TestSettingFailureConfigurations()
         {

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Service.Configurations;
 using Azure.DataApiBuilder.Service.Exceptions;
@@ -53,7 +55,49 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
                     subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
             }
 
+            foreach(Entity entity in _runtimeConfig.Entities.Values)
+            {
+                CheckFieldPermissionsForEntity(entity);
+            }
+
             _cosmosDb = cosmosDb;
+        }
+
+        public void CheckFieldPermissionsForEntity(Entity entity)
+        {
+            foreach (PermissionSetting permission in entity.Permissions)
+            {
+                string role = permission.Role;
+                RoleMetadata roleToOperation = new();
+                object[] Operations = permission.Operations;
+                foreach (JsonElement operationElement in Operations)
+                {
+                    if (operationElement.ValueKind is JsonValueKind.String)
+                    {
+                        continue;
+                    }
+                    else
+                    {
+                        // If not a string, the operationObj is expected to be an object that can be deserialized into PermissionOperation
+                        // object.
+                        if (RuntimeConfig.TryGetDeserializedJsonString(operationElement.ToString(), out PermissionOperation? operationObj, null!)
+                            && operationObj is not null)
+                        {
+                            if (operationObj.Fields is null)
+                            {
+                                continue;
+                            }
+                            else
+                            {
+                                throw new DataApiBuilderException(
+                                  message: "Invalid runtime configuration, CosmosDB_NoSql currently doesn't support field level authorization.",
+                                  statusCode: System.Net.HttpStatusCode.BadRequest,
+                                  subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         /// <inheritdoc />

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -81,19 +81,12 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
                         // If not a string, the operationObj is expected to be an object that can be deserialized into PermissionOperation
                         // object.
                         if (RuntimeConfig.TryGetDeserializedJsonString(operationElement.ToString(), out PermissionOperation? operationObj, null!)
-                            && operationObj is not null)
+                            && operationObj is not null && operationObj.Fields is not null)
                         {
-                            if (operationObj.Fields is null)
-                            {
-                                continue;
-                            }
-                            else
-                            {
-                                throw new DataApiBuilderException(
-                                  message: "Invalid runtime configuration, CosmosDB_NoSql currently doesn't support field level authorization.",
-                                  statusCode: System.Net.HttpStatusCode.BadRequest,
-                                  subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
-                            }
+                            throw new DataApiBuilderException(
+                                message: "Invalid runtime configuration, CosmosDB_NoSql currently doesn't support field level authorization.",
+                                statusCode: System.Net.HttpStatusCode.BadRequest,
+                                subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
                         }
                     }
                 }

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -55,7 +55,7 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
                     subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
             }
 
-            foreach(Entity entity in _runtimeConfig.Entities.Values)
+            foreach (Entity entity in _runtimeConfig.Entities.Values)
             {
                 CheckFieldPermissionsForEntity(entity);
             }


### PR DESCRIPTION
## Why make this change?

- Closes this issue referenced here https://github.com/Azure/data-api-builder/discussions/1423. Additional issue related to this change https://github.com/Azure/data-api-builder/issues/597
- This is the change that included in the March hotfix but doesn't have in main.

## What is this change?

- Add check for Cosmos to fail if field permission gets passed in the config.

## How was this tested?

- [x] Integration Tests
- [x] Unit Tests
