### PR TITLE
Fix CLI test warnings

### DIFF
--- a/src/Cli.Tests/AddEntityTests.cs
+++ b/src/Cli.Tests/AddEntityTests.cs
@@ -12,8 +12,8 @@ namespace Cli.Tests
         /// <summary>
         /// Setup the logger for CLI
         /// </summary>
-        [TestInitialize]
-        public void SetupLoggerForCLI()
+        [ClassInitialize]
+        public static void SetupLoggerForCLI(TestContext context)
         {
             TestHelper.SetupTestLoggerForCLI();
         }

--- a/src/Cli.Tests/EndToEndTests.cs
+++ b/src/Cli.Tests/EndToEndTests.cs
@@ -13,7 +13,7 @@ public class EndToEndTests
     /// Setup the logger and test file for CLI
     /// </summary>
     [ClassInitialize]
-    public static void Setup()
+    public static void Setup(TestContext context)
     {
         if (!File.Exists(TEST_SCHEMA_FILE))
         {

--- a/src/Cli.Tests/InitTests.cs
+++ b/src/Cli.Tests/InitTests.cs
@@ -15,7 +15,7 @@ namespace Cli.Tests
         /// Setup the logger and test file for CLI
         /// </summary>
         [ClassInitialize]
-        public static void Setup()
+        public static void Setup(TestContext context)
         {
             if (!File.Exists(TEST_SCHEMA_FILE))
             {

--- a/src/Cli.Tests/UpdateEntityTests.cs
+++ b/src/Cli.Tests/UpdateEntityTests.cs
@@ -12,8 +12,8 @@ namespace Cli.Tests
         /// <summary>
         /// Setup the logger for CLI
         /// </summary>
-        [TestInitialize]
-        public void SetupLoggerForCLI()
+        [ClassInitialize]
+        public static void SetupLoggerForCLI(TestContext context)
         {
             TestHelper.SetupTestLoggerForCLI();
         }

--- a/src/Cli.Tests/UtilsTests.cs
+++ b/src/Cli.Tests/UtilsTests.cs
@@ -12,8 +12,8 @@ namespace Cli.Tests
         /// <summary>
         /// Setup the logger for CLI
         /// </summary>
-        [TestInitialize]
-        public void SetupLoggerForCLI()
+        [ClassInitialize]
+        public static void SetupLoggerForCLI(TestContext context)
         {
             Mock<ILogger<Utils>> utilsLogger = new();
             Utils.SetCliUtilsLogger(utilsLogger.Object);


### PR DESCRIPTION
## Why make this change?

- Some unit Tests were complaining about wrong Signature of the Class Initialization Test Setup method, due to which they were not getting discovered.

## What is this change?

- When declaring ClassInitialize attribute on a method, the method has to be static, public, void and should take a single parameter of type TestContext.
- I added a parameter of type TestContext to fix.
- Performance Improvement by using ClassInitialize than TestInitialize.

## How was this tested?

- [x] Passing existing Unit Tests
- [x] No warnings 

