### PR TITLE
Add support for Cosmos field level auth

### DIFF
--- a/src/Service.Tests/CosmosTests/CosmosTestHelper.cs
+++ b/src/Service.Tests/CosmosTests/CosmosTestHelper.cs
@@ -58,6 +58,11 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
                     name = "first moon",
                     details = "12 Craters"
                 },
+                earth = new
+                {
+                    id = id,
+                    name = "blue earth"
+                },
                 tags = new[] { "tag1", "tag2" }
             };
         }

--- a/src/Service.Tests/CosmosTests/MutationTests.cs
+++ b/src/Service.Tests/CosmosTests/MutationTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.Resolvers;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,6 +42,7 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
             cosmosClient.GetDatabase(DATABASE_NAME).CreateContainerIfNotExistsAsync(_containerName, "/id").Wait();
             CreateItems(DATABASE_NAME, _containerName, 10);
             OverrideEntityContainer("Planet", _containerName);
+            OverrideEntityContainer("Earth", _containerName);
         }
 
         [TestMethod]
@@ -283,7 +283,7 @@ mutation {{
 
             // Validate the result contains the GraphQL authorization error code.
             string errorMessage = response.ToString();
-            Assert.IsTrue(errorMessage.Contains(DataApiBuilderException.GRAPHQL_FILTER_FIELD_AUTHZ_FAILURE));
+            Assert.IsTrue(errorMessage.Contains("Unauthorized due to one or more fields in this mutation."));
         }
 
         /// <summary>

--- a/src/Service.Tests/CosmosTests/TestBase.cs
+++ b/src/Service.Tests/CosmosTests/TestBase.cs
@@ -10,13 +10,16 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config;
+using Azure.DataApiBuilder.Service.Authorization;
 using Azure.DataApiBuilder.Service.Configurations;
 using Azure.DataApiBuilder.Service.Resolvers;
-using Azure.DataApiBuilder.Service.Tests.GraphQLBuilder.Helpers;
+using Azure.DataApiBuilder.Service.Services;
+using Azure.DataApiBuilder.Service.Services.MetadataProviders;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -42,6 +45,7 @@ type Planet @model(name:""Planet"") {
     character: Character,
     age : Int,
     dimension : String,
+    earth: Earth,
     stars: [Star],
     moons: [Moon],
     tags: [String!]
@@ -56,6 +60,11 @@ type Moon @model(name:""Moon"") @authorize(policy: ""Crater"") {
     id : ID,
     name : String,
     details : String
+}
+
+type Earth @model(name:""Earth"") {
+    id : ID,
+    name : String
 }";
 
         private static string[] _planets = { "Earth", "Mars", "Jupiter", "Tatooine", "Endor", "Dagobah", "Hoth", "Bespin", "Spec%ial" };
@@ -71,15 +80,10 @@ type Moon @model(name:""Moon"") @authorize(policy: ""Crater"") {
                 { @"../schema.gql", new MockFileData(GRAPHQL_SCHEMA) }
             });
 
-            //create mock authorization resolver where mock entityPermissionsMap is created for Planet and Character.
-            Mock<IAuthorizationResolver> authorizationResolverCosmos = new();
-            authorizationResolverCosmos.Setup(x => x.EntityPermissionsMap).Returns(GetEntityPermissionsMap(new string[] { "Character", "Planet", "StarAlias", "Moon" }));
-            authorizationResolverCosmos.Setup(x => x.AreColumnsAllowedForOperation(
-                It.IsAny<string>(),
-                It.IsAny<string>(),
-                It.IsAny<Config.Operation>(),
-                It.IsAny<IEnumerable<string>>()
-                )).Returns(false);
+            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GetRuntimeConfigProvider(CosmosTestHelper.ConfigPath);
+            ISqlMetadataProvider cosmosSqlMetadataProvider = new CosmosSqlMetadataProvider(runtimeConfigProvider, fileSystem);
+            Mock<ILogger<AuthorizationResolver>> authorizationResolverLogger = new();
+            IAuthorizationResolver authorizationResolverCosmos = new AuthorizationResolver(runtimeConfigProvider, cosmosSqlMetadataProvider, authorizationResolverLogger.Object);
 
             _application = new WebApplicationFactory<Startup>()
                 .WithWebHostBuilder(builder =>
@@ -87,12 +91,10 @@ type Moon @model(name:""Moon"") @authorize(policy: ""Crater"") {
                     _ = builder.ConfigureTestServices(services =>
                     {
                         services.AddSingleton<IFileSystem>(fileSystem);
-                        services.AddSingleton(TestHelper.GetRuntimeConfigProvider(CosmosTestHelper.ConfigPath));
-                        services.AddSingleton(authorizationResolverCosmos.Object);
+                        services.AddSingleton(runtimeConfigProvider);
+                        services.AddSingleton(authorizationResolverCosmos);
                     });
                 });
-
-            RuntimeConfigProvider configProvider = _application.Services.GetService<RuntimeConfigProvider>();
 
             _client = _application.CreateClient();
         }
@@ -170,15 +172,5 @@ type Moon @model(name:""Moon"") @authorize(policy: ""Crater"") {
 
             return JsonDocument.Parse(jarray.ToString().Trim());
         }
-
-        private static Dictionary<string, EntityMetadata> GetEntityPermissionsMap(string[] entities)
-        {
-            return GraphQLTestHelpers.CreateStubEntityPermissionsMap(
-                    entityNames: entities,
-                    operations: new Config.Operation[] { Config.Operation.Create, Config.Operation.Read, Config.Operation.Update, Config.Operation.Delete },
-                    roles: new string[] { "anonymous", "authenticated" }
-                );
-        }
-
     }
 }

--- a/src/Service.Tests/dab-config.CosmosDb_NoSql.json
+++ b/src/Service.Tests/dab-config.CosmosDb_NoSql.json
@@ -66,6 +66,15 @@
       "source": "graphqldb.character",
       "permissions": [
         {
+          "role": "anonymous",
+          "actions": [
+            "create",
+            "read",
+            "update",
+            "delete"
+          ]
+        },
+        {
           "role": "authenticated",
           "actions": [
             "create",
@@ -133,6 +142,63 @@
           ]
         }
       ]
+    },
+    "Earth": {
+      "source": "graphqldb.earth",
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": {
+                "include": [
+                  "id"
+                ],
+                "exclude": [
+                  "name"
+                ]
+              }
+            },
+            {
+              "action": "read",
+              "fields": {
+                "include": [
+                  "id"
+                ],
+                "exclude": [
+                  "name"
+      ]
+              }
+            },
+            "update",
+            "delete"
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            "create",
+            {
+              "action": "read",
+              "fields": {
+                "include": [
+                  "*"
+                ],
+                "exclude": []
+              }
+            },
+            "update",
+            "delete"
+          ]
+    }
+      ],
+      "graphql": {
+        "type": {
+          "singular": "Earth",
+          "plural": "Earths"
+        }
+      }
     }
   }
 }

--- a/src/Service/Authorization/AuthorizationResolver.cs
+++ b/src/Service/Authorization/AuthorizationResolver.cs
@@ -687,7 +687,7 @@ namespace Azure.DataApiBuilder.Service.Authorization
         {
             if (_metadataProvider.GetDatabaseType() is DatabaseType.cosmosdb_nosql)
             {
-                return _metadataProvider.GetSchemaGraphQLFieldsForEntityName(entityName);
+                return _metadataProvider.GetSchemaGraphQLFieldNamesForEntityName(entityName);
             }
 
             // Table definition is null on stored procedure entities

--- a/src/Service/Authorization/AuthorizationResolver.cs
+++ b/src/Service/Authorization/AuthorizationResolver.cs
@@ -687,7 +687,7 @@ namespace Azure.DataApiBuilder.Service.Authorization
         {
             if (_metadataProvider.GetDatabaseType() is DatabaseType.cosmosdb_nosql)
             {
-                return new List<string>();
+                return _metadataProvider.GetSchemaGraphQLFieldsForEntityName(entityName);
             }
 
             // Table definition is null on stored procedure entities

--- a/src/Service/Models/GraphQLFilterParsers.cs
+++ b/src/Service/Models/GraphQLFilterParsers.cs
@@ -141,11 +141,10 @@ namespace Azure.DataApiBuilder.Service.Models
                         relationshipField = false;
                     }
 
-                    // Only perform field (column) authorization when the field is not a relationship field and when the database type is not Cosmos DB.
-                    // Currently Cosmos DB doesn't support field level authorization.
+                    // Only perform field (column) authorization when the field is not a relationship field.
                     // Due to the recursive behavior of SqlExistsQueryStructure compilation, the column authorization
                     // check only occurs when access to the column's owner entity is confirmed.
-                    if (!relationshipField && _metadataProvider.GetDatabaseType() is not DatabaseType.cosmosdb_nosql)
+                    if (!relationshipField)
                     {
                         string targetEntity = queryStructure.EntityName;
 

--- a/src/Service/Resolvers/BaseQueryStructure.cs
+++ b/src/Service/Resolvers/BaseQueryStructure.cs
@@ -18,7 +18,7 @@ namespace Azure.DataApiBuilder.Service.Resolvers
         /// <summary>
         /// The Entity name associated with this query as appears in the config file.
         /// </summary>
-        public string EntityName { get; protected set; }
+        public string EntityName { get; set; }
 
         /// <summary>
         /// The alias of the entity as used in the generated query.

--- a/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -5,14 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
-using System.Text.Json;
+using System.Linq;
 using System.Threading.Tasks;
-using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Service.Configurations;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.Parsers;
 using Azure.DataApiBuilder.Service.Resolvers;
+using HotChocolate.Language;
 
 namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
 {
@@ -25,6 +25,7 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
         private readonly RuntimeConfig _runtimeConfig;
         private Dictionary<string, string> _partitionKeyPaths = new();
         private Dictionary<string, string> _graphQLSingularTypeToEntityNameMap = new();
+        private Dictionary<string, List<string>> _graphQLTypeToFieldsMap = new();
         private readonly RuntimeConfigProvider _runtimeConfigProvider;
 
         /// <inheritdoc />
@@ -44,7 +45,7 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
             _entities = _runtimeConfig.Entities;
             _databaseType = _runtimeConfig.DatabaseType;
             _graphQLSingularTypeToEntityNameMap = _runtimeConfig.GraphQLSingularTypeToEntityNameMap;
-
+            
             CosmosDbNoSqlOptions? cosmosDb = _runtimeConfig.DataSource.CosmosDbNoSql;
 
             if (cosmosDb is null)
@@ -55,42 +56,8 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
                     subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
             }
 
-            foreach (Entity entity in _runtimeConfig.Entities.Values)
-            {
-                CheckFieldPermissionsForEntity(entity);
-            }
-
             _cosmosDb = cosmosDb;
-        }
-
-        public void CheckFieldPermissionsForEntity(Entity entity)
-        {
-            foreach (PermissionSetting permission in entity.Permissions)
-            {
-                string role = permission.Role;
-                RoleMetadata roleToOperation = new();
-                object[] Operations = permission.Operations;
-                foreach (JsonElement operationElement in Operations)
-                {
-                    if (operationElement.ValueKind is JsonValueKind.String)
-                    {
-                        continue;
-                    }
-                    else
-                    {
-                        // If not a string, the operationObj is expected to be an object that can be deserialized into PermissionOperation
-                        // object.
-                        if (RuntimeConfig.TryGetDeserializedJsonString(operationElement.ToString(), out PermissionOperation? operationObj, null!)
-                            && operationObj is not null && operationObj.Fields is not null)
-                        {
-                            throw new DataApiBuilderException(
-                                message: "Invalid runtime configuration, CosmosDB_NoSql currently doesn't support field level authorization.",
-                                statusCode: System.Net.HttpStatusCode.BadRequest,
-                                subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
-                        }
-                    }
-                }
-            }
+            ParseSchemaGraphQLFieldsForGraphQLType();
         }
 
         /// <inheritdoc />
@@ -181,6 +148,41 @@ namespace Azure.DataApiBuilder.Service.Services.MetadataProviders
             }
 
             return _cosmosDb.GraphQLSchema;
+        }
+
+        private void ParseSchemaGraphQLFieldsForGraphQLType()
+        {
+            string graphqlSchema = GraphQLSchema();
+            DocumentNode root = Utf8GraphQLParser.Parse(graphqlSchema);
+
+            IEnumerable<ObjectTypeDefinitionNode> objectNodes = root.Definitions.Where(d => d is ObjectTypeDefinitionNode).Cast<ObjectTypeDefinitionNode>();
+            foreach (ObjectTypeDefinitionNode node in objectNodes)
+            {
+                string typeName = node.Name.Value;
+                _graphQLTypeToFieldsMap.TryAdd(typeName, new List<string>());
+                foreach (FieldDefinitionNode field in node.Fields)
+                {
+                    string fieldName = field.Name.Value;
+                    _graphQLTypeToFieldsMap[typeName].Add(fieldName);
+                }
+            }
+        }
+
+        public List<string> GetSchemaGraphQLFieldsForEntityName(string entityName)
+        {
+            List<string>? fields;
+            // Check if entity name is using alias name, if so, fetch graph type name with the alias name
+            foreach (string typeName in _graphQLSingularTypeToEntityNameMap.Keys) {
+                if (_graphQLSingularTypeToEntityNameMap[typeName] == entityName
+                    && _graphQLTypeToFieldsMap.TryGetValue(typeName, out fields))
+                {
+                    return fields is null ? new List<string>() : fields;
+                }
+            }
+
+            // Get all the fields for a graph type
+            _graphQLTypeToFieldsMap.TryGetValue(entityName, out fields);
+            return fields is null ? new List<string>() : fields;
         }
 
         public ODataParser GetODataParser()

--- a/src/Service/Services/MetadataProviders/ISqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/ISqlMetadataProvider.cs
@@ -39,6 +39,11 @@ namespace Azure.DataApiBuilder.Service.Services
         (string, string) ParseSchemaAndDbTableName(string source);
 
         /// <summary>
+        /// Obtains the underlying all column names for each entity name.
+        /// </summary>
+        List<string> GetSchemaGraphQLFieldsForEntityName(string entityName);
+
+        /// <summary>
         /// Obtains the underlying SourceDefinition for the given entity name.
         /// </summary>
         SourceDefinition GetSourceDefinition(string entityName);

--- a/src/Service/Services/MetadataProviders/ISqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/ISqlMetadataProvider.cs
@@ -41,7 +41,12 @@ namespace Azure.DataApiBuilder.Service.Services
         /// <summary>
         /// Obtains the underlying all column names for each entity name.
         /// </summary>
-        List<string> GetSchemaGraphQLFieldsForEntityName(string entityName);
+        List<string> GetSchemaGraphQLFieldNamesForEntityName(string entityName);
+
+        /// <summary>
+        /// Obtains the underlying column type for an entity field.
+        /// </summary>
+        string? GetSchemaGraphQLFieldTypeByFieldName(string graphQLType, string fieldName);
 
         /// <summary>
         /// Obtains the underlying SourceDefinition for the given entity name.

--- a/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -788,6 +788,10 @@ namespace Azure.DataApiBuilder.Service.Services
             return (schemaName, dbTableName);
         }
 
+        /// <inheritdoc />
+        public List<string> GetSchemaGraphQLFieldsForEntityName(string entityName)
+            => throw new NotImplementedException();
+
         /// <summary>
         /// Enrich the entities in the runtime config with the
         /// object definition information needed by the runtime to serve requests.

--- a/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Service/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -789,7 +789,11 @@ namespace Azure.DataApiBuilder.Service.Services
         }
 
         /// <inheritdoc />
-        public List<string> GetSchemaGraphQLFieldsForEntityName(string entityName)
+        public List<string> GetSchemaGraphQLFieldNamesForEntityName(string entityName)
+            => throw new NotImplementedException();
+
+        /// <inheritdoc />
+        public string? GetSchemaGraphQLFieldTypeByFieldName(string graphQLType, string fieldName)
             => throw new NotImplementedException();
 
         /// <summary>


### PR DESCRIPTION
## Why make this change?

- Closes #1434, related discussion #1423 .
  - Changes to add support for Cosmos to check field level auth for query filter and query nested filter.
  - Changes to add support for Cosmos to check field level auth for mutation operation.
  - Note: current mutation field auth support only check one level down, will have a follow up PR to check nested field auth for mutations.

## What is this change?

- Enable ```GraphQLFilterParser``` for Cosmos. 
- Resolve ```WILDCARD``` and parse all the columns from schema.gql
- Parse ```Included``` and ```Excluded``` columns from runtime config by injecting``` AuthorizationResolver``` into the ```CosmosMustationEngine``` to make a call to check the columns. 

## How was this tested?

- [x] Integration Tests
- [x] Unit Tests
