### PR TITLE
Fix merge config file not available issue

### DIFF
--- a/src/Cli.Tests/UtilsTests.cs
+++ b/src/Cli.Tests/UtilsTests.cs
@@ -239,7 +239,7 @@ namespace Cli.Tests
         /// 1. Environment value is set.
         /// 2. Both Base and envBased config file is present.
         /// In all other cases, the TryMergeConfigsIfAvailable method should return false
-        /// and out string for the mergedConfigFile should be empty.
+        /// and out param for the mergedConfigFile should be null.
         /// </summary>
         [DataTestMethod]
         [DataRow("", false, false, null, false, DisplayName = "If environment value is not set, merged config file is not generated.")]

--- a/src/Cli.Tests/UtilsTests.cs
+++ b/src/Cli.Tests/UtilsTests.cs
@@ -222,7 +222,7 @@ namespace Cli.Tests
             Environment.SetEnvironmentVariable(RUNTIME_ENVIRONMENT_VAR_NAME, "Test");
             File.WriteAllText("dab-config.json", BASE_CONFIG);
             File.WriteAllText("dab-config.Test.json", ENV_BASED_CONFIG);
-            if (TryMergeConfigsIfAvailable(out string mergedConfig))
+            if (TryMergeConfigsIfAvailable(out string? mergedConfig))
             {
                 Assert.AreEqual(mergedConfig, "dab-config.Test.merged.json");
                 Assert.IsTrue(File.Exists(mergedConfig));
@@ -242,21 +242,26 @@ namespace Cli.Tests
         /// and out string for the mergedConfigFile should be empty.
         /// </summary>
         [DataTestMethod]
-        [DataRow("", false, false, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]
-        [DataRow("", false, true, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]
-        [DataRow("", true, false, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]
-        [DataRow("", true, true, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]
-        [DataRow("Test", false, false, "", false, DisplayName = "Environment value set but base config not available, merged config file is not generated.")]
-        [DataRow("Test", false, true, "", false, DisplayName = "Environment value set but base config not available, merged config file is not generated.")]
-        [DataRow("Test", true, false, "", false, DisplayName = "Environment value set but env based config not available, merged config file is not generated.")]
+        [DataRow("", false, false, null, false, DisplayName = "If environment value is not set, merged config file is not generated.")]
+        [DataRow("", false, true, null, false, DisplayName = "If environment value is not set, merged config file is not generated.")]
+        [DataRow("", true, false, null, false, DisplayName = "If environment value is not set, merged config file is not generated.")]
+        [DataRow("", true, true, null, false, DisplayName = "If environment value is not set, merged config file is not generated.")]
+        [DataRow(null, false, false, null, false, DisplayName = "If environment variable is removed, merged config file is not generated.")]
+        [DataRow(null, false, true, null, false, DisplayName = "If environment variable is removed, merged config file is not generated.")]
+        [DataRow(null, true, false, null, false, DisplayName = "If environment variable is removed, merged config file is not generated.")]
+        [DataRow(null, true, true, null, false, DisplayName = "If environment variable is removed, merged config file is not generated.")]
+        [DataRow("Test", false, false, null, false, DisplayName = "Environment value set but base config not available, merged config file is not generated.")]
+        [DataRow("Test", false, true, null, false, DisplayName = "Environment value set but base config not available, merged config file is not generated.")]
+        [DataRow("Test", true, false, null, false, DisplayName = "Environment value set but env based config not available, merged config file is not generated.")]
         [DataRow("Test", true, true, "dab-config.Test.merged.json", true, DisplayName = "Environment value set and both base and envConfig available, merged config file is generated.")]
         public void TestMergeConfigAvailability(
-            string environmentValue,
+            string? environmentValue,
             bool isBaseConfigPresent,
             bool isEnvironmentBasedConfigPresent,
-            string expectedMergedConfigFileName,
+            string? expectedMergedConfigFileName,
             bool expectedIsMergedConfigAvailable)
         {
+            // Setting up the test scenarios
             Environment.SetEnvironmentVariable(RUNTIME_ENVIRONMENT_VAR_NAME, environmentValue);
             string baseConfig = "dab-config.json";
             string envBasedConfig = "dab-config.Test.json";
@@ -288,7 +293,7 @@ namespace Cli.Tests
                 }
             }
 
-            Assert.AreEqual(expectedIsMergedConfigAvailable, TryMergeConfigsIfAvailable(out string mergedConfigFile));
+            Assert.AreEqual(expectedIsMergedConfigAvailable, TryMergeConfigsIfAvailable(out string? mergedConfigFile));
             Assert.AreEqual(expectedMergedConfigFileName, mergedConfigFile);
         }
 

--- a/src/Cli.Tests/UtilsTests.cs
+++ b/src/Cli.Tests/UtilsTests.cs
@@ -238,7 +238,8 @@ namespace Cli.Tests
         /// Test to verify that merged config file is only used for the below scenario
         /// 1. Environment value is set.
         /// 2. Both Base and envBased config file is present.
-        /// In all other cases, the mergedConfigFile method should return empty string for the mergedConfigFile.
+        /// In all other cases, the TryMergeConfigsIfAvailable method should return false
+        /// and out string for the mergedConfigFile should be empty.
         /// </summary>
         [DataTestMethod]
         [DataRow("", false, false, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]

--- a/src/Cli.Tests/UtilsTests.cs
+++ b/src/Cli.Tests/UtilsTests.cs
@@ -233,7 +233,7 @@ namespace Cli.Tests
                 Assert.Fail("Failed to merge config files.");
             }
         }
-        
+
         /// <summary>
         /// Test to verify that merged config file is only used for the below scenario
         /// 1. Environment value is set.
@@ -248,7 +248,7 @@ namespace Cli.Tests
         [DataRow("Test", false, false, "", false, DisplayName = "Environment value set but base config not available, merged config file is not generated.")]
         [DataRow("Test", false, true, "", false, DisplayName = "Environment value set but base config not available, merged config file is not generated.")]
         [DataRow("Test", true, false, "", false, DisplayName = "Environment value set but env based config not available, merged config file is not generated.")]
-        [DataRow("Test", true, true, "dab-config.Test.merged.json", true, DisplayName = "environment value set and both base and envConfig available, merged config file is generated.")]
+        [DataRow("Test", true, true, "dab-config.Test.merged.json", true, DisplayName = "Environment value set and both base and envConfig available, merged config file is generated.")]
         public void TestMergeConfigAvailability(
             string environmentValue,
             bool isBaseConfigPresent,

--- a/src/Cli.Tests/UtilsTests.cs
+++ b/src/Cli.Tests/UtilsTests.cs
@@ -233,6 +233,63 @@ namespace Cli.Tests
                 Assert.Fail("Failed to merge config files.");
             }
         }
+        
+        /// <summary>
+        /// Test to verify that merged config file is only used for the below scenario
+        /// 1. Environment value is set.
+        /// 2. Both Base and envBased config file is present.
+        /// In all other cases, the mergedConfigFile method should return empty string for the mergedConfigFile.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("", false, false, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]
+        [DataRow("", false, true, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]
+        [DataRow("", true, false, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]
+        [DataRow("", true, true, "", false, DisplayName = "If environment value is not set, merged config file is not generated.")]
+        [DataRow("Test", false, false, "", false, DisplayName = "Environment value set but base config not available, merged config file is not generated.")]
+        [DataRow("Test", false, true, "", false, DisplayName = "Environment value set but base config not available, merged config file is not generated.")]
+        [DataRow("Test", true, false, "", false, DisplayName = "Environment value set but env based config not available, merged config file is not generated.")]
+        [DataRow("Test", true, true, "dab-config.Test.merged.json", true, DisplayName = "environment value set and both base and envConfig available, merged config file is generated.")]
+        public void TestMergeConfigAvailability(
+            string environmentValue,
+            bool isBaseConfigPresent,
+            bool isEnvironmentBasedConfigPresent,
+            string expectedMergedConfigFileName,
+            bool expectedIsMergedConfigAvailable)
+        {
+            Environment.SetEnvironmentVariable(RUNTIME_ENVIRONMENT_VAR_NAME, environmentValue);
+            string baseConfig = "dab-config.json";
+            string envBasedConfig = "dab-config.Test.json";
+            if (File.Exists(baseConfig))
+            {
+                File.Delete(baseConfig);
+            }
+
+            if (File.Exists(envBasedConfig))
+            {
+                File.Delete(envBasedConfig);
+            }
+
+            if (isBaseConfigPresent)
+            {
+                if (!File.Exists(baseConfig))
+                {
+                    File.Create(baseConfig).Close();
+                    File.WriteAllText(baseConfig, "{}");
+                }
+            }
+
+            if (isEnvironmentBasedConfigPresent)
+            {
+                if (!File.Exists(envBasedConfig))
+                {
+                    File.Create(envBasedConfig).Close();
+                    File.WriteAllText(envBasedConfig, "{}");
+                }
+            }
+
+            Assert.AreEqual(expectedIsMergedConfigAvailable, TryMergeConfigsIfAvailable(out string mergedConfigFile));
+            Assert.AreEqual(expectedMergedConfigFileName, mergedConfigFile);
+        }
 
         [ClassCleanup]
         public static void Cleanup()

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -898,10 +898,10 @@ namespace Cli
             {
                 string baseConfigFile = RuntimeConfigPath.DefaultName;
                 string environmentBasedConfigFile = RuntimeConfigPath.GetFileName(environmentValue, considerOverrides: false);
-                mergedConfigFile = RuntimeConfigPath.GetMergedFileNameForEnvironment(CONFIGFILE_NAME, environmentValue);
 
                 if (DoesFileExistInCurrentDirectory(baseConfigFile) && !string.IsNullOrEmpty(environmentBasedConfigFile))
                 {
+                    mergedConfigFile = RuntimeConfigPath.GetMergedFileNameForEnvironment(CONFIGFILE_NAME, environmentValue);
                     try
                     {
                         string baseConfigJson = File.ReadAllText(baseConfigFile);

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -889,11 +889,11 @@ namespace Cli
         /// If yes, it will try to merge dab-config.json with dab-config.{DAB_ENVIRONMENT}.json
         /// and create a merged file called dab-config.{DAB_ENVIRONMENT}.merged.json
         /// </summary>
-        /// <returns>Returns the name of the merged Config if successful.</returns>
-        public static bool TryMergeConfigsIfAvailable(out string mergedConfigFile)
+        /// <returns>Returns the name of the merged config if successful.</returns>
+        public static bool TryMergeConfigsIfAvailable([NotNullWhen(true)] out string? mergedConfigFile)
         {
             string? environmentValue = Environment.GetEnvironmentVariable(RUNTIME_ENVIRONMENT_VAR_NAME);
-            mergedConfigFile = string.Empty;
+            mergedConfigFile = null;
             if (!string.IsNullOrEmpty(environmentValue))
             {
                 string baseConfigFile = RuntimeConfigPath.DefaultName;
@@ -905,16 +905,19 @@ namespace Cli
                     {
                         string baseConfigJson = File.ReadAllText(baseConfigFile);
                         string overrideConfigJson = File.ReadAllText(environmentBasedConfigFile);
-                        _logger.LogInformation($"Merging {baseConfigFile} and {environmentBasedConfigFile}");
+                        string currentDir = Directory.GetCurrentDirectory();
+                        _logger.LogInformation($"Merging {Path.Combine(currentDir, baseConfigFile)}"
+                            + $" and {Path.Combine(currentDir, environmentBasedConfigFile)}");
                         string mergedConfigJson = Merge(baseConfigJson, overrideConfigJson);
                         mergedConfigFile = RuntimeConfigPath.GetMergedFileNameForEnvironment(CONFIGFILE_NAME, environmentValue);
                         File.WriteAllText(mergedConfigFile, mergedConfigJson);
-                        _logger.LogInformation($"Generated merged config file: {mergedConfigFile}");
+                        _logger.LogInformation($"Generated merged config file: {Path.Combine(currentDir, mergedConfigFile)}");
                         return true;
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, $"Failed to merge the config files.");
+                        mergedConfigFile = null;
                         return false;
                     }
                 }

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -901,14 +901,15 @@ namespace Cli
 
                 if (DoesFileExistInCurrentDirectory(baseConfigFile) && !string.IsNullOrEmpty(environmentBasedConfigFile))
                 {
-                    mergedConfigFile = RuntimeConfigPath.GetMergedFileNameForEnvironment(CONFIGFILE_NAME, environmentValue);
                     try
                     {
                         string baseConfigJson = File.ReadAllText(baseConfigFile);
                         string overrideConfigJson = File.ReadAllText(environmentBasedConfigFile);
+                        _logger.LogInformation($"Merging {baseConfigFile} and {environmentBasedConfigFile}");
                         string mergedConfigJson = Merge(baseConfigJson, overrideConfigJson);
-
+                        mergedConfigFile = RuntimeConfigPath.GetMergedFileNameForEnvironment(CONFIGFILE_NAME, environmentValue);
                         File.WriteAllText(mergedConfigFile, mergedConfigJson);
+                        _logger.LogInformation($"Generated merged config file: {mergedConfigFile}");
                         return true;
                     }
                     catch (Exception ex)


### PR DESCRIPTION
## What is the issue?
- This issue occurs specifically when the environment variable is set and `environmentBasedConfigFile` is not present and the user tries to do `dab start`. It will search for the merged file and fail directly if the merged file is not present. Ideally it should not and rather look for the default file.
- Even though the merging was not happening and the method `TryMergeConfigsIfAvailable` was returning false, the out file was not empty and it was containing the name of expected mergeConfigFile.
 
## Why make this change?
  - the merge config file name is generated and set as the config to be used even if the merged config file is not available.
  - This will make sure merge config file name is not used if it is not available

## What is this change?

- Moving the line which creates the merged file name inside the validation check for existence of the base and environment config.

## How was this tested?

- [x] Unit Tests

