### PR TITLE
Making the EntitySource.Type nullable

### DIFF
--- a/src/Auth/AuthorizationMetadataHelpers.cs
+++ b/src/Auth/AuthorizationMetadataHelpers.cs
@@ -42,12 +42,6 @@ namespace Azure.DataApiBuilder.Auth
         /// Set of Http verbs enabled for Stored Procedure entities that have their REST endpoint enabled.
         /// </summary>
         public HashSet<SupportedHttpVerb> StoredProcedureHttpVerbs { get; set; } = new();
-
-        /// <summary>
-        /// Defines the type of database object the entity represents.
-        /// Examples include Table, View, StoredProcedure
-        /// </summary>
-        public EntitySourceType ObjectType { get; set; } = EntitySourceType.Table;
     }
 
     /// <summary>

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithAnExistingNameButWithDifferentCase.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithAnExistingNameButWithDifferentCase.verified.txt
@@ -30,7 +30,8 @@
     {
       FirstEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: FirstEntity,
@@ -67,7 +68,8 @@
     {
       FIRSTEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: FIRSTEntity,

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_70de36ebf1478d0d.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_70de36ebf1478d0d.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_9f612e68879149a3.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_9f612e68879149a3.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_bea2d26f3e5462d8.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_bea2d26f3e5462d8.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesEmpty.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesEmpty.verified.txt
@@ -30,7 +30,8 @@
     {
       FirstEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: FirstEntity,

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesNotEmpty.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesNotEmpty.verified.txt
@@ -30,7 +30,8 @@
     {
       FirstEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: FirstEntity,
@@ -67,7 +68,8 @@
     {
       SecondEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: SecondEntity,

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceWithDefaultType.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceWithDefaultType.verified.txt
@@ -32,6 +32,7 @@
       MyEntity: {
         Source: {
           Object: s001.book,
+          Type: Table,
           KeyFields: [
             id,
             name

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithoutIEnumerables.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithoutIEnumerables.verified.txt
@@ -32,7 +32,8 @@
     {
       book: {
         Source: {
-          Object: s001.book
+          Object: s001.book,
+          Type: Table
         },
         GraphQL: {
           Singular: book,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_103655d39b48d89f.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_103655d39b48d89f.verified.txt
@@ -31,6 +31,7 @@
       MyEntity: {
         Source: {
           Object: s001.book,
+          Type: Table,
           KeyFields: [
             id,
             name

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_7f2338fdc84aafc3.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_7f2338fdc84aafc3.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: s001.book
+          Object: s001.book,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityByAddingNewRelationship.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityByAddingNewRelationship.verified.txt
@@ -29,7 +29,8 @@
     {
       FirstEntity: {
         Source: {
-          Object: Table1
+          Object: Table1,
+          Type: Table
         },
         GraphQL: {
           Singular: FirstEntity,
@@ -71,7 +72,8 @@
     {
       SecondEntity: {
         Source: {
-          Object: Table2
+          Object: Table2,
+          Type: Table
         },
         GraphQL: {
           Singular: SecondEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityByModifyingRelationship.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityByModifyingRelationship.verified.txt
@@ -29,7 +29,8 @@
     {
       FirstEntity: {
         Source: {
-          Object: Table1
+          Object: Table1,
+          Type: Table
         },
         GraphQL: {
           Singular: FirstEntity,
@@ -71,7 +72,8 @@
     {
       SecondEntity: {
         Source: {
-          Object: Table2
+          Object: Table2,
+          Type: Table
         },
         GraphQL: {
           Singular: SecondEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermission.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermission.verified.txt
@@ -29,7 +29,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermissionByAddingNewRole.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermissionByAddingNewRole.verified.txt
@@ -29,7 +29,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermissionHavingWildcardAction.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermissionHavingWildcardAction.verified.txt
@@ -29,7 +29,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermissionWithExistingAction.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermissionWithExistingAction.verified.txt
@@ -29,7 +29,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermissionWithWildcardAction.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityPermissionWithWildcardAction.verified.txt
@@ -29,7 +29,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithMappings.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithMappings.verified.txt
@@ -29,7 +29,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_088d6237033e0a7c.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_088d6237033e0a7c.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_3ea32fdef7aed1b4.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_3ea32fdef7aed1b4.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_4d25c2c012107597.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_4d25c2c012107597.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithSpecialCharacterInMappings.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithSpecialCharacterInMappings.verified.txt
@@ -29,7 +29,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateExistingMappings.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateExistingMappings.verified.txt
@@ -29,7 +29,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdatePolicy.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdatePolicy.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: MyTable
+          Object: MyTable,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a13a9ca73b21f261.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a13a9ca73b21f261.verified.txt
@@ -31,6 +31,7 @@
       MyEntity: {
         Source: {
           Object: s001.book,
+          Type: Table,
           KeyFields: [
             id,
             name

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a5ce76c8bea25cc8.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a5ce76c8bea25cc8.verified.txt
@@ -31,6 +31,7 @@
       MyEntity: {
         Source: {
           Object: s001.book,
+          Type: Table,
           KeyFields: [
             id,
             name

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_bba111332a1f973f.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_bba111332a1f973f.verified.txt
@@ -30,7 +30,8 @@
     {
       MyEntity: {
         Source: {
-          Object: s001.book
+          Object: s001.book,
+          Type: Table
         },
         GraphQL: {
           Singular: MyEntity,

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceKeyFields.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceKeyFields.verified.txt
@@ -31,6 +31,7 @@
       MyEntity: {
         Source: {
           Object: s001.book,
+          Type: Table,
           KeyFields: [
             col1,
             col2

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -208,6 +208,7 @@ namespace Cli
             // Try to get the source object as string or DatabaseObjectSource for new Entity
             if (!TryCreateSourceObjectForNewEntity(
                 options,
+                initialRuntimeConfig.DataSource.DatabaseType == DatabaseType.CosmosDB_NoSQL,
                 out EntitySource? source))
             {
                 _logger.LogError("Unable to create the source object.");
@@ -294,12 +295,13 @@ namespace Cli
         /// </summary>
         public static bool TryCreateSourceObjectForNewEntity(
             AddOptions options,
+            bool isCosmosDbNoSQL,
             [NotNullWhen(true)] out EntitySource? sourceObject)
         {
             sourceObject = null;
 
-            // default entity type will be table
-            EntitySourceType objectType = EntitySourceType.Table;
+            // default entity type will be null if it's CosmosDB_NoSQL otherwise it will be Table
+            EntitySourceType? objectType = isCosmosDbNoSQL ? null : EntitySourceType.Table;
 
             if (options.SourceType is not null)
             {
@@ -364,7 +366,7 @@ namespace Cli
             IEnumerable<string> permissions,
             EntityActionPolicy? policy,
             EntityActionFields? fields,
-            EntitySourceType sourceType)
+            EntitySourceType? sourceType)
         {
             // Getting Role and Operations from permission string
             string? role, operations;
@@ -485,7 +487,7 @@ namespace Cli
                 _logger.LogWarning("Disabling GraphQL for this entity will restrict its usage in relationships");
             }
 
-            EntitySourceType updatedSourceType = updatedSource.Type;
+            EntitySourceType? updatedSourceType = updatedSource.Type;
 
             if (options.Permissions is not null && options.Permissions.Any())
             {
@@ -581,20 +583,19 @@ namespace Cli
                                                                         IEnumerable<string> permissions,
                                                                         EntityActionPolicy? policy,
                                                                         EntityActionFields? fields,
-                                                                        EntitySourceType sourceType)
+                                                                        EntitySourceType? sourceType)
         {
-            string? newRole, newOperations;
 
             // Parse role and operations from the permissions string
             //
-            if (!TryGetRoleAndOperationFromPermission(permissions, out newRole, out newOperations))
+            if (!TryGetRoleAndOperationFromPermission(permissions, out string? newRole, out string? newOperations))
             {
                 _logger.LogError("Failed to fetch the role and operation from the given permission string: {permissions}.", permissions);
                 return null;
             }
 
             List<EntityPermission> updatedPermissionsList = new();
-            string[] newOperationArray = newOperations!.Split(",");
+            string[] newOperationArray = newOperations.Split(",");
 
             // Verifies that the list of operations declared are valid for the specified sourceType.
             // Example: Stored-procedure can only have 1 operation.
@@ -642,7 +643,7 @@ namespace Cli
             // and add it to permissionSettings list.
             if (!role_found)
             {
-                updatedPermissionsList.Add(CreatePermissions(newRole!, newOperations!, policy, fields));
+                updatedPermissionsList.Add(CreatePermissions(newRole, newOperations, policy, fields));
             }
 
             return updatedPermissionsList.ToArray();
@@ -714,7 +715,7 @@ namespace Cli
             updatedSourceObject = null;
             string updatedSourceName = options.Source ?? entity.Source.Object;
             string[]? updatedKeyFields = entity.Source.KeyFields;
-            EntitySourceType updatedSourceType = entity.Source.Type;
+            EntitySourceType? updatedSourceType = entity.Source.Type;
             Dictionary<string, object>? updatedSourceParameters = entity.Source.Parameters;
 
             // If SourceType provided by user is null,

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -89,7 +89,7 @@ namespace Cli
         /// </summary>
         /// <param name="operations">Array of operations which is of type JsonElement.</param>
         /// <returns>Dictionary of operations</returns>
-        public static IDictionary<EntityActionOperation, EntityAction> ConvertOperationArrayToIEnumerable(EntityAction[] operations, EntitySourceType sourceType)
+        public static IDictionary<EntityActionOperation, EntityAction> ConvertOperationArrayToIEnumerable(EntityAction[] operations, EntitySourceType? sourceType)
         {
             Dictionary<EntityActionOperation, EntityAction> result = new();
             foreach (EntityAction operation in operations)
@@ -301,7 +301,7 @@ namespace Cli
         /// </summary>
         /// <param name="operations">array of string containing operations for permissions</param>
         /// <returns>True if no invalid operation is found.</returns>
-        public static bool VerifyOperations(string[] operations, EntitySourceType sourceType)
+        public static bool VerifyOperations(string[] operations, EntitySourceType? sourceType)
         {
             // Check if there are any duplicate operations
             // Ex: read,read,create
@@ -363,7 +363,7 @@ namespace Cli
         /// It will return true if parsing is successful and add the parsed value
         /// to the out params role and operations.
         /// </summary>
-        public static bool TryGetRoleAndOperationFromPermission(IEnumerable<string> permissions, out string? role, out string? operations)
+        public static bool TryGetRoleAndOperationFromPermission(IEnumerable<string> permissions, [NotNullWhen(true)] out string? role, [NotNullWhen(true)] out string? operations)
         {
             // Split permission to role and operations.
             role = null;
@@ -468,7 +468,7 @@ namespace Cli
         /// <returns>True in case of successful creation of source object.</returns>
         public static bool TryCreateSourceObject(
             string name,
-            EntitySourceType type,
+            EntitySourceType? type,
             Dictionary<string, object>? parameters,
             string[]? keyFields,
             [NotNullWhen(true)] out EntitySource? sourceObject)

--- a/src/Config/ObjectModel/EntitySource.cs
+++ b/src/Config/ObjectModel/EntitySource.cs
@@ -13,4 +13,4 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 /// <param name="Parameters"> If Type is SourceType.StoredProcedure,
 /// Parameters to be passed as defaults to the procedure call </param>
 /// <param name="KeyFields"> The field(s) to be used as primary keys.
-public record EntitySource(string Object, EntitySourceType Type, Dictionary<string, object>? Parameters, string[]? KeyFields);
+public record EntitySource(string Object, EntitySourceType? Type, Dictionary<string, object>? Parameters, string[]? KeyFields);

--- a/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
+++ b/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
@@ -34,7 +34,8 @@
     {
       Publisher: {
         Source: {
-          Object: publishers
+          Object: publishers,
+          Type: Table
         },
         GraphQL: {
           Singular: Publisher,
@@ -275,7 +276,8 @@
     {
       Stock: {
         Source: {
-          Object: stocks
+          Object: stocks,
+          Type: Table
         },
         GraphQL: {
           Singular: Stock,
@@ -375,7 +377,8 @@
     {
       Book: {
         Source: {
-          Object: books
+          Object: books,
+          Type: Table
         },
         GraphQL: {
           Singular: book,
@@ -739,7 +742,8 @@
     {
       BookWebsitePlacement: {
         Source: {
-          Object: book_website_placements
+          Object: book_website_placements,
+          Type: Table
         },
         GraphQL: {
           Singular: BookWebsitePlacement,
@@ -794,7 +798,8 @@
     {
       Author: {
         Source: {
-          Object: authors
+          Object: authors,
+          Type: Table
         },
         GraphQL: {
           Singular: Author,
@@ -848,7 +853,8 @@
     {
       Revenue: {
         Source: {
-          Object: revenues
+          Object: revenues,
+          Type: Table
         },
         GraphQL: {
           Singular: Revenue,
@@ -885,7 +891,8 @@
     {
       Review: {
         Source: {
-          Object: reviews
+          Object: reviews,
+          Type: Table
         },
         GraphQL: {
           Singular: review,
@@ -945,7 +952,8 @@
     {
       Comic: {
         Source: {
-          Object: comics
+          Object: comics,
+          Type: Table
         },
         GraphQL: {
           Singular: Comic,
@@ -1054,7 +1062,8 @@
     {
       Broker: {
         Source: {
-          Object: brokers
+          Object: brokers,
+          Type: Table
         },
         GraphQL: {
           Singular: Broker,
@@ -1101,7 +1110,8 @@
     {
       WebsiteUser: {
         Source: {
-          Object: website_users
+          Object: website_users,
+          Type: Table
         },
         GraphQL: {
           Singular: websiteUser,
@@ -1160,7 +1170,8 @@
     {
       SupportedType: {
         Source: {
-          Object: type_table
+          Object: type_table,
+          Type: Table
         },
         GraphQL: {
           Singular: SupportedType,
@@ -1222,7 +1233,8 @@
     {
       stocks_price: {
         Source: {
-          Object: stocks_price
+          Object: stocks_price,
+          Type: Table
         },
         GraphQL: {
           Singular: stocks_price,
@@ -1283,7 +1295,8 @@
     {
       Tree: {
         Source: {
-          Object: trees
+          Object: trees,
+          Type: Table
         },
         GraphQL: {
           Singular: Tree,
@@ -1346,7 +1359,8 @@
     {
       Shrub: {
         Source: {
-          Object: trees
+          Object: trees,
+          Type: Table
         },
         GraphQL: {
           Singular: Shrub,
@@ -1409,7 +1423,8 @@
     {
       Fungus: {
         Source: {
-          Object: fungi
+          Object: fungi,
+          Type: Table
         },
         GraphQL: {
           Singular: fungus,
@@ -1713,7 +1728,8 @@
     {
       Empty: {
         Source: {
-          Object: empty_table
+          Object: empty_table,
+          Type: Table
         },
         GraphQL: {
           Singular: Empty,
@@ -1760,7 +1776,8 @@
     {
       Notebook: {
         Source: {
-          Object: notebooks
+          Object: notebooks,
+          Type: Table
         },
         GraphQL: {
           Singular: Notebook,
@@ -1805,7 +1822,8 @@
     {
       Journal: {
         Source: {
-          Object: journals
+          Object: journals,
+          Type: Table
         },
         GraphQL: {
           Singular: Journal,
@@ -1904,7 +1922,8 @@
     {
       ArtOfWar: {
         Source: {
-          Object: aow
+          Object: aow,
+          Type: Table
         },
         GraphQL: {
           Singular: ArtOfWar,
@@ -1945,7 +1964,8 @@
     {
       series: {
         Source: {
-          Object: series
+          Object: series,
+          Type: Table
         },
         GraphQL: {
           Singular: series,
@@ -2026,7 +2046,8 @@
     {
       Sales: {
         Source: {
-          Object: sales
+          Object: sales,
+          Type: Table
         },
         GraphQL: {
           Singular: Sales,
@@ -2439,7 +2460,8 @@
     {
       GQLmappings: {
         Source: {
-          Object: GQLmappings
+          Object: GQLmappings,
+          Type: Table
         },
         GraphQL: {
           Singular: GQLmappings,
@@ -2478,7 +2500,8 @@
     {
       Bookmarks: {
         Source: {
-          Object: bookmarks
+          Object: bookmarks,
+          Type: Table
         },
         GraphQL: {
           Singular: Bookmarks,
@@ -2513,7 +2536,8 @@
     {
       MappedBookmarks: {
         Source: {
-          Object: mappedbookmarks
+          Object: mappedbookmarks,
+          Type: Table
         },
         GraphQL: {
           Singular: MappedBookmarks,
@@ -2552,7 +2576,8 @@
     {
       PublisherNF: {
         Source: {
-          Object: publishers
+          Object: publishers,
+          Type: Table
         },
         GraphQL: {
           Singular: PublisherNF,
@@ -2637,7 +2662,8 @@
     {
       BookNF: {
         Source: {
-          Object: books
+          Object: books,
+          Type: Table
         },
         GraphQL: {
           Singular: bookNF,
@@ -2738,7 +2764,8 @@
     {
       AuthorNF: {
         Source: {
-          Object: authors
+          Object: authors,
+          Type: Table
         },
         GraphQL: {
           Singular: AuthorNF,

--- a/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMySql.verified.txt
+++ b/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMySql.verified.txt
@@ -29,7 +29,8 @@
     {
       Publisher: {
         Source: {
-          Object: publishers
+          Object: publishers,
+          Type: Table
         },
         GraphQL: {
           Singular: Publisher,
@@ -268,7 +269,8 @@
     {
       Stock: {
         Source: {
-          Object: stocks
+          Object: stocks,
+          Type: Table
         },
         GraphQL: {
           Singular: Stock,
@@ -329,7 +331,8 @@
     {
       Book: {
         Source: {
-          Object: books
+          Object: books,
+          Type: Table
         },
         GraphQL: {
           Singular: book,
@@ -693,7 +696,8 @@
     {
       BookWebsitePlacement: {
         Source: {
-          Object: book_website_placements
+          Object: book_website_placements,
+          Type: Table
         },
         GraphQL: {
           Singular: BookWebsitePlacement,
@@ -748,7 +752,8 @@
     {
       Author: {
         Source: {
-          Object: authors
+          Object: authors,
+          Type: Table
         },
         GraphQL: {
           Singular: Author,
@@ -802,7 +807,8 @@
     {
       Review: {
         Source: {
-          Object: reviews
+          Object: reviews,
+          Type: Table
         },
         GraphQL: {
           Singular: review,
@@ -862,7 +868,8 @@
     {
       Comic: {
         Source: {
-          Object: comics
+          Object: comics,
+          Type: Table
         },
         GraphQL: {
           Singular: Comic,
@@ -922,7 +929,8 @@
     {
       Broker: {
         Source: {
-          Object: brokers
+          Object: brokers,
+          Type: Table
         },
         GraphQL: {
           Singular: Broker,
@@ -969,7 +977,8 @@
     {
       WebsiteUser: {
         Source: {
-          Object: website_users
+          Object: website_users,
+          Type: Table
         },
         GraphQL: {
           Singular: websiteUser,
@@ -1028,7 +1037,8 @@
     {
       SupportedType: {
         Source: {
-          Object: type_table
+          Object: type_table,
+          Type: Table
         },
         GraphQL: {
           Singular: SupportedType,
@@ -1090,7 +1100,8 @@
     {
       stocks_price: {
         Source: {
-          Object: stocks_price
+          Object: stocks_price,
+          Type: Table
         },
         GraphQL: {
           Singular: stocks_price,
@@ -1137,7 +1148,8 @@
     {
       Tree: {
         Source: {
-          Object: trees
+          Object: trees,
+          Type: Table
         },
         GraphQL: {
           Singular: Tree,
@@ -1200,7 +1212,8 @@
     {
       Shrub: {
         Source: {
-          Object: trees
+          Object: trees,
+          Type: Table
         },
         GraphQL: {
           Singular: Shrub,
@@ -1263,7 +1276,8 @@
     {
       Fungus: {
         Source: {
-          Object: fungi
+          Object: fungi,
+          Type: Table
         },
         GraphQL: {
           Singular: fungus,
@@ -1567,7 +1581,8 @@
     {
       Empty: {
         Source: {
-          Object: empty_table
+          Object: empty_table,
+          Type: Table
         },
         GraphQL: {
           Singular: Empty,
@@ -1614,7 +1629,8 @@
     {
       Notebook: {
         Source: {
-          Object: notebooks
+          Object: notebooks,
+          Type: Table
         },
         GraphQL: {
           Singular: Notebook,
@@ -1659,7 +1675,8 @@
     {
       Journal: {
         Source: {
-          Object: journals
+          Object: journals,
+          Type: Table
         },
         GraphQL: {
           Singular: Journal,
@@ -1758,7 +1775,8 @@
     {
       ArtOfWar: {
         Source: {
-          Object: aow
+          Object: aow,
+          Type: Table
         },
         GraphQL: {
           Singular: ArtOfWar,
@@ -1799,7 +1817,8 @@
     {
       series: {
         Source: {
-          Object: series
+          Object: series,
+          Type: Table
         },
         GraphQL: {
           Singular: series,
@@ -1831,7 +1850,8 @@
     {
       Sales: {
         Source: {
-          Object: sales
+          Object: sales,
+          Type: Table
         },
         GraphQL: {
           Singular: Sales,
@@ -1866,7 +1886,8 @@
     {
       GQLmappings: {
         Source: {
-          Object: GQLmappings
+          Object: GQLmappings,
+          Type: Table
         },
         GraphQL: {
           Singular: GQLmappings,
@@ -1905,7 +1926,8 @@
     {
       Bookmarks: {
         Source: {
-          Object: bookmarks
+          Object: bookmarks,
+          Type: Table
         },
         GraphQL: {
           Singular: Bookmarks,
@@ -1940,7 +1962,8 @@
     {
       MappedBookmarks: {
         Source: {
-          Object: mappedbookmarks
+          Object: mappedbookmarks,
+          Type: Table
         },
         GraphQL: {
           Singular: MappedBookmarks,

--- a/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForPostgreSql.verified.txt
+++ b/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForPostgreSql.verified.txt
@@ -29,7 +29,8 @@
     {
       Publisher: {
         Source: {
-          Object: publishers
+          Object: publishers,
+          Type: Table
         },
         GraphQL: {
           Singular: Publisher,
@@ -268,7 +269,8 @@
     {
       Stock: {
         Source: {
-          Object: stocks
+          Object: stocks,
+          Type: Table
         },
         GraphQL: {
           Singular: Stock,
@@ -366,7 +368,8 @@
     {
       Book: {
         Source: {
-          Object: books
+          Object: books,
+          Type: Table
         },
         GraphQL: {
           Singular: book,
@@ -730,7 +733,8 @@
     {
       BookWebsitePlacement: {
         Source: {
-          Object: book_website_placements
+          Object: book_website_placements,
+          Type: Table
         },
         GraphQL: {
           Singular: BookWebsitePlacement,
@@ -785,7 +789,8 @@
     {
       Author: {
         Source: {
-          Object: authors
+          Object: authors,
+          Type: Table
         },
         GraphQL: {
           Singular: Author,
@@ -839,7 +844,8 @@
     {
       Review: {
         Source: {
-          Object: reviews
+          Object: reviews,
+          Type: Table
         },
         GraphQL: {
           Singular: review,
@@ -899,7 +905,8 @@
     {
       Comic: {
         Source: {
-          Object: comics
+          Object: comics,
+          Type: Table
         },
         GraphQL: {
           Singular: Comic,
@@ -1008,7 +1015,8 @@
     {
       Broker: {
         Source: {
-          Object: brokers
+          Object: brokers,
+          Type: Table
         },
         GraphQL: {
           Singular: Broker,
@@ -1055,7 +1063,8 @@
     {
       WebsiteUser: {
         Source: {
-          Object: website_users
+          Object: website_users,
+          Type: Table
         },
         GraphQL: {
           Singular: websiteUser,
@@ -1114,7 +1123,8 @@
     {
       SupportedType: {
         Source: {
-          Object: type_table
+          Object: type_table,
+          Type: Table
         },
         GraphQL: {
           Singular: SupportedType,
@@ -1176,7 +1186,8 @@
     {
       stocks_price: {
         Source: {
-          Object: stocks_price
+          Object: stocks_price,
+          Type: Table
         },
         GraphQL: {
           Singular: stocks_price,
@@ -1237,7 +1248,8 @@
     {
       Tree: {
         Source: {
-          Object: trees
+          Object: trees,
+          Type: Table
         },
         GraphQL: {
           Singular: Tree,
@@ -1300,7 +1312,8 @@
     {
       Shrub: {
         Source: {
-          Object: trees
+          Object: trees,
+          Type: Table
         },
         GraphQL: {
           Singular: Shrub,
@@ -1363,7 +1376,8 @@
     {
       Fungus: {
         Source: {
-          Object: fungi
+          Object: fungi,
+          Type: Table
         },
         GraphQL: {
           Singular: fungus,
@@ -1624,7 +1638,8 @@
     {
       Empty: {
         Source: {
-          Object: empty_table
+          Object: empty_table,
+          Type: Table
         },
         GraphQL: {
           Singular: Empty,
@@ -1671,7 +1686,8 @@
     {
       Notebook: {
         Source: {
-          Object: notebooks
+          Object: notebooks,
+          Type: Table
         },
         GraphQL: {
           Singular: Notebook,
@@ -1716,7 +1732,8 @@
     {
       Journal: {
         Source: {
-          Object: journals
+          Object: journals,
+          Type: Table
         },
         GraphQL: {
           Singular: Journal,
@@ -1815,7 +1832,8 @@
     {
       ArtOfWar: {
         Source: {
-          Object: aow
+          Object: aow,
+          Type: Table
         },
         GraphQL: {
           Singular: ArtOfWar,
@@ -1856,7 +1874,8 @@
     {
       series: {
         Source: {
-          Object: series
+          Object: series,
+          Type: Table
         },
         GraphQL: {
           Singular: series,
@@ -1937,7 +1956,8 @@
     {
       Sales: {
         Source: {
-          Object: sales
+          Object: sales,
+          Type: Table
         },
         GraphQL: {
           Singular: Sales,
@@ -1972,7 +1992,8 @@
     {
       GQLmappings: {
         Source: {
-          Object: gqlmappings
+          Object: gqlmappings,
+          Type: Table
         },
         GraphQL: {
           Singular: GQLmappings,
@@ -2011,7 +2032,8 @@
     {
       Bookmarks: {
         Source: {
-          Object: bookmarks
+          Object: bookmarks,
+          Type: Table
         },
         GraphQL: {
           Singular: Bookmarks,
@@ -2046,7 +2068,8 @@
     {
       MappedBookmarks: {
         Source: {
-          Object: mappedbookmarks
+          Object: mappedbookmarks,
+          Type: Table
         },
         GraphQL: {
           Singular: MappedBookmarks,
@@ -2085,7 +2108,8 @@
     {
       PublisherNF: {
         Source: {
-          Object: publishers
+          Object: publishers,
+          Type: Table
         },
         GraphQL: {
           Singular: PublisherNF,
@@ -2170,7 +2194,8 @@
     {
       BookNF: {
         Source: {
-          Object: books
+          Object: books,
+          Type: Table
         },
         GraphQL: {
           Singular: bookNF,
@@ -2271,7 +2296,8 @@
     {
       AuthorNF: {
         Source: {
-          Object: authors
+          Object: authors,
+          Type: Table
         },
         GraphQL: {
           Singular: AuthorNF,

--- a/src/Service.Tests/dab-config.CosmosDb_NoSql.json
+++ b/src/Service.Tests/dab-config.CosmosDb_NoSql.json
@@ -11,7 +11,7 @@
   },
   "runtime": {
     "rest": {
-      "enabled": true,
+      "enabled": false,
       "path": "/api"
     },
     "graphql": {
@@ -40,7 +40,7 @@
     "Planet": {
   "source": {
     "object": "graphqldb.planet",
-    "type": "table",
+    "type": null,
     "parameters": null,
     "key-fields": null
   },
@@ -144,7 +144,7 @@
     "Character": {
   "source": {
     "object": "graphqldb.character",
-    "type": "table",
+    "type": null,
     "parameters": null,
     "key-fields": null
   },
@@ -206,7 +206,7 @@
     "StarAlias": {
   "source": {
     "object": "graphqldb.star",
-    "type": "table",
+    "type": null,
     "parameters": null,
     "key-fields": null
   },
@@ -305,7 +305,7 @@
     "TagAlias": {
   "source": {
     "object": "graphqldb.tag",
-    "type": "table",
+    "type": null,
     "parameters": null,
     "key-fields": null
   },
@@ -367,7 +367,7 @@
     "Moon": {
   "source": {
     "object": "graphqldb.moon",
-    "type": "table",
+    "type": null,
     "parameters": null,
     "key-fields": null
   },
@@ -466,7 +466,7 @@
     "Earth": {
   "source": {
     "object": "graphqldb.earth",
-    "type": "table",
+    "type": null,
     "parameters": null,
     "key-fields": null
   },
@@ -585,7 +585,7 @@
     "Sun": {
   "source": {
     "object": "graphqldb.sun",
-    "type": "table",
+    "type": null,
     "parameters": null,
     "key-fields": null
   },

--- a/src/Service.Tests/dab-config.PostgreSql.json
+++ b/src/Service.Tests/dab-config.PostgreSql.json
@@ -17,9 +17,7 @@
     },
     "host": {
       "cors": {
-        "origins": [
-          "http://localhost:5000"
-        ],
+        "origins": ["http://localhost:5000"],
         "allow-credentials": false
       },
       "authentication": {
@@ -34,3485 +32,3357 @@
   },
   "entities": {
     "Publisher": {
-  "source": {
-    "object": "publishers",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Publisher",
-      "plural": "Publishers"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+      "source": {
+        "object": "publishers",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Publisher",
+          "plural": "Publishers"
         }
-      ]
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_01",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id eq 1940"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_02",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 1940"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_03",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 1940"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_04",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id eq 1940"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_06",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id eq 1940"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "database_policy_tester",
+          "actions": [
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 1234"
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 1234 or @item.id gt 1940"
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": {
+        "books": {
+          "cardinality": "many",
+          "target.entity": "Book",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        }
+      }
     },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_01",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id eq 1940"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_02",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 1940"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_03",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 1940"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_04",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id eq 1940"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_06",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id eq 1940"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "database_policy_tester",
-      "actions": [
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 1234"
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 1234 or @item.id gt 1940"
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": {
-    "books": {
-      "cardinality": "many",
-      "target.entity": "Book",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-},
     "Stock": {
-  "source": {
-    "object": "stocks",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Stock",
-      "plural": "Stocks"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": "/commodities",
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+      "source": {
+        "object": "stocks",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Stock",
+          "plural": "Stocks"
         }
-      ]
+      },
+      "rest": {
+        "enabled": true,
+        "path": "/commodities",
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "database_policy_tester",
+          "actions": [
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": "@item.pieceid ne 1"
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": {
+        "stocks_price": {
+          "cardinality": "one",
+          "target.entity": "stocks_price",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        }
+      }
     },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "database_policy_tester",
-      "actions": [
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": "@item.pieceid ne 1"
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": {
-    "stocks_price": {
-      "cardinality": "one",
-      "target.entity": "stocks_price",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-},
     "Book": {
-  "source": {
-    "object": "books",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "book",
-      "plural": "books"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+      "source": {
+        "object": "books",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "book",
+          "plural": "books"
         }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
         {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         },
         {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         },
         {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+          "role": "policy_tester_01",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.title eq \u0027Policy-Test-01\u0027"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         },
         {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+          "role": "policy_tester_02",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.title ne \u0027Policy-Test-01\u0027"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_03",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.title eq \u0027Policy-Test-01\u0027"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_04",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.title ne \u0027Policy-Test-01\u0027"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_05",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 9"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_06",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 10"
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_07",
+          "actions": [
+            {
+              "action": "delete",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 9"
+              }
+            },
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 9"
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_08",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id eq 9"
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id eq 9"
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         }
-      ]
-    },
-    {
-      "role": "policy_tester_01",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.title eq \u0027Policy-Test-01\u0027"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_02",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.title ne \u0027Policy-Test-01\u0027"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_03",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.title eq \u0027Policy-Test-01\u0027"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_04",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.title ne \u0027Policy-Test-01\u0027"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_05",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 9"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_06",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 10"
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_07",
-      "actions": [
-        {
-          "action": "delete",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 9"
-          }
-        },
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 9"
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_08",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id eq 9"
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id eq 9"
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "id": "id",
-    "title": "title"
-  },
-  "relationships": {
-    "publishers": {
-      "cardinality": "one",
-      "target.entity": "Publisher",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    },
-    "websiteplacement": {
-      "cardinality": "one",
-      "target.entity": "BookWebsitePlacement",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    },
-    "reviews": {
-      "cardinality": "many",
-      "target.entity": "Review",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    },
-    "authors": {
-      "cardinality": "many",
-      "target.entity": "Author",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": "book_author_link",
-      "linking.source.fields": [
-        "book_id"
       ],
-      "linking.target.fields": [
-        "author_id"
-      ]
-    }
-  }
-},
+      "mappings": {
+        "id": "id",
+        "title": "title"
+      },
+      "relationships": {
+        "publishers": {
+          "cardinality": "one",
+          "target.entity": "Publisher",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        },
+        "websiteplacement": {
+          "cardinality": "one",
+          "target.entity": "BookWebsitePlacement",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        },
+        "reviews": {
+          "cardinality": "many",
+          "target.entity": "Review",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        },
+        "authors": {
+          "cardinality": "many",
+          "target.entity": "Author",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": "book_author_link",
+          "linking.source.fields": ["book_id"],
+          "linking.target.fields": ["author_id"]
+        }
+      }
+    },
     "BookWebsitePlacement": {
-  "source": {
-    "object": "book_website_placements",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "BookWebsitePlacement",
-      "plural": "BookWebsitePlacements"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "delete",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@claims.userId eq @item.id"
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": {
-    "books": {
-      "cardinality": "one",
-      "target.entity": "Book",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-},
-    "Author": {
-  "source": {
-    "object": "authors",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Author",
-      "plural": "Authors"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": {
-    "books": {
-      "cardinality": "many",
-      "target.entity": "Book",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": "book_author_link",
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-},
-    "Review": {
-  "source": {
-    "object": "reviews",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "review",
-      "plural": "reviews"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": {
-    "books": {
-      "cardinality": "one",
-      "target.entity": "Book",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-},
-    "Comic": {
-  "source": {
-    "object": "comics",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Comic",
-      "plural": "Comics"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterManyOne_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterManyOne_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterOneMany_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [
-              "categoryName"
-            ],
-            "include": null
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterOneMany_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": {
-    "myseries": {
-      "cardinality": "one",
-      "target.entity": "series",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-},
-    "Broker": {
-  "source": {
-    "object": "brokers",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": false,
-    "operation": null,
-    "type": {
-      "singular": "Broker",
-      "plural": "Brokers"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "WebsiteUser": {
-  "source": {
-    "object": "website_users",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "websiteUser",
-      "plural": "websiteUsers"
-    }
-  },
-  "rest": {
-    "enabled": false,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "SupportedType": {
-  "source": {
-    "object": "type_table",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "SupportedType",
-      "plural": "SupportedTypes"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "id": "typeid"
-  },
-  "relationships": null
-},
-    "stocks_price": {
-  "source": {
-    "object": "stocks_price",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "stocks_price",
-      "plural": "stocks_prices"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [
-              "price"
-            ],
-            "include": null
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "Tree": {
-  "source": {
-    "object": "trees",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": false,
-    "operation": null,
-    "type": {
-      "singular": "Tree",
-      "plural": "Trees"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "species": "Scientific Name",
-    "region": "United State\u0027s Region"
-  },
-  "relationships": null
-},
-    "Shrub": {
-  "source": {
-    "object": "trees",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Shrub",
-      "plural": "Shrubs"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": "/plants",
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "species": "fancyName"
-  },
-  "relationships": null
-},
-    "Fungus": {
-  "source": {
-    "object": "fungi",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "fungus",
-      "plural": "fungi"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_01",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.region ne \u0027northeast\u0027"
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "spores": "hazards"
-  },
-  "relationships": null
-},
-    "books_view_all": {
-  "source": {
-    "object": "books_view_all",
-    "type": "view",
-    "parameters": null,
-    "key-fields": [
-      "id"
-    ]
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "books_view_all",
-      "plural": "books_view_alls"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": [
-      "get",
-      "post",
-      "put",
-      "patch",
-      "delete"
-    ]
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "books_view_with_mapping": {
-  "source": {
-    "object": "books_view_with_mapping",
-    "type": "view",
-    "parameters": null,
-    "key-fields": [
-      "id"
-    ]
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "books_view_with_mapping",
-      "plural": "books_view_with_mappings"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "id": "book_id"
-  },
-  "relationships": null
-},
-    "stocks_view_selected": {
-  "source": {
-    "object": "stocks_view_selected",
-    "type": "view",
-    "parameters": null,
-    "key-fields": [
-      "categoryid",
-      "pieceid"
-    ]
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "stocks_view_selected",
-      "plural": "stocks_view_selecteds"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": [
-      "get",
-      "post",
-      "put",
-      "patch",
-      "delete"
-    ]
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "books_publishers_view_composite": {
-  "source": {
-    "object": "books_publishers_view_composite",
-    "type": "view",
-    "parameters": null,
-    "key-fields": [
-      "id",
-      "pub_id"
-    ]
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "books_publishers_view_composite",
-      "plural": "books_publishers_view_composites"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": [
-      "get",
-      "post",
-      "put",
-      "patch",
-      "delete"
-    ]
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "books_publishers_view_composite_insertable": {
-  "source": {
-    "object": "books_publishers_view_composite_insertable",
-    "type": "view",
-    "parameters": null,
-    "key-fields": [
-      "id"
-    ]
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "books_publishers_view_composite_insertable",
-      "plural": "books_publishers_view_composite_insertables"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": [
-      "get",
-      "post",
-      "put",
-      "patch",
-      "delete"
-    ]
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "Empty": {
-  "source": {
-    "object": "empty_table",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Empty",
-      "plural": "Empties"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "Notebook": {
-  "source": {
-    "object": "notebooks",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Notebook",
-      "plural": "Notebooks"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item ne 1"
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "Journal": {
-  "source": {
-    "object": "journals",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Journal",
-      "plural": "Journals"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "policy_tester_noupdate",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id ne 1"
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "policy_tester_update_noread",
-      "actions": [
-        {
-          "action": "delete",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id eq 1"
-          }
-        },
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [
-              "*"
-            ],
-            "include": null
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": {
-            "exclude": [],
-            "include": [
-              "*"
-            ]
-          },
-          "policy": {
-            "request": null,
-            "database": "@item.id eq 1"
-          }
-        },
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authorizationHandlerTester",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "ArtOfWar": {
-  "source": {
-    "object": "aow",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": false,
-    "operation": null,
-    "type": {
-      "singular": "ArtOfWar",
-      "plural": "ArtOfWars"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "DetailAssessmentAndPlanning": "\u59CB\u8A08",
-    "WagingWar": "\u4F5C\u6230",
-    "StrategicAttack": "\u8B00\u653B",
-    "NoteNum": "\u252C\u2500\u252C\u30CE( \u00BA _ \u00BA\u30CE)"
-  },
-  "relationships": null
-},
-    "series": {
-  "source": {
-    "object": "series",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "series",
-      "plural": "series"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterManyOne_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [
-              "name"
-            ],
-            "include": null
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterManyOne_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterOneMany_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterOneMany_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": {
-    "comics": {
-      "cardinality": "many",
-      "target.entity": "Comic",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-},
-    "Sales": {
-  "source": {
-    "object": "sales",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Sales",
-      "plural": "Sales"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "GQLmappings": {
-  "source": {
-    "object": "gqlmappings",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "GQLmappings",
-      "plural": "GQLmappings"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "__column1": "column1",
-    "__column2": "column2"
-  },
-  "relationships": null
-},
-    "Bookmarks": {
-  "source": {
-    "object": "bookmarks",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "Bookmarks",
-      "plural": "Bookmarks"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": null
-},
-    "MappedBookmarks": {
-  "source": {
-    "object": "mappedbookmarks",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "MappedBookmarks",
-      "plural": "MappedBookmarks"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "anonymous",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "*",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": {
-    "id": "bkid",
-    "bkname": "name"
-  },
-  "relationships": null
-},
-    "PublisherNF": {
-  "source": {
-    "object": "publishers",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "PublisherNF",
-      "plural": "PublisherNFs"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilter_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilter_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterChained_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterChained_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [
-              "name"
-            ],
-            "include": null
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    }
-  ],
-  "mappings": null,
-  "relationships": {
-    "books": {
-      "cardinality": "many",
-      "target.entity": "BookNF",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-},
-    "BookNF": {
-  "source": {
-    "object": "books",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "bookNF",
-      "plural": "booksNF"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "authenticated",
-      "actions": [
-        {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        },
-        {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilter_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilter_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterChained_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterChained_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+      "source": {
+        "object": "book_website_placements",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "BookWebsitePlacement",
+          "plural": "BookWebsitePlacements"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "delete",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@claims.userId eq @item.id"
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         }
-      ]
-    }
-  ],
-  "mappings": {
-    "id": "id",
-    "title": "title"
-  },
-  "relationships": {
-    "publishers": {
-      "cardinality": "one",
-      "target.entity": "PublisherNF",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    },
-    "websiteplacement": {
-      "cardinality": "one",
-      "target.entity": "BookWebsitePlacement",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    },
-    "reviews": {
-      "cardinality": "many",
-      "target.entity": "Review",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": null,
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    },
-    "authors": {
-      "cardinality": "many",
-      "target.entity": "AuthorNF",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": "book_author_link",
-      "linking.source.fields": [
-        "book_id"
       ],
-      "linking.target.fields": [
-        "author_id"
-      ]
-    }
-  }
-},
+      "mappings": null,
+      "relationships": {
+        "books": {
+          "cardinality": "one",
+          "target.entity": "Book",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        }
+      }
+    },
+    "Author": {
+      "source": {
+        "object": "authors",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Author",
+          "plural": "Authors"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": {
+        "books": {
+          "cardinality": "many",
+          "target.entity": "Book",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": "book_author_link",
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        }
+      }
+    },
+    "Review": {
+      "source": {
+        "object": "reviews",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "review",
+          "plural": "reviews"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": {
+        "books": {
+          "cardinality": "one",
+          "target.entity": "Book",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        }
+      }
+    },
+    "Comic": {
+      "source": {
+        "object": "comics",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Comic",
+          "plural": "Comics"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterManyOne_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterManyOne_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterOneMany_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": ["categoryName"],
+                "include": null
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterOneMany_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": {
+        "myseries": {
+          "cardinality": "one",
+          "target.entity": "series",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        }
+      }
+    },
+    "Broker": {
+      "source": {
+        "object": "brokers",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": false,
+        "operation": null,
+        "type": {
+          "singular": "Broker",
+          "plural": "Brokers"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "WebsiteUser": {
+      "source": {
+        "object": "website_users",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "websiteUser",
+          "plural": "websiteUsers"
+        }
+      },
+      "rest": {
+        "enabled": false,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "SupportedType": {
+      "source": {
+        "object": "type_table",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "SupportedType",
+          "plural": "SupportedTypes"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "id": "typeid"
+      },
+      "relationships": null
+    },
+    "stocks_price": {
+      "source": {
+        "object": "stocks_price",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "stocks_price",
+          "plural": "stocks_prices"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": ["price"],
+                "include": null
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "Tree": {
+      "source": {
+        "object": "trees",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": false,
+        "operation": null,
+        "type": {
+          "singular": "Tree",
+          "plural": "Trees"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "species": "Scientific Name",
+        "region": "United State\u0027s Region"
+      },
+      "relationships": null
+    },
+    "Shrub": {
+      "source": {
+        "object": "trees",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Shrub",
+          "plural": "Shrubs"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": "/plants",
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "species": "fancyName"
+      },
+      "relationships": null
+    },
+    "Fungus": {
+      "source": {
+        "object": "fungi",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "fungus",
+          "plural": "fungi"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_01",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.region ne \u0027northeast\u0027"
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "spores": "hazards"
+      },
+      "relationships": null
+    },
+    "books_view_all": {
+      "source": {
+        "object": "books_view_all",
+        "type": "view",
+        "parameters": null,
+        "key-fields": ["id"]
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "books_view_all",
+          "plural": "books_view_alls"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": ["get", "post", "put", "patch", "delete"]
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "books_view_with_mapping": {
+      "source": {
+        "object": "books_view_with_mapping",
+        "type": "view",
+        "parameters": null,
+        "key-fields": ["id"]
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "books_view_with_mapping",
+          "plural": "books_view_with_mappings"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "id": "book_id"
+      },
+      "relationships": null
+    },
+    "stocks_view_selected": {
+      "source": {
+        "object": "stocks_view_selected",
+        "type": "view",
+        "parameters": null,
+        "key-fields": ["categoryid", "pieceid"]
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "stocks_view_selected",
+          "plural": "stocks_view_selecteds"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": ["get", "post", "put", "patch", "delete"]
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "books_publishers_view_composite": {
+      "source": {
+        "object": "books_publishers_view_composite",
+        "type": "view",
+        "parameters": null,
+        "key-fields": ["id", "pub_id"]
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "books_publishers_view_composite",
+          "plural": "books_publishers_view_composites"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": ["get", "post", "put", "patch", "delete"]
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "books_publishers_view_composite_insertable": {
+      "source": {
+        "object": "books_publishers_view_composite_insertable",
+        "type": "view",
+        "parameters": null,
+        "key-fields": ["id"]
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "books_publishers_view_composite_insertable",
+          "plural": "books_publishers_view_composite_insertables"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": ["get", "post", "put", "patch", "delete"]
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "Empty": {
+      "source": {
+        "object": "empty_table",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Empty",
+          "plural": "Empties"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "Notebook": {
+      "source": {
+        "object": "notebooks",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Notebook",
+          "plural": "Notebooks"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item ne 1"
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "Journal": {
+      "source": {
+        "object": "journals",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Journal",
+          "plural": "Journals"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "policy_tester_noupdate",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id ne 1"
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "policy_tester_update_noread",
+          "actions": [
+            {
+              "action": "delete",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id eq 1"
+              }
+            },
+            {
+              "action": "read",
+              "fields": {
+                "exclude": ["*"],
+                "include": null
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": {
+                "exclude": [],
+                "include": ["*"]
+              },
+              "policy": {
+                "request": null,
+                "database": "@item.id eq 1"
+              }
+            },
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authorizationHandlerTester",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "ArtOfWar": {
+      "source": {
+        "object": "aow",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": false,
+        "operation": null,
+        "type": {
+          "singular": "ArtOfWar",
+          "plural": "ArtOfWars"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "DetailAssessmentAndPlanning": "\u59CB\u8A08",
+        "WagingWar": "\u4F5C\u6230",
+        "StrategicAttack": "\u8B00\u653B",
+        "NoteNum": "\u252C\u2500\u252C\u30CE( \u00BA _ \u00BA\u30CE)"
+      },
+      "relationships": null
+    },
+    "series": {
+      "source": {
+        "object": "series",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "series",
+          "plural": "series"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterManyOne_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": ["name"],
+                "include": null
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterManyOne_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterOneMany_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterOneMany_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": {
+        "comics": {
+          "cardinality": "many",
+          "target.entity": "Comic",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        }
+      }
+    },
+    "Sales": {
+      "source": {
+        "object": "sales",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Sales",
+          "plural": "Sales"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "GQLmappings": {
+      "source": {
+        "object": "gqlmappings",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "GQLmappings",
+          "plural": "GQLmappings"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "__column1": "column1",
+        "__column2": "column2"
+      },
+      "relationships": null
+    },
+    "Bookmarks": {
+      "source": {
+        "object": "bookmarks",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "Bookmarks",
+          "plural": "Bookmarks"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": null
+    },
+    "MappedBookmarks": {
+      "source": {
+        "object": "mappedbookmarks",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "MappedBookmarks",
+          "plural": "MappedBookmarks"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "*",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "id": "bkid",
+        "bkname": "name"
+      },
+      "relationships": null
+    },
+    "PublisherNF": {
+      "source": {
+        "object": "publishers",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "PublisherNF",
+          "plural": "PublisherNFs"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilter_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilter_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterChained_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterChained_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": ["name"],
+                "include": null
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": null,
+      "relationships": {
+        "books": {
+          "cardinality": "many",
+          "target.entity": "BookNF",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        }
+      }
+    },
+    "BookNF": {
+      "source": {
+        "object": "books",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "bookNF",
+          "plural": "booksNF"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilter_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilter_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterChained_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterChained_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        }
+      ],
+      "mappings": {
+        "id": "id",
+        "title": "title"
+      },
+      "relationships": {
+        "publishers": {
+          "cardinality": "one",
+          "target.entity": "PublisherNF",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        },
+        "websiteplacement": {
+          "cardinality": "one",
+          "target.entity": "BookWebsitePlacement",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        },
+        "reviews": {
+          "cardinality": "many",
+          "target.entity": "Review",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": null,
+          "linking.source.fields": [],
+          "linking.target.fields": []
+        },
+        "authors": {
+          "cardinality": "many",
+          "target.entity": "AuthorNF",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": "book_author_link",
+          "linking.source.fields": ["book_id"],
+          "linking.target.fields": ["author_id"]
+        }
+      }
+    },
     "AuthorNF": {
-  "source": {
-    "object": "authors",
-    "type": "table",
-    "parameters": null,
-    "key-fields": null
-  },
-  "graphql": {
-    "enabled": true,
-    "operation": null,
-    "type": {
-      "singular": "AuthorNF",
-      "plural": "AuthorNFs"
-    }
-  },
-  "rest": {
-    "enabled": true,
-    "path": null,
-    "methods": []
-  },
-  "permissions": [
-    {
-      "role": "authenticated",
-      "actions": [
+      "source": {
+        "object": "authors",
+        "type": "table",
+        "parameters": null,
+        "key-fields": null
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": null,
+        "type": {
+          "singular": "AuthorNF",
+          "plural": "AuthorNFs"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "path": null,
+        "methods": []
+      },
+      "permissions": [
         {
-          "action": "create",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "update",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            },
+            {
+              "action": "delete",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         },
         {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+          "role": "TestNestedFilter_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "create",
+              "fields": {
+                "exclude": ["name"],
+                "include": null
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         },
         {
-          "action": "update",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
+          "role": "TestNestedFilter_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": ["name"],
+                "include": null
+              },
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         },
         {
-          "action": "delete",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilter_EntityReadForbidden",
-      "actions": [
+          "role": "TestNestedFilterChained_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
+        },
         {
-          "action": "create",
-          "fields": {
-            "exclude": [
-              "name"
-            ],
-            "include": null
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
+          "role": "TestNestedFilterChained_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": null,
+              "policy": {
+                "request": null,
+                "database": null
+              }
+            }
+          ]
         }
-      ]
-    },
-    {
-      "role": "TestNestedFilter_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": {
-            "exclude": [
-              "name"
-            ],
-            "include": null
-          },
-          "policy": {
-            "request": null,
-            "database": null
-          }
+      ],
+      "mappings": null,
+      "relationships": {
+        "books": {
+          "cardinality": "many",
+          "target.entity": "BookNF",
+          "source.fields": [],
+          "target.fields": [],
+          "linking.object": "book_author_link",
+          "linking.source.fields": [],
+          "linking.target.fields": []
         }
-      ]
-    },
-    {
-      "role": "TestNestedFilterChained_EntityReadForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
-    },
-    {
-      "role": "TestNestedFilterChained_ColumnForbidden",
-      "actions": [
-        {
-          "action": "read",
-          "fields": null,
-          "policy": {
-            "request": null,
-            "database": null
-          }
-        }
-      ]
+      }
     }
-  ],
-  "mappings": null,
-  "relationships": {
-    "books": {
-      "cardinality": "many",
-      "target.entity": "BookNF",
-      "source.fields": [],
-      "target.fields": [],
-      "linking.object": "book_author_link",
-      "linking.source.fields": [],
-      "linking.target.fields": []
-    }
-  }
-}
   }
 }

--- a/src/Service.Tests/dab-config.PostgreSql.json
+++ b/src/Service.Tests/dab-config.PostgreSql.json
@@ -34,3485 +34,3485 @@
   },
   "entities": {
     "Publisher": {
-      "source": {
-        "object": "publishers",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Publisher",
-          "plural": "Publishers"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_01",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id eq 1940"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_02",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 1940"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_03",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 1940"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_04",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id eq 1940"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_06",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id eq 1940"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "database_policy_tester",
-          "actions": [
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 1234"
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 1234 or @item.id gt 1940"
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "books": {
-          "cardinality": "many",
-          "target.entity": "Book",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
-    },
-    "Stock": {
-      "source": {
-        "object": "stocks",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Stock",
-          "plural": "Stocks"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": "/commodities",
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "database_policy_tester",
-          "actions": [
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": "@item.pieceid ne 1"
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "stocks_price": {
-          "cardinality": "one",
-          "target.entity": "stocks_price",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
-    },
-    "Book": {
-      "source": {
-        "object": "books",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "book",
-          "plural": "books"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_01",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.title eq \u0027Policy-Test-01\u0027"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_02",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.title ne \u0027Policy-Test-01\u0027"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_03",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.title eq \u0027Policy-Test-01\u0027"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_04",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.title ne \u0027Policy-Test-01\u0027"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_05",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 9"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_06",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 10"
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_07",
-          "actions": [
-            {
-              "action": "delete",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 9"
-              }
-            },
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 9"
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_08",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id eq 9"
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id eq 9"
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "id": "id",
-        "title": "title"
-      },
-      "relationships": {
-        "publishers": {
-          "cardinality": "one",
-          "target.entity": "Publisher",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        },
-        "websiteplacement": {
-          "cardinality": "one",
-          "target.entity": "BookWebsitePlacement",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        },
-        "reviews": {
-          "cardinality": "many",
-          "target.entity": "Review",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        },
-        "authors": {
-          "cardinality": "many",
-          "target.entity": "Author",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": "book_author_link",
-          "linking.source.fields": [
-            "book_id"
-          ],
-          "linking.target.fields": [
-            "author_id"
-          ]
-        }
-      }
-    },
-    "BookWebsitePlacement": {
-      "source": {
-        "object": "book_website_placements",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "BookWebsitePlacement",
-          "plural": "BookWebsitePlacements"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "delete",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@claims.userId eq @item.id"
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "books": {
-          "cardinality": "one",
-          "target.entity": "Book",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
-    },
-    "Author": {
-      "source": {
-        "object": "authors",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Author",
-          "plural": "Authors"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "books": {
-          "cardinality": "many",
-          "target.entity": "Book",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": "book_author_link",
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
-    },
-    "Review": {
-      "source": {
-        "object": "reviews",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "review",
-          "plural": "reviews"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "books": {
-          "cardinality": "one",
-          "target.entity": "Book",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
-    },
-    "Comic": {
-      "source": {
-        "object": "comics",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Comic",
-          "plural": "Comics"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterManyOne_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterManyOne_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterOneMany_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [
-                  "categoryName"
-                ],
-                "include": null
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterOneMany_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "myseries": {
-          "cardinality": "one",
-          "target.entity": "series",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
-    },
-    "Broker": {
-      "source": {
-        "object": "brokers",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": false,
-        "operation": null,
-        "type": {
-          "singular": "Broker",
-          "plural": "Brokers"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "WebsiteUser": {
-      "source": {
-        "object": "website_users",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "websiteUser",
-          "plural": "websiteUsers"
-        }
-      },
-      "rest": {
-        "enabled": false,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "SupportedType": {
-      "source": {
-        "object": "type_table",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "SupportedType",
-          "plural": "SupportedTypes"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "id": "typeid"
-      },
-      "relationships": null
-    },
-    "stocks_price": {
-      "source": {
-        "object": "stocks_price",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "stocks_price",
-          "plural": "stocks_prices"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [
-                  "price"
-                ],
-                "include": null
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "Tree": {
-      "source": {
-        "object": "trees",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": false,
-        "operation": null,
-        "type": {
-          "singular": "Tree",
-          "plural": "Trees"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "species": "Scientific Name",
-        "region": "United State\u0027s Region"
-      },
-      "relationships": null
-    },
-    "Shrub": {
-      "source": {
-        "object": "trees",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Shrub",
-          "plural": "Shrubs"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": "/plants",
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "species": "fancyName"
-      },
-      "relationships": null
-    },
-    "Fungus": {
-      "source": {
-        "object": "fungi",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "fungus",
-          "plural": "fungi"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_01",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.region ne \u0027northeast\u0027"
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "spores": "hazards"
-      },
-      "relationships": null
-    },
-    "books_view_all": {
-      "source": {
-        "object": "books_view_all",
-        "type": "view",
-        "parameters": null,
-        "key-fields": [
-          "id"
-        ]
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "books_view_all",
-          "plural": "books_view_alls"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": [
-          "get",
-          "post",
-          "put",
-          "patch",
-          "delete"
-        ]
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "books_view_with_mapping": {
-      "source": {
-        "object": "books_view_with_mapping",
-        "type": "view",
-        "parameters": null,
-        "key-fields": [
-          "id"
-        ]
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "books_view_with_mapping",
-          "plural": "books_view_with_mappings"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "id": "book_id"
-      },
-      "relationships": null
-    },
-    "stocks_view_selected": {
-      "source": {
-        "object": "stocks_view_selected",
-        "type": "view",
-        "parameters": null,
-        "key-fields": [
-          "categoryid",
-          "pieceid"
-        ]
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "stocks_view_selected",
-          "plural": "stocks_view_selecteds"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": [
-          "get",
-          "post",
-          "put",
-          "patch",
-          "delete"
-        ]
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "books_publishers_view_composite": {
-      "source": {
-        "object": "books_publishers_view_composite",
-        "type": "view",
-        "parameters": null,
-        "key-fields": [
-          "id",
-          "pub_id"
-        ]
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "books_publishers_view_composite",
-          "plural": "books_publishers_view_composites"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": [
-          "get",
-          "post",
-          "put",
-          "patch",
-          "delete"
-        ]
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "books_publishers_view_composite_insertable": {
-      "source": {
-        "object": "books_publishers_view_composite_insertable",
-        "type": "view",
-        "parameters": null,
-        "key-fields": [
-          "id"
-        ]
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "books_publishers_view_composite_insertable",
-          "plural": "books_publishers_view_composite_insertables"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": [
-          "get",
-          "post",
-          "put",
-          "patch",
-          "delete"
-        ]
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "Empty": {
-      "source": {
-        "object": "empty_table",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Empty",
-          "plural": "Empties"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "Notebook": {
-      "source": {
-        "object": "notebooks",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Notebook",
-          "plural": "Notebooks"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item ne 1"
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "Journal": {
-      "source": {
-        "object": "journals",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Journal",
-          "plural": "Journals"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "policy_tester_noupdate",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id ne 1"
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "policy_tester_update_noread",
-          "actions": [
-            {
-              "action": "delete",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id eq 1"
-              }
-            },
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [
-                  "*"
-                ],
-                "include": null
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "*"
-                ]
-              },
-              "policy": {
-                "request": null,
-                "database": "@item.id eq 1"
-              }
-            },
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authorizationHandlerTester",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "ArtOfWar": {
-      "source": {
-        "object": "aow",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": false,
-        "operation": null,
-        "type": {
-          "singular": "ArtOfWar",
-          "plural": "ArtOfWars"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "DetailAssessmentAndPlanning": "\u59CB\u8A08",
-        "WagingWar": "\u4F5C\u6230",
-        "StrategicAttack": "\u8B00\u653B",
-        "NoteNum": "\u252C\u2500\u252C\u30CE( \u00BA _ \u00BA\u30CE)"
-      },
-      "relationships": null
-    },
-    "series": {
-      "source": {
-        "object": "series",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "series",
-          "plural": "series"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterManyOne_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [
-                  "name"
-                ],
-                "include": null
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterManyOne_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterOneMany_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterOneMany_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "comics": {
-          "cardinality": "many",
-          "target.entity": "Comic",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
-    },
-    "Sales": {
-      "source": {
-        "object": "sales",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Sales",
-          "plural": "Sales"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "GQLmappings": {
-      "source": {
-        "object": "gqlmappings",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "GQLmappings",
-          "plural": "GQLmappings"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "__column1": "column1",
-        "__column2": "column2"
-      },
-      "relationships": null
-    },
-    "Bookmarks": {
-      "source": {
-        "object": "bookmarks",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "Bookmarks",
-          "plural": "Bookmarks"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": null
-    },
-    "MappedBookmarks": {
-      "source": {
-        "object": "mappedbookmarks",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "MappedBookmarks",
-          "plural": "MappedBookmarks"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "anonymous",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "*",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "id": "bkid",
-        "bkname": "name"
-      },
-      "relationships": null
-    },
-    "PublisherNF": {
-      "source": {
-        "object": "publishers",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "PublisherNF",
-          "plural": "PublisherNFs"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilter_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilter_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterChained_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterChained_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [
-                  "name"
-                ],
-                "include": null
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "books": {
-          "cardinality": "many",
-          "target.entity": "BookNF",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
-    },
-    "BookNF": {
-      "source": {
-        "object": "books",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "bookNF",
-          "plural": "booksNF"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilter_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilter_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterChained_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterChained_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": {
-        "id": "id",
-        "title": "title"
-      },
-      "relationships": {
-        "publishers": {
-          "cardinality": "one",
-          "target.entity": "PublisherNF",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        },
-        "websiteplacement": {
-          "cardinality": "one",
-          "target.entity": "BookWebsitePlacement",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        },
-        "reviews": {
-          "cardinality": "many",
-          "target.entity": "Review",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": null,
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        },
-        "authors": {
-          "cardinality": "many",
-          "target.entity": "AuthorNF",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": "book_author_link",
-          "linking.source.fields": [
-            "book_id"
-          ],
-          "linking.target.fields": [
-            "author_id"
-          ]
-        }
-      }
-    },
-    "AuthorNF": {
-      "source": {
-        "object": "authors",
-        "type": "table",
-        "parameters": null,
-        "key-fields": null
-      },
-      "graphql": {
-        "enabled": true,
-        "operation": null,
-        "type": {
-          "singular": "AuthorNF",
-          "plural": "AuthorNFs"
-        }
-      },
-      "rest": {
-        "enabled": true,
-        "path": null,
-        "methods": []
-      },
-      "permissions": [
-        {
-          "role": "authenticated",
-          "actions": [
-            {
-              "action": "create",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "update",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            },
-            {
-              "action": "delete",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilter_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "create",
-              "fields": {
-                "exclude": [
-                  "name"
-                ],
-                "include": null
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilter_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": {
-                "exclude": [
-                  "name"
-                ],
-                "include": null
-              },
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterChained_EntityReadForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        },
-        {
-          "role": "TestNestedFilterChained_ColumnForbidden",
-          "actions": [
-            {
-              "action": "read",
-              "fields": null,
-              "policy": {
-                "request": null,
-                "database": null
-              }
-            }
-          ]
-        }
-      ],
-      "mappings": null,
-      "relationships": {
-        "books": {
-          "cardinality": "many",
-          "target.entity": "BookNF",
-          "source.fields": [],
-          "target.fields": [],
-          "linking.object": "book_author_link",
-          "linking.source.fields": [],
-          "linking.target.fields": []
-        }
-      }
+  "source": {
+    "object": "publishers",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Publisher",
+      "plural": "Publishers"
     }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_01",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id eq 1940"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_02",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 1940"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_03",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 1940"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_04",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id eq 1940"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_06",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id eq 1940"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "database_policy_tester",
+      "actions": [
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 1234"
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 1234 or @item.id gt 1940"
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "books": {
+      "cardinality": "many",
+      "target.entity": "Book",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+},
+    "Stock": {
+  "source": {
+    "object": "stocks",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Stock",
+      "plural": "Stocks"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": "/commodities",
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "database_policy_tester",
+      "actions": [
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": "@item.pieceid ne 1"
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "stocks_price": {
+      "cardinality": "one",
+      "target.entity": "stocks_price",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+},
+    "Book": {
+  "source": {
+    "object": "books",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "book",
+      "plural": "books"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_01",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.title eq \u0027Policy-Test-01\u0027"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_02",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.title ne \u0027Policy-Test-01\u0027"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_03",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.title eq \u0027Policy-Test-01\u0027"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_04",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.title ne \u0027Policy-Test-01\u0027"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_05",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 9"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_06",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 10"
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_07",
+      "actions": [
+        {
+          "action": "delete",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 9"
+          }
+        },
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 9"
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_08",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id eq 9"
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id eq 9"
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "id": "id",
+    "title": "title"
+  },
+  "relationships": {
+    "publishers": {
+      "cardinality": "one",
+      "target.entity": "Publisher",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    },
+    "websiteplacement": {
+      "cardinality": "one",
+      "target.entity": "BookWebsitePlacement",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    },
+    "reviews": {
+      "cardinality": "many",
+      "target.entity": "Review",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    },
+    "authors": {
+      "cardinality": "many",
+      "target.entity": "Author",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": "book_author_link",
+      "linking.source.fields": [
+        "book_id"
+      ],
+      "linking.target.fields": [
+        "author_id"
+      ]
+    }
+  }
+},
+    "BookWebsitePlacement": {
+  "source": {
+    "object": "book_website_placements",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "BookWebsitePlacement",
+      "plural": "BookWebsitePlacements"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "delete",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@claims.userId eq @item.id"
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "books": {
+      "cardinality": "one",
+      "target.entity": "Book",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+},
+    "Author": {
+  "source": {
+    "object": "authors",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Author",
+      "plural": "Authors"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "books": {
+      "cardinality": "many",
+      "target.entity": "Book",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": "book_author_link",
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+},
+    "Review": {
+  "source": {
+    "object": "reviews",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "review",
+      "plural": "reviews"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "books": {
+      "cardinality": "one",
+      "target.entity": "Book",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+},
+    "Comic": {
+  "source": {
+    "object": "comics",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Comic",
+      "plural": "Comics"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterManyOne_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterManyOne_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterOneMany_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [
+              "categoryName"
+            ],
+            "include": null
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterOneMany_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "myseries": {
+      "cardinality": "one",
+      "target.entity": "series",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+},
+    "Broker": {
+  "source": {
+    "object": "brokers",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": false,
+    "operation": null,
+    "type": {
+      "singular": "Broker",
+      "plural": "Brokers"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "WebsiteUser": {
+  "source": {
+    "object": "website_users",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "websiteUser",
+      "plural": "websiteUsers"
+    }
+  },
+  "rest": {
+    "enabled": false,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "SupportedType": {
+  "source": {
+    "object": "type_table",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "SupportedType",
+      "plural": "SupportedTypes"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "id": "typeid"
+  },
+  "relationships": null
+},
+    "stocks_price": {
+  "source": {
+    "object": "stocks_price",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "stocks_price",
+      "plural": "stocks_prices"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [
+              "price"
+            ],
+            "include": null
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "Tree": {
+  "source": {
+    "object": "trees",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": false,
+    "operation": null,
+    "type": {
+      "singular": "Tree",
+      "plural": "Trees"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "species": "Scientific Name",
+    "region": "United State\u0027s Region"
+  },
+  "relationships": null
+},
+    "Shrub": {
+  "source": {
+    "object": "trees",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Shrub",
+      "plural": "Shrubs"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": "/plants",
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "species": "fancyName"
+  },
+  "relationships": null
+},
+    "Fungus": {
+  "source": {
+    "object": "fungi",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "fungus",
+      "plural": "fungi"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_01",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.region ne \u0027northeast\u0027"
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "spores": "hazards"
+  },
+  "relationships": null
+},
+    "books_view_all": {
+  "source": {
+    "object": "books_view_all",
+    "type": "view",
+    "parameters": null,
+    "key-fields": [
+      "id"
+    ]
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "books_view_all",
+      "plural": "books_view_alls"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": [
+      "get",
+      "post",
+      "put",
+      "patch",
+      "delete"
+    ]
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "books_view_with_mapping": {
+  "source": {
+    "object": "books_view_with_mapping",
+    "type": "view",
+    "parameters": null,
+    "key-fields": [
+      "id"
+    ]
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "books_view_with_mapping",
+      "plural": "books_view_with_mappings"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "id": "book_id"
+  },
+  "relationships": null
+},
+    "stocks_view_selected": {
+  "source": {
+    "object": "stocks_view_selected",
+    "type": "view",
+    "parameters": null,
+    "key-fields": [
+      "categoryid",
+      "pieceid"
+    ]
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "stocks_view_selected",
+      "plural": "stocks_view_selecteds"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": [
+      "get",
+      "post",
+      "put",
+      "patch",
+      "delete"
+    ]
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "books_publishers_view_composite": {
+  "source": {
+    "object": "books_publishers_view_composite",
+    "type": "view",
+    "parameters": null,
+    "key-fields": [
+      "id",
+      "pub_id"
+    ]
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "books_publishers_view_composite",
+      "plural": "books_publishers_view_composites"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": [
+      "get",
+      "post",
+      "put",
+      "patch",
+      "delete"
+    ]
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "books_publishers_view_composite_insertable": {
+  "source": {
+    "object": "books_publishers_view_composite_insertable",
+    "type": "view",
+    "parameters": null,
+    "key-fields": [
+      "id"
+    ]
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "books_publishers_view_composite_insertable",
+      "plural": "books_publishers_view_composite_insertables"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": [
+      "get",
+      "post",
+      "put",
+      "patch",
+      "delete"
+    ]
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "Empty": {
+  "source": {
+    "object": "empty_table",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Empty",
+      "plural": "Empties"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "Notebook": {
+  "source": {
+    "object": "notebooks",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Notebook",
+      "plural": "Notebooks"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item ne 1"
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "Journal": {
+  "source": {
+    "object": "journals",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Journal",
+      "plural": "Journals"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "policy_tester_noupdate",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id ne 1"
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "policy_tester_update_noread",
+      "actions": [
+        {
+          "action": "delete",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id eq 1"
+          }
+        },
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [
+              "*"
+            ],
+            "include": null
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": {
+            "exclude": [],
+            "include": [
+              "*"
+            ]
+          },
+          "policy": {
+            "request": null,
+            "database": "@item.id eq 1"
+          }
+        },
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authorizationHandlerTester",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "ArtOfWar": {
+  "source": {
+    "object": "aow",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": false,
+    "operation": null,
+    "type": {
+      "singular": "ArtOfWar",
+      "plural": "ArtOfWars"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "DetailAssessmentAndPlanning": "\u59CB\u8A08",
+    "WagingWar": "\u4F5C\u6230",
+    "StrategicAttack": "\u8B00\u653B",
+    "NoteNum": "\u252C\u2500\u252C\u30CE( \u00BA _ \u00BA\u30CE)"
+  },
+  "relationships": null
+},
+    "series": {
+  "source": {
+    "object": "series",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "series",
+      "plural": "series"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterManyOne_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [
+              "name"
+            ],
+            "include": null
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterManyOne_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterOneMany_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterOneMany_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "comics": {
+      "cardinality": "many",
+      "target.entity": "Comic",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+},
+    "Sales": {
+  "source": {
+    "object": "sales",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Sales",
+      "plural": "Sales"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "GQLmappings": {
+  "source": {
+    "object": "gqlmappings",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "GQLmappings",
+      "plural": "GQLmappings"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "__column1": "column1",
+    "__column2": "column2"
+  },
+  "relationships": null
+},
+    "Bookmarks": {
+  "source": {
+    "object": "bookmarks",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "Bookmarks",
+      "plural": "Bookmarks"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": null
+},
+    "MappedBookmarks": {
+  "source": {
+    "object": "mappedbookmarks",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "MappedBookmarks",
+      "plural": "MappedBookmarks"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "anonymous",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "*",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "id": "bkid",
+    "bkname": "name"
+  },
+  "relationships": null
+},
+    "PublisherNF": {
+  "source": {
+    "object": "publishers",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "PublisherNF",
+      "plural": "PublisherNFs"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilter_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilter_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterChained_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterChained_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [
+              "name"
+            ],
+            "include": null
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "books": {
+      "cardinality": "many",
+      "target.entity": "BookNF",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+},
+    "BookNF": {
+  "source": {
+    "object": "books",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "bookNF",
+      "plural": "booksNF"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilter_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilter_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterChained_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterChained_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": {
+    "id": "id",
+    "title": "title"
+  },
+  "relationships": {
+    "publishers": {
+      "cardinality": "one",
+      "target.entity": "PublisherNF",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    },
+    "websiteplacement": {
+      "cardinality": "one",
+      "target.entity": "BookWebsitePlacement",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    },
+    "reviews": {
+      "cardinality": "many",
+      "target.entity": "Review",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": null,
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    },
+    "authors": {
+      "cardinality": "many",
+      "target.entity": "AuthorNF",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": "book_author_link",
+      "linking.source.fields": [
+        "book_id"
+      ],
+      "linking.target.fields": [
+        "author_id"
+      ]
+    }
+  }
+},
+    "AuthorNF": {
+  "source": {
+    "object": "authors",
+    "type": "table",
+    "parameters": null,
+    "key-fields": null
+  },
+  "graphql": {
+    "enabled": true,
+    "operation": null,
+    "type": {
+      "singular": "AuthorNF",
+      "plural": "AuthorNFs"
+    }
+  },
+  "rest": {
+    "enabled": true,
+    "path": null,
+    "methods": []
+  },
+  "permissions": [
+    {
+      "role": "authenticated",
+      "actions": [
+        {
+          "action": "create",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "update",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        },
+        {
+          "action": "delete",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilter_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "create",
+          "fields": {
+            "exclude": [
+              "name"
+            ],
+            "include": null
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilter_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": {
+            "exclude": [
+              "name"
+            ],
+            "include": null
+          },
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterChained_EntityReadForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    },
+    {
+      "role": "TestNestedFilterChained_ColumnForbidden",
+      "actions": [
+        {
+          "action": "read",
+          "fields": null,
+          "policy": {
+            "request": null,
+            "database": null
+          }
+        }
+      ]
+    }
+  ],
+  "mappings": null,
+  "relationships": {
+    "books": {
+      "cardinality": "many",
+      "target.entity": "BookNF",
+      "source.fields": [],
+      "target.fields": [],
+      "linking.object": "book_author_link",
+      "linking.source.fields": [],
+      "linking.target.fields": []
+    }
+  }
+}
   }
 }

--- a/src/Service/Authorization/AuthorizationResolver.cs
+++ b/src/Service/Authorization/AuthorizationResolver.cs
@@ -231,10 +231,7 @@ namespace Azure.DataApiBuilder.Service.Authorization
         {
             foreach ((string entityName, Entity entity) in runtimeConfig.Entities)
             {
-                EntityMetadata entityToRoleMap = new()
-                {
-                    ObjectType = entity.Source.Type,
-                };
+                EntityMetadata entityToRoleMap = new();
 
                 bool isStoredProcedureEntity = entity.Source.Type is EntitySourceType.StoredProcedure;
                 if (isStoredProcedureEntity)
@@ -397,7 +394,7 @@ namespace Azure.DataApiBuilder.Service.Authorization
         /// <param name="operation">operation type.</param>
         /// <param name="sourceType">Type of database object: Table, View, or Stored Procedure.</param>
         /// <returns>IEnumerable of all available operations.</returns>
-        public static IEnumerable<EntityActionOperation> GetAllOperationsForObjectType(EntityActionOperation operation, EntitySourceType sourceType)
+        public static IEnumerable<EntityActionOperation> GetAllOperationsForObjectType(EntityActionOperation operation, EntitySourceType? sourceType)
         {
             if (sourceType is EntitySourceType.StoredProcedure)
             {
@@ -675,7 +672,7 @@ namespace Azure.DataApiBuilder.Service.Authorization
         /// There are only five possible operations
         /// </summary>
         /// <returns>Dictionary: Key - Operation | Value - List of roles.</returns>
-        private static Dictionary<EntityActionOperation, List<string>> CreateOperationToRoleMap(EntitySourceType sourceType)
+        private static Dictionary<EntityActionOperation, List<string>> CreateOperationToRoleMap(EntitySourceType? sourceType)
         {
             if (sourceType is EntitySourceType.StoredProcedure)
             {


### PR DESCRIPTION
When it is a CosmosDB_NoSQL config, the entity 'type' is not important as there are no types in CosmosDB_NoSQL, so we don't want anything there.

Combining this with #1529 will see the value removed from the config entirely
