### PR TITLE
Adding constructor to RunTimeConfigProvider so that we have option to…

### DIFF
--- a/src/Core/Configurations/RuntimeConfigProvider.cs
+++ b/src/Core/Configurations/RuntimeConfigProvider.cs
@@ -52,7 +52,7 @@ public class RuntimeConfigProvider
 
     public RuntimeConfigProvider(RuntimeConfig config)
     {
-       _runtimeConfig = config;
+        _runtimeConfig = config;
     }
 
     /// <summary>
@@ -103,6 +103,15 @@ public class RuntimeConfigProvider
     {
         if (_runtimeConfig is null)
         {
+            // if no runtimeconfig, appropriate loader must be provided.
+            if (_runtimeConfigLoader is null)
+            {
+                throw new DataApiBuilderException(
+                    message: "Runtime config loader isn't setup.",
+                    statusCode: HttpStatusCode.InternalServerError,
+                    subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
+            }
+
             if (_runtimeConfigLoader.TryLoadKnownConfig(out RuntimeConfig? config))
             {
                 _runtimeConfig = config;


### PR DESCRIPTION
… initialize the RuntimeConfigProvider with runtimeconfig if being created dynamically.

## Why make this change?

- Reference associated issue using `#` syntax. e.g. Closes #XX
  - Include summary (1-2 sentences) of linked issue to avoid redirecting reviewers to different pages.
  Need ability to provide a runtimeconfig into runtimeconfigprovider if being initialized dynamically without a .json file.

## What is this change?

- Summary of how your changes work to give reviewers context of your intent.
  Added extra constructor. 
  Made RuntimeConfigLoader nullable as for the case where there is no file to load for, it is not valid. 

## How was this tested?

- [ ] Integration Tests
yes
- [ ] Unit Tests
yes
