### PR TITLE
[BugFix] Handle configs which have missing options for MsSql

### DIFF
--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithAnExistingNameButWithDifferentCase.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithAnExistingNameButWithDifferentCase.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithAnExistingNameButWithDifferentCase.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithAnExistingNameButWithDifferentCase.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_70de36ebf1478d0d.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_70de36ebf1478d0d.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_70de36ebf1478d0d.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_70de36ebf1478d0d.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_9f612e68879149a3.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_9f612e68879149a3.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_9f612e68879149a3.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_9f612e68879149a3.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_bea2d26f3e5462d8.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_bea2d26f3e5462d8.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_bea2d26f3e5462d8.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithPolicyAndFieldProperties_bea2d26f3e5462d8.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesEmpty.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesEmpty.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesEmpty.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesEmpty.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesNotEmpty.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesNotEmpty.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesNotEmpty.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesNotEmpty.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesWithSourceAsStoredProcedure.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesWithSourceAsStoredProcedure.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesWithSourceAsStoredProcedure.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddNewEntityWhenEntitiesWithSourceAsStoredProcedure.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_0c9cbb8942b4a4e5.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_0c9cbb8942b4a4e5.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_0c9cbb8942b4a4e5.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_0c9cbb8942b4a4e5.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_286d268a654ece27.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_286d268a654ece27.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_286d268a654ece27.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_286d268a654ece27.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_3048323e01b42681.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_3048323e01b42681.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_3048323e01b42681.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_3048323e01b42681.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_3440d150a2282b9c.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_3440d150a2282b9c.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_3440d150a2282b9c.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_3440d150a2282b9c.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_381c28d25063be0c.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_381c28d25063be0c.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_381c28d25063be0c.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_381c28d25063be0c.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_458373311f6ed4ed.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_458373311f6ed4ed.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_458373311f6ed4ed.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_458373311f6ed4ed.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_66799c963a6306ae.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_66799c963a6306ae.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_66799c963a6306ae.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_66799c963a6306ae.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_66f598295b8682fd.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_66f598295b8682fd.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_66f598295b8682fd.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_66f598295b8682fd.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_73f95f7e2cd3ed71.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_73f95f7e2cd3ed71.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_73f95f7e2cd3ed71.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_73f95f7e2cd3ed71.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_79d59edde7f6a272.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_79d59edde7f6a272.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_79d59edde7f6a272.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_79d59edde7f6a272.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_7ec82512a1df5293.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_7ec82512a1df5293.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_7ec82512a1df5293.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_7ec82512a1df5293.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_cbb6e5548e4d3535.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_cbb6e5548e4d3535.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_cbb6e5548e4d3535.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_cbb6e5548e4d3535.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_dc629052f38cea32.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_dc629052f38cea32.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_dc629052f38cea32.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_dc629052f38cea32.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_e4a97c7e3507d2c6.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_e4a97c7e3507d2c6.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_e4a97c7e3507d2c6.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_e4a97c7e3507d2c6.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_f8d0d0c2a38bd3b8.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_f8d0d0c2a38bd3b8.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_f8d0d0c2a38bd3b8.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddNewSpWithDifferentRestAndGraphQLOptions_f8d0d0c2a38bd3b8.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/AddEntityTests.TestAddStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.TestAddStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestAddingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestAddingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestAddingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestAddingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestAddingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestAddingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL
+    DatabaseType: MSSQL,
+    Options: {
+      set-session-context: {
+        ValueKind: True
+      }
+    }
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceAsStoredProcedure.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceAsStoredProcedure.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceAsStoredProcedure.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceAsStoredProcedure.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceAsStoredProcedure.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceAsStoredProcedure.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL
+    DatabaseType: MSSQL,
+    Options: {
+      set-session-context: {
+        ValueKind: True
+      }
+    }
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceWithDefaultType.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceWithDefaultType.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceWithDefaultType.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceWithDefaultType.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceWithDefaultType.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithSourceWithDefaultType.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL
+    DatabaseType: MSSQL,
+    Options: {
+      set-session-context: {
+        ValueKind: True
+      }
+    }
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithoutIEnumerables.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithoutIEnumerables.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithoutIEnumerables.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithoutIEnumerables.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithoutIEnumerables.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestConfigGeneratedAfterAddingEntityWithoutIEnumerables.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL
+    DatabaseType: MSSQL,
+    Options: {
+      set-session-context: {
+        ValueKind: True
+      }
+    }
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethods.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethods.verified.txt
@@ -1,11 +1,6 @@
 {
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethods.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethods.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethods.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethods.verified.txt
@@ -1,6 +1,11 @@
 {
   DataSource: {
-    DatabaseType: MSSQL
+    DatabaseType: MSSQL,
+    Options: {
+      set-session-context: {
+        ValueKind: True
+      }
+    }
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
+++ b/src/Cli.Tests/Snapshots/EndToEndTests.TestUpdatingStoredProcedureWithRestMethodsAndGraphQLOperations.verified.txt
@@ -1,6 +1,11 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL
+    DatabaseType: MSSQL,
+    Options: {
+      set-session-context: {
+        ValueKind: True
+      }
+    }
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_036a859f50ce167c.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_036a859f50ce167c.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_036a859f50ce167c.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_036a859f50ce167c.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_103655d39b48d89f.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_103655d39b48d89f.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_103655d39b48d89f.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_103655d39b48d89f.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_442649c7ef2176bd.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_442649c7ef2176bd.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_442649c7ef2176bd.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_442649c7ef2176bd.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_7f2338fdc84aafc3.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_7f2338fdc84aafc3.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_7f2338fdc84aafc3.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_7f2338fdc84aafc3.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_a70c086a74142c82.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_a70c086a74142c82.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_a70c086a74142c82.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_a70c086a74142c82.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_c26902b0e44f97cd.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_c26902b0e44f97cd.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_c26902b0e44f97cd.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestConversionOfSourceObject_c26902b0e44f97cd.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_088d6237033e0a7c.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_088d6237033e0a7c.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_088d6237033e0a7c.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_088d6237033e0a7c.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_3ea32fdef7aed1b4.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_3ea32fdef7aed1b4.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_3ea32fdef7aed1b4.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_3ea32fdef7aed1b4.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_4d25c2c012107597.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_4d25c2c012107597.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_4d25c2c012107597.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityWithPolicyAndFieldProperties_4d25c2c012107597.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdatePolicy.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdatePolicy.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdatePolicy.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdatePolicy.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_10ea92e3b25ab0c9.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_10ea92e3b25ab0c9.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_10ea92e3b25ab0c9.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_10ea92e3b25ab0c9.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_127bb81593f835fe.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_127bb81593f835fe.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_127bb81593f835fe.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_127bb81593f835fe.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_386efa1a113fac6b.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_386efa1a113fac6b.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_386efa1a113fac6b.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_386efa1a113fac6b.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_53db4712d83be8e6.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_53db4712d83be8e6.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_53db4712d83be8e6.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_53db4712d83be8e6.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_5e9ddd8c7c740efd.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_5e9ddd8c7c740efd.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_5e9ddd8c7c740efd.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_5e9ddd8c7c740efd.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_6c5b3bfc72e5878a.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_6c5b3bfc72e5878a.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_6c5b3bfc72e5878a.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_6c5b3bfc72e5878a.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_8398059a743d7027.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_8398059a743d7027.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_8398059a743d7027.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_8398059a743d7027.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_a49380ce6d1fd8ba.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_a49380ce6d1fd8ba.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_a49380ce6d1fd8ba.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_a49380ce6d1fd8ba.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_c9b12fe27be53878.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_c9b12fe27be53878.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_c9b12fe27be53878.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_c9b12fe27be53878.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_d19603117eb8b51b.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_d19603117eb8b51b.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_d19603117eb8b51b.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_d19603117eb8b51b.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_d770d682c5802737.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_d770d682c5802737.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_d770d682c5802737.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_d770d682c5802737.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_ef8cc721c9dfc7e4.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_ef8cc721c9dfc7e4.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_ef8cc721c9dfc7e4.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_ef8cc721c9dfc7e4.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f3897e2254996db0.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f3897e2254996db0.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f3897e2254996db0.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f3897e2254996db0.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f4cadb897fc5b0fe.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f4cadb897fc5b0fe.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f4cadb897fc5b0fe.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f4cadb897fc5b0fe.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f59b2a65fc1e18a3.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f59b2a65fc1e18a3.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f59b2a65fc1e18a3.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateRestAndGraphQLSettingsForStoredProcedures_f59b2a65fc1e18a3.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_574e1995f787740f.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_574e1995f787740f.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_574e1995f787740f.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_574e1995f787740f.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a13a9ca73b21f261.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a13a9ca73b21f261.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a13a9ca73b21f261.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a13a9ca73b21f261.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a5ce76c8bea25cc8.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a5ce76c8bea25cc8.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a5ce76c8bea25cc8.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_a5ce76c8bea25cc8.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_bba111332a1f973f.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_bba111332a1f973f.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_bba111332a1f973f.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateSourceStringToDatabaseSourceObject_bba111332a1f973f.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceKeyFields.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceKeyFields.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceKeyFields.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceKeyFields.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceName.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceName.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceName.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceName.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceParameters.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceParameters.verified.txt
@@ -3,7 +3,7 @@
     DatabaseType: MSSQL,
     Options: {
       set-session-context: {
-        ValueKind: True
+        ValueKind: False
       }
     }
   },

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceParameters.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.UpdateDatabaseSourceParameters.verified.txt
@@ -1,11 +1,6 @@
 ﻿{
   DataSource: {
-    DatabaseType: MSSQL,
-    Options: {
-      set-session-context: {
-        ValueKind: False
-      }
-    }
+    DatabaseType: MSSQL
   },
   Runtime: {
     Rest: {

--- a/src/Cli.Tests/TestHelper.cs
+++ b/src/Cli.Tests/TestHelper.cs
@@ -70,10 +70,7 @@ namespace Cli.Tests
         public const string SAMPLE_SCHEMA_DATA_SOURCE = SCHEMA_PROPERTY + "," + @"
             ""data-source"": {
               ""database-type"": ""mssql"",
-              ""connection-string"": ""testconnectionstring"",
-              ""options"":{
-                ""set-session-context"": true
-                }
+              ""connection-string"": ""testconnectionstring""
             }
         ";
 

--- a/src/Config/ObjectModel/DataSource.cs
+++ b/src/Config/ObjectModel/DataSource.cs
@@ -12,40 +12,62 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 /// </summary>
 /// <param name="DatabaseType">Type of database to use.</param>
 /// <param name="ConnectionString">Connection string to access the database.</param>
-/// <param name="Options">Custom options for the specific database. If there are no options this will be empty.</param>
-public record DataSource(DatabaseType DatabaseType, string ConnectionString, Dictionary<string, JsonElement> Options)
+/// <param name="Options">Custom options for the specific database. If there are no options, this could be null.</param>
+public record DataSource(DatabaseType DatabaseType, string ConnectionString, Dictionary<string, JsonElement>? Options)
 {
     /// <summary>
     /// Converts the <c>Options</c> dictionary into a typed options object.
+    /// May return null if the dictionary is null.
     /// </summary>
     /// <typeparam name="TOptionType">The strongly typed object for Options.</typeparam>
     /// <returns>The strongly typed representation of Options.</returns>
     /// <exception cref="NotSupportedException">Thrown when the provided <c>TOptionType</c> is not supported for parsing.</exception>
-    public TOptionType GetTypedOptions<TOptionType>() where TOptionType : IDataSourceOptions
+    public TOptionType? GetTypedOptions<TOptionType>() where TOptionType : IDataSourceOptions
     {
         HyphenatedNamingPolicy namingPolicy = new();
 
         if (typeof(TOptionType).IsAssignableFrom(typeof(CosmosDbNoSQLDataSourceOptions)))
         {
-            return (TOptionType)(object)new CosmosDbNoSQLDataSourceOptions(
-                    Database: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Database))),
-                    Container: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Container))),
-                    Schema: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Schema))),
-                    // The "raw" schema will be provided via the controller to setup config, rather than parsed from the JSON file.
-                    GraphQLSchema: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.GraphQLSchema))));
+            return Options is not null ?
+                (TOptionType)(object)new CosmosDbNoSQLDataSourceOptions(
+                Database: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Database))),
+                Container: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Container))),
+                Schema: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Schema))),
+                // The "raw" schema will be provided via the controller to setup config, rather than parsed from the JSON file.
+                GraphQLSchema: ReadStringOption(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.GraphQLSchema))))
+                : default;
         }
 
         if (typeof(TOptionType).IsAssignableFrom(typeof(MsSqlOptions)))
         {
-            return (TOptionType)(object)new MsSqlOptions(
-                SetSessionContext: ReadBoolOption(namingPolicy.ConvertName(nameof(MsSqlOptions.SetSessionContext))));
+            return Options is not null ?
+                (TOptionType)(object)new MsSqlOptions(
+                SetSessionContext: ReadBoolOption(namingPolicy.ConvertName(nameof(MsSqlOptions.SetSessionContext))))
+                : default;
         }
 
         throw new NotSupportedException($"The type {typeof(TOptionType).FullName} is not a supported strongly typed options object");
     }
 
-    private string? ReadStringOption(string option) => Options.ContainsKey(option) ? Options[option].GetString() : null;
-    private bool ReadBoolOption(string option) => Options.ContainsKey(option) ? Options[option].GetBoolean() : false;
+    private string? ReadStringOption(string option)
+    {
+        if (Options is not null && Options.TryGetValue(option, out JsonElement value))
+        {
+            return value.GetString();
+        }
+
+        return null;
+    }
+
+    private bool ReadBoolOption(string option)
+    {
+        if (Options is not null && Options.TryGetValue(option, out JsonElement value))
+        {
+            return value.GetBoolean();
+        }
+
+        return false;
+    }
 
     [JsonIgnore]
     public string DatabaseTypeNotSupportedMessage => $"The provided database-type value: {DatabaseType} is currently not supported. Please check the configuration file.";

--- a/src/Config/ObjectModel/DataSource.cs
+++ b/src/Config/ObjectModel/DataSource.cs
@@ -40,10 +40,8 @@ public record DataSource(DatabaseType DatabaseType, string ConnectionString, Dic
 
         if (typeof(TOptionType).IsAssignableFrom(typeof(MsSqlOptions)))
         {
-            return Options is not null ?
-                (TOptionType)(object)new MsSqlOptions(
-                SetSessionContext: ReadBoolOption(namingPolicy.ConvertName(nameof(MsSqlOptions.SetSessionContext))))
-                : default;
+            return (TOptionType)(object)new MsSqlOptions(
+                SetSessionContext: ReadBoolOption(namingPolicy.ConvertName(nameof(MsSqlOptions.SetSessionContext))));
         }
 
         throw new NotSupportedException($"The type {typeof(TOptionType).FullName} is not a supported strongly typed options object");

--- a/src/Core/Configurations/RuntimeConfigProvider.cs
+++ b/src/Core/Configurations/RuntimeConfigProvider.cs
@@ -227,11 +227,19 @@ public class RuntimeConfigProvider
 
         HyphenatedNamingPolicy namingPolicy = new();
 
-        Dictionary<string, JsonElement> options = new(runtimeConfig.DataSource.Options)
+        Dictionary<string, JsonElement> options;
+        if (runtimeConfig.DataSource.Options is not null)
         {
-            // push the "raw" GraphQL schema into the options to pull out later when requested
-            { namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.GraphQLSchema)), JsonSerializer.SerializeToElement(schema) }
-        };
+            options = new(runtimeConfig.DataSource.Options)
+            {
+                // push the "raw" GraphQL schema into the options to pull out later when requested
+                { namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.GraphQLSchema)), JsonSerializer.SerializeToElement(schema) }
+            };
+        }
+        else
+        {
+            throw new ArgumentException($"'{nameof(CosmosDbNoSQLDataSourceOptions)}' cannot be null or empty.", nameof(CosmosDbNoSQLDataSourceOptions));
+        }
 
         // SWA may provide CosmosDB database name in connectionString
         string? database = dbConnectionStringBuilder.ContainsKey("Database") ? (string)dbConnectionStringBuilder["Database"] : null;

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -1053,7 +1053,9 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         {
             GraphQLRuntimeOptions graphqlOptions = new(Path: graphQLConfiguredPath);
 
-            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), new());
+            DataSource dataSource = new(DatabaseType.MSSQL,
+                GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL),
+                Options: null);
 
             RuntimeConfig configuration = InitMinimalRuntimeConfig(dataSource, graphqlOptions, new());
             const string CUSTOM_CONFIG = "custom-config.json";
@@ -1268,7 +1270,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             GraphQLRuntimeOptions graphqlOptions = new(Enabled: isGraphQLEnabled);
             RestRuntimeOptions restRuntimeOptions = new(Enabled: isRestEnabled);
 
-            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), new());
+            DataSource dataSource = new(DatabaseType.MSSQL,
+                GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), Options: null);
 
             RuntimeConfig configuration = InitMinimalRuntimeConfig(dataSource, graphqlOptions, restRuntimeOptions);
             const string CUSTOM_CONFIG = "custom-config.json";
@@ -1336,7 +1339,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         [TestMethod, TestCategory(TestCategory.MSSQL)]
         public async Task TestEngineSupportViewsWithoutKeyFieldsInConfigForMsSQL()
         {
-            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), new());
+            DataSource dataSource = new(DatabaseType.MSSQL,
+                GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), Options: null);
             Entity viewEntity = new(
                 Source: new("books_view_all", EntitySourceType.Table, null, null),
                 Rest: new(EntityRestOptions.DEFAULT_SUPPORTED_VERBS),
@@ -1468,7 +1472,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             GraphQLRuntimeOptions graphqlOptions = new(AllowIntrospection: enableIntrospection);
             RestRuntimeOptions restRuntimeOptions = new();
 
-            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), new());
+            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), Options: null);
 
             RuntimeConfig configuration = InitMinimalRuntimeConfig(dataSource, graphqlOptions, restRuntimeOptions);
             const string CUSTOM_CONFIG = "custom-config.json";
@@ -1520,7 +1524,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             GraphQLRuntimeOptions graphqlOptions = new(Enabled: globalGraphQLEnabled);
             RestRuntimeOptions restRuntimeOptions = new(Enabled: true);
 
-            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), new());
+            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), Options: null);
 
             // Configure Entity for testing
             Dictionary<string, string> mappings = new()
@@ -1593,7 +1597,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             string expectedOpenApiTargetContent)
         {
             string swaggerEndpoint = "/swagger";
-            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), new());
+            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), Options: null);
 
             RuntimeConfig configuration = InitMinimalRuntimeConfig(dataSource: dataSource, new(), new(Path: customRestPath));
             configuration = configuration
@@ -1791,7 +1795,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         /// <param name="entityMap">Collection of entityName -> Entity object.</param>
         private static void CreateCustomConfigFile(bool globalRestEnabled, Dictionary<string, Entity> entityMap)
         {
-            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), new());
+            DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), Options: null);
 
             RuntimeConfig runtimeConfig = new(
                 Schema: string.Empty,

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -767,11 +767,13 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
             ConfigurationPostParameters expectedParameters = GetCosmosConfigurationParameters();
             Assert.AreEqual(DatabaseType.CosmosDB_NoSQL, configuration.DataSource.DatabaseType, "Expected CosmosDB_NoSQL database type after configuring the runtime with CosmosDB_NoSQL settings.");
-            Assert.AreEqual(expectedParameters.Schema, configuration.DataSource.GetTypedOptions<CosmosDbNoSQLDataSourceOptions>().GraphQLSchema, "Expected the schema in the configuration to match the one sent to the configuration endpoint.");
+            CosmosDbNoSQLDataSourceOptions options = configuration.DataSource.GetTypedOptions<CosmosDbNoSQLDataSourceOptions>();
+            Assert.IsNotNull(options);
+            Assert.AreEqual(expectedParameters.Schema, options.GraphQLSchema, "Expected the schema in the configuration to match the one sent to the configuration endpoint.");
 
             // Don't use Assert.AreEqual, because a failure will print the entire connection string in the error message.
             Assert.IsTrue(expectedParameters.ConnectionString == configuration.DataSource.ConnectionString, "Expected the connection string in the configuration to match the one sent to the configuration endpoint.");
-            string db = configuration.DataSource.GetTypedOptions<CosmosDbNoSQLDataSourceOptions>().Database;
+            string db = options.Database;
             Assert.AreEqual(COSMOS_DATABASE_NAME, db, "Expected the database name in the runtime config to match the one sent to the configuration endpoint.");
         }
 

--- a/src/Service.Tests/TestHelper.cs
+++ b/src/Service.Tests/TestHelper.cs
@@ -115,10 +115,7 @@ namespace Azure.DataApiBuilder.Service.Tests
         public const string SAMPLE_SCHEMA_DATA_SOURCE = SCHEMA_PROPERTY + "," + @"
             ""data-source"": {
               ""database-type"": ""mssql"",
-              ""connection-string"": ""testconnectionstring"",
-              ""options"": {
-                ""set-session-context"": true
-                }
+              ""connection-string"": ""testconnectionstring""
             }
         ";
 

--- a/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
@@ -250,7 +250,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -314,7 +314,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -368,7 +368,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -475,7 +475,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -566,7 +566,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -846,7 +846,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -920,7 +920,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, string.Empty, new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, string.Empty, Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -1275,7 +1275,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             RestRuntimeOptions rest = new(Path: restConfiguredPath);
 
             RuntimeConfig configuration = ConfigurationTests.InitMinimalRuntimeConfig(
-                new(DatabaseType.MSSQL, "", new()),
+                new(DatabaseType.MSSQL, "", Options: null),
                 graphQL,
                 rest);
             string expectedErrorMessage = "Conflicting GraphQL and REST path configuration.";
@@ -1502,7 +1502,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             RestRuntimeOptions rest = new(Path: restPathPrefix);
 
             RuntimeConfig configuration = ConfigurationTests.InitMinimalRuntimeConfig(
-                new(DatabaseType.MSSQL, "", new()),
+                new(DatabaseType.MSSQL, "", Options: null),
                 graphQL,
                 rest);
 
@@ -1540,7 +1540,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             RestRuntimeOptions rest = new(Enabled: restEnabled);
 
             RuntimeConfig configuration = ConfigurationTests.InitMinimalRuntimeConfig(
-                new(DatabaseType.MSSQL, "", new()),
+                new(DatabaseType.MSSQL, "", Options: null),
                 graphQL,
                 rest);
             string expectedErrorMessage = "Both GraphQL and REST endpoints are disabled.";
@@ -1905,7 +1905,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -1973,7 +1973,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -2033,7 +2033,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", new()),
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),

--- a/src/Service.Tests/dab-config.MySql.json
+++ b/src/Service.Tests/dab-config.MySql.json
@@ -2,8 +2,7 @@
   "$schema": "https://github.com/Azure/data-api-builder/releases/download/vmajor.minor.patch/dab.draft.schema.json",
   "data-source": {
     "database-type": "mysql",
-    "connection-string": "server=localhost;database=datagatewaytest;uid=root;pwd=REPLACEME",
-    "options": {}
+    "connection-string": "server=localhost;database=datagatewaytest;uid=root;pwd=REPLACEME"
   },
   "runtime": {
     "rest": {

--- a/src/Service.Tests/dab-config.PostgreSql.json
+++ b/src/Service.Tests/dab-config.PostgreSql.json
@@ -2,8 +2,7 @@
   "$schema": "https://github.com/Azure/data-api-builder/releases/download/vmajor.minor.patch/dab.draft.schema.json",
   "data-source": {
     "database-type": "postgresql",
-    "connection-string": "Host=localhost;Database=datagatewaytest;username=REPLACEME;password=REPLACEME",
-    "options": {}
+    "connection-string": "Host=localhost;Database=datagatewaytest;username=REPLACEME;password=REPLACEME"
   },
   "runtime": {
     "rest": {


### PR DESCRIPTION
## Why make this change?

- With the recent refactor #1402, if `options` property is not specified in the config, after deserialization the `Options` dictionary of `DataSource` object is `null`  
- This leads to a null dereference when trying to `GetTypedOptions(MsSqlOptions)` [here](https://github.com/Azure/data-api-builder/blob/bda0d6551f8f75fc7b98f888bdfce1f3dd317378/src/Core/Resolvers/MsSqlQueryExecutor.cs#L76C70-L76C70). 

## What is this change?

- Make `Options` a nullable property since its not required as per the schema.
- Handle all the instances of Options considering it could be null.

## How was this tested?

- Manually running dab.
- Automated tests:
      1. Removed the `options: set-session-context` from the initial config used in the CLI tests to verify deserialization results in a null  `Options` dictionary as demonstrated by the Snapshots
      2. Modified tests which create a custom config and start the engine by setting `Options` to null and verifying those continue to pass.  
Note: The checked in configuration file for MsSql sets the session context to true for integration tests of row level security feature. So, did not modify that file even though options is optional for MsSql.