### PR TITLE
OpenAPI document resolves custom configured REST path

### DIFF
--- a/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
+++ b/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
@@ -677,7 +677,7 @@ namespace Azure.DataApiBuilder.Core.Services
         /// If no override exists, this method returns the passed in entity name.
         /// </summary>
         /// <param name="entityName">Name of the entity.</param>
-        /// <returns>Returns the REST path name for the provided entity.</returns>
+        /// <returns>Returns the REST path name for the provided entity with no starting slash: {entityName} or {entityRestPath}.</returns>
         private string GetEntityRestPath(string entityName)
         {
             string entityRestPath = entityName;

--- a/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
+++ b/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
@@ -673,8 +673,8 @@ namespace Azure.DataApiBuilder.Core.Services
         }
 
         /// <summary>
-        /// Resolves any REST path overrides present for the provided entity in the runtime config.
-        /// If no overrides exist, returns the passed in entity name.
+        /// Attempts to resolve the REST path override set for an entity in the runtime config.
+        /// If no override exists, this method returns the passed in entity name.
         /// </summary>
         /// <param name="entityName">Name of the entity.</param>
         /// <returns>Returns the REST path name for the provided entity.</returns>
@@ -683,10 +683,10 @@ namespace Azure.DataApiBuilder.Core.Services
             string entityRestPath = entityName;
             EntityRestOptions entityRestSettings = _runtimeConfig.Entities[entityName].Rest;
 
-            if (!string.IsNullOrEmpty(entityRestSettings.Path) && entityRestSettings.Path.StartsWith('/'))
+            if (!string.IsNullOrEmpty(entityRestSettings.Path))
             {
-                // Remove slash from start of rest path.
-                entityRestPath = entityRestPath.Substring(1);
+                // Remove slash from start of REST path.
+                entityRestPath = entityRestSettings.Path.TrimStart('/');
             }
 
             return entityRestPath;

--- a/src/Service.Tests/OpenApiDocumentor/OpenApiTestBootstrap.cs
+++ b/src/Service.Tests/OpenApiDocumentor/OpenApiTestBootstrap.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
+
+namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
+{
+    // Defines helpers used to help generate an OpenApiDocument object which
+    // can be validated in tests so that a constantly running DAB instance
+    // isn't necessary.
+    internal class OpenApiTestBootstrap
+    {
+        /// <summary>
+        /// Bootstraps a test server instance using a runtime config file generated
+        /// from the provided entity collection. The test server is only used to generate
+        /// and return the OpenApiDocument for use this method's callers.
+        /// </summary>
+        /// <param name="runtimeEntities"></param>
+        /// <param name="configFileName"></param>
+        /// <param name="databaseEnvironment"></param>
+        /// <returns>Generated OpenApiDocument</returns>
+        internal static async Task<OpenApiDocument> GenerateOpenApiDocument(
+            RuntimeEntities runtimeEntities,
+            string configFileName,
+            string databaseEnvironment)
+        {
+            TestHelper.SetupDatabaseEnvironment(databaseEnvironment);
+            FileSystem fileSystem = new();
+            FileSystemRuntimeConfigLoader loader = new(fileSystem);
+            loader.TryLoadKnownConfig(out RuntimeConfig config);
+
+            RuntimeConfig configWithCustomHostMode = config with
+            {
+                Runtime = config.Runtime with
+                {
+                    Host = config.Runtime.Host with { Mode = HostMode.Production }
+                },
+                Entities = runtimeEntities
+            };
+
+            File.WriteAllText(configFileName, configWithCustomHostMode.ToJson());
+            string[] args = new[]
+            {
+                $"--ConfigFileName={configFileName}"
+            };
+
+            using TestServer server = new(Program.CreateWebHostBuilder(args));
+            using HttpClient client = server.CreateClient();
+            {
+                HttpRequestMessage request = new(HttpMethod.Get, "/api/openapi");
+
+                HttpResponseMessage response = await client.SendAsync(request);
+                Stream responseStream = await response.Content.ReadAsStreamAsync();
+
+                // Read V3 as YAML
+                OpenApiDocument openApiDocument = new OpenApiStreamReader().Read(responseStream, out OpenApiDiagnostic diagnostic);
+
+                TestHelper.UnsetAllDABEnvironmentVariables();
+                return openApiDocument;
+            }
+        }
+
+        /// <summary>
+        /// Creates basic permissions collection with the anonymous and authenticated roles
+        /// where all actions are permitted.
+        /// </summary>
+        /// <returns>Array of EntityPermission objects.</returns>
+        internal static EntityPermission[] CreateBasicPermissions()
+        {
+            List<EntityPermission> permissions = new()
+            {
+                new EntityPermission("anonymous", new EntityAction[]
+                {
+                    new(EntityActionOperation.All, null, new())
+                }),
+                new EntityPermission("authenticated", new EntityAction[]
+                {
+                    new(EntityActionOperation.All, null, new())
+                })
+            };
+
+            return permissions.ToArray();
+        }
+    }
+}

--- a/src/Service.Tests/OpenApiDocumentor/OpenApiTestBootstrap.cs
+++ b/src/Service.Tests/OpenApiDocumentor/OpenApiTestBootstrap.cs
@@ -78,13 +78,13 @@ namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
         {
             List<EntityPermission> permissions = new()
             {
-                new EntityPermission("anonymous", new EntityAction[]
+                new EntityPermission(Role: "anonymous", Actions: new EntityAction[]
                 {
-                    new(EntityActionOperation.All, null, new())
+                    new(Action: EntityActionOperation.All, Fields: null, Policy: new())
                 }),
-                new EntityPermission("authenticated", new EntityAction[]
+                new EntityPermission(Role: "authenticated", Actions: new EntityAction[]
                 {
-                    new(EntityActionOperation.All, null, new())
+                    new(Action: EntityActionOperation.All, Fields: null, Policy: new())
                 })
             };
 

--- a/src/Service.Tests/OpenApiDocumentor/PathValidation.cs
+++ b/src/Service.Tests/OpenApiDocumentor/PathValidation.cs
@@ -27,22 +27,26 @@ namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
         /// Validates that the OpenApiDocument object's Paths property for an entity is generated
         /// with the entity's explicitly configured REST path, if set. Otherwise, the top level
         /// entity name is used.
+        /// When OpenApiDocumentor.BuildPaths() is called, the entityBasePathComponent is created using
+        /// the formula "/{entityRestPath}" where {entityRestPath} has no starting slashes and is either
+        /// the entity name or the explicitly configured entity REST path
         /// </summary>
         /// <param name="entityName">Top level entity name defined in runtime config.</param>
-        /// <param name="restPath">Entity's configured REST path.</param>
-        /// <param name="expectedOpenApiPath">Expected path generated for OpenApiDocument.Paths</param>
+        /// <param name="configuredRestPath">Entity's configured REST path.</param>
+        /// <param name="expectedOpenApiPath">Expected path generated for OpenApiDocument.Paths with format: "/{entityRestPath}"</param>
         [DataRow("entity", "/customEntityPath", "/customEntityPath", DisplayName = "Entity REST path has leading slash - REST path override used.")]
-        [DataRow("entity", "//customEntityPath", "/customEntityPath", DisplayName = "Entity REST path has leading slashes - REST path override used.")]
+        [DataRow("entity", "//customEntityPath", "/customEntityPath", DisplayName = "Entity REST path has two leading slashes - REST path override used.")]
+        [DataRow("entity", "///customEntityPath", "/customEntityPath", DisplayName = "Entity REST path has many leading slashes - REST path override used.")]
         [DataRow("entity", "customEntityPath", "/customEntityPath", DisplayName = "Entity REST path has no leading slash(es) - REST path override used.")]
         [DataRow("entity", "", "/entity", DisplayName = "Entity REST path is an emtpy string - top level entity name used.")]
         [DataRow("entity", null, "/entity", DisplayName = "Entity REST path is null - top level entity name used.")]
         [DataTestMethod]
-        public async Task ValidateEntityRestPath(string entityName, string restPath, string expectedOpenApiPath)
+        public async Task ValidateEntityRestPath(string entityName, string configuredRestPath, string expectedOpenApiPath)
         {
             Entity entity = new(
                 Source: new(Object: "books", EntitySourceType.Table, null, null),
                 GraphQL: new(Singular: null, Plural: null, Enabled: false),
-                Rest: new(Methods: EntityRestOptions.DEFAULT_SUPPORTED_VERBS, Path: restPath),
+                Rest: new(Methods: EntityRestOptions.DEFAULT_SUPPORTED_VERBS, Path: configuredRestPath),
                 Permissions: OpenApiTestBootstrap.CreateBasicPermissions(),
                 Mappings: null,
                 Relationships: null);

--- a/src/Service.Tests/OpenApiDocumentor/PathValidation.cs
+++ b/src/Service.Tests/OpenApiDocumentor/PathValidation.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Microsoft.OpenApi.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
+{
+    /// <summary>
+    /// Integration tests validating correct keys are created for OpenApiDocument.Paths
+    /// which represent the path used to access an entity in DAB's REST API endpoint.
+    /// </summary>
+    [TestCategory(TestCategory.MSSQL)]
+    [TestClass]
+    public class PathValidation
+    {
+        private const string CUSTOM_CONFIG = "path-config.MsSql.json";
+        private const string MSSQL_ENVIRONMENT = TestCategory.MSSQL;
+
+        // Error messages
+        private const string PATH_GENERATION_ERROR = "Unexpected path value for entity in OpenAPI description document: ";
+
+        /// <summary>
+        /// Validates that the OpenApiDocument object's Paths property for an entity is generated
+        /// with the entity's explicitly configured REST path, if set. Otherwise, the top level
+        /// entity name is used.
+        /// </summary>
+        /// <param name="entityName">Top level entity name defined in runtime config.</param>
+        /// <param name="restPath">Entity's configured REST path.</param>
+        /// <param name="expectedOpenApiPath">Expected path generated for OpenApiDocument.Paths</param>
+        [DataRow("entity", "/customEntityPath", "/customEntityPath", DisplayName = "Entity REST path has leading slash - REST path override used.")]
+        [DataRow("entity", "//customEntityPath", "/customEntityPath", DisplayName = "Entity REST path has leading slashes - REST path override used.")]
+        [DataRow("entity", "customEntityPath", "/customEntityPath", DisplayName = "Entity REST path has no leading slash(es) - REST path override used.")]
+        [DataRow("entity", "", "/entity", DisplayName = "Entity REST path is an emtpy string - top level entity name used.")]
+        [DataRow("entity", null, "/entity", DisplayName = "Entity REST path is null - top level entity name used.")]
+        [DataTestMethod]
+        public async Task ValidateEntityRestPath(string entityName, string restPath, string expectedOpenApiPath)
+        {
+            Entity entity = new(
+                Source: new(Object: "books", EntitySourceType.Table, null, null),
+                GraphQL: new(Singular: null, Plural: null, Enabled: false),
+                Rest: new(Methods: EntityRestOptions.DEFAULT_SUPPORTED_VERBS, Path: restPath),
+                Permissions: OpenApiTestBootstrap.CreateBasicPermissions(),
+                Mappings: null,
+                Relationships: null);
+
+            Dictionary<string, Entity> entities = new()
+            {
+                { entityName, entity }
+            };
+
+            RuntimeEntities runtimeEntities = new(entities);
+            OpenApiDocument openApiDocument = await OpenApiTestBootstrap.GenerateOpenApiDocument(
+                runtimeEntities: runtimeEntities,
+                configFileName: CUSTOM_CONFIG,
+                databaseEnvironment: MSSQL_ENVIRONMENT);
+
+            // For a given table backed entity, there will be two paths:
+            // 1. GetById path: "/customEntityPath/id/{id}"
+            // 2. GetAll path:  "/customEntityPath"
+            foreach (string actualPath in openApiDocument.Paths.Keys)
+            {
+                Assert.AreEqual(expected: true, actual: actualPath.StartsWith(expectedOpenApiPath), message: PATH_GENERATION_ERROR + actualPath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why make this change?

- Closes #1633
  - The wrong 'path' value is generated in the OpenAPI description document created. This was observed when looking at the `/swagger` endpoint to see the REST endpoint documentation.
  - When an entity's REST path property is explicitly set AND includes a starting slash `/`, the openapidocumentor does not properly create the PATH used to access the entity in the REST endpoint.

## What is this change?

- Correctly process an entity's REST path configuration. Before this change, the method at fault was improperly calling `Substring()` on the wrong variable. Although the variable was previously `restPath`, the value at the time of calling substring was the top-level entity name which did not have a starting slash `/`. 
- The variable `restPath` is modified depending on whether the entity has explicit rest path config. If no explicit rest path is configured, the top level entity name is returned as the resolved rest path. 
- Now, calling `entityRestSettings.Path.TrimStart('/')` will correctly remove a starting slash IF one exists. This accommodates the following formatting of the explicit rest path:

1. `/customRestPath`
2. `customRestPath`
3. `//customRestPath` -> while this option is not advisable to use in practice, we still support it and this PR is not meant to change that behavior. But for complete test coverage, this case is tested.

## How was this tested?

- [x] Integration Tests

