### PR TITLE
Adds Embedded Sources and enable deterministic builds for Core module

### DIFF
--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,10 +21,7 @@
     <PackageReference Include="Microsoft.OData.Core" />
     <PackageReference Include="Microsoft.OData.Edm" />
     <PackageReference Include="Microsoft.OpenApi" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="Newtonsoft.Json" />
@@ -33,6 +31,10 @@
     <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+    
   <ItemGroup>
     <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj" />
     <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj" />

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -21,7 +21,10 @@
     <PackageReference Include="Microsoft.OData.Core" />
     <PackageReference Include="Microsoft.OData.Edm" />
     <PackageReference Include="Microsoft.OpenApi" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/Product/Azure.DataApiBuilder.Product.csproj
+++ b/src/Product/Azure.DataApiBuilder.Product.csproj
@@ -12,8 +12,4 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-  </ItemGroup>
-    
 </Project>

--- a/src/Product/Azure.DataApiBuilder.Product.csproj
+++ b/src/Product/Azure.DataApiBuilder.Product.csproj
@@ -12,4 +12,8 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+    
 </Project>


### PR DESCRIPTION
## Why make this change?

-  Closes #1655 
  - Health of [0.8.44-rc nupkg](https://nuget.info/packages/Microsoft.DataApiBuilder/0.8.44-rc) nupkg needs to be fixed

## What is this change?

- To fix the NuGet generated in the `main` branch, `Product` and `Core` modules needs to be updated. `Product` module was introduced later and `0.8.*` NuGets do not have the Product module. So, the fix is broken into two PRs. 
- This PR adds changes only to the `Core` module. After merging to `main`, this PR can be ported over to `release/0.8` branch.  
- [PR #1657 ](https://github.com/Azure/data-api-builder/pull/1657) adds the changes to `Product` module.
 
- Sets `EmbedUntrackedSources` and `ContinuousIntegrationBuild` to `true`


## How was this tested?

- [x] Manual Tests
By applying the change on top of the `release/0.8` branch, the health of the NuGet generated was validated 
![image](https://github.com/Azure/data-api-builder/assets/11196553/551713f7-1f96-46e5-a310-91bccfeab87c)


