### PR TITLE
Adds SourceLink dependency to Product module

### DIFF
--- a/src/Product/Azure.DataApiBuilder.Product.csproj
+++ b/src/Product/Azure.DataApiBuilder.Product.csproj
@@ -12,4 +12,8 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+  </ItemGroup>
+    
 </Project>

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -504,7 +504,12 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 replaceEnvVar: true));
 
             string actualUpdatedConnectionString = updatedRuntimeConfig.DataSource.ConnectionString;
-            Assert.AreEqual(expectedUpdatedConnectionString, actualUpdatedConnectionString);
+
+            // SourceLink appends the commit ID to the assembly metadata. The application name is extracted from the
+            // assembly metadata. So, the connection string after appending the application name will be of the form
+            // dab_oss_1.0.0+<commit-id> or dab_hosted_1.0.0+<commit-id> depending on oss or hosted scenario respectively.
+            // So, the updated connection string is validated to check if it starts with dab_oss_1.0.0 or dab_hosted_1.0.0.
+            Assert.IsTrue(actualUpdatedConnectionString.StartsWith(expectedUpdatedConnectionString));
         }
 
         [TestMethod("Validates that once the configuration is set, the config controller isn't reachable."), TestCategory(TestCategory.COSMOSDBNOSQL)]


### PR DESCRIPTION
## Why make this change?

- Closes #1655 
  - The `SourceLink` NuGet health property is not `valid` due to the absence of SourceLink dependency

## What is this change?

- `SourceLink` dependency is added to the `Product` module
- `SourceLink` embeds the git commit ID to assembly metadata. So, the application name will be of the form `dab_oss_1.0.0+<commit_id>`. So, test assertion logic is updated.
- This PR is a subsequent change for [PR #1656 ](https://github.com/Azure/data-api-builder/pull/1656). It describes why the changes for fixing the NuGet health are broken down into two separate PRs. 

## How was this tested?
- [x] Manual Tests. Health of the NuGet after applying the changes from this PR and [PR #1656 ](https://github.com/Azure/data-api-builder/pull/1656) was validated.

![image](https://github.com/Azure/data-api-builder/assets/11196553/859b507a-32d1-4990-967e-9d25884b1ea6)

