### PR TITLE
[Cherry Pick]: Adds Embedded Sources and enable deterministic builds for Core module…

### DIFF
--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +33,10 @@
     <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+    
   <ItemGroup>
     <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj" />
     <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj" />


### PR DESCRIPTION
Cherry-Picks (#1656) to release/0.8 branch

**Original Description:**

## Why make this change?

-  Closes #1655 
- Health of [0.8.44-rc nupkg](https://nuget.info/packages/Microsoft.DataApiBuilder/0.8.44-rc) nupkg needs to be fixed

## What is this change?

- To fix the NuGet generated in the `main` branch, `Product` and `Core` modules needs to be updated. `Product` module was introduced later and `0.8.*` NuGets do not have the Product module. So, the fix is broken into two PRs.
- This PR adds changes only to the `Core` module. After merging to `main`, this PR can be ported over to `release/0.8` branch.
- [PR #1657 ](https://github.com/Azure/data-api-builder/pull/1657) adds the changes to `Product` module.
 
- Sets `EmbedUntrackedSources` and `ContinuousIntegrationBuild` to `true`


## How was this tested?

- [x] Manual Tests By applying the change on top of the `release/0.8` branch, the health of the NuGet generated was validated

![image](https://github.com/Azure/data-api-builder/assets/11196553/551713f7-1f96-46e5-a310-91bccfeab87c)

---------