### PR TITLE
Fixing indentation in the generated configuration

### DIFF
--- a/src/Config/Converters/RuntimeEntitiesConverter.cs
+++ b/src/Config/Converters/RuntimeEntitiesConverter.cs
@@ -26,9 +26,8 @@ class RuntimeEntitiesConverter : JsonConverter<RuntimeEntities>
         writer.WriteStartObject();
         foreach ((string key, Entity entity) in value.Entities)
         {
-            string json = JsonSerializer.Serialize(entity, options);
             writer.WritePropertyName(key);
-            writer.WriteRawValue(json);
+            JsonSerializer.Serialize(writer, entity, options);
         }
 
         writer.WriteEndObject();


### PR DESCRIPTION
## Why make this change?

- With the overhaul of the config system using our own Write method while serializing objects, the config that is generated is misaligned with respect to indentation for all the keys under each entity name.
For e.g.:
In the following picture, the entity name `Todo` is indented with 4 leading spaces, subsequently its child key `source` should have been indented with 6 leading spaces, however its currently indented with only 2 spaces.

![image](https://github.com/Azure/data-api-builder/assets/3513779/4c4a926f-ae22-444e-bc86-23f207b3cf22)

- This is a regression in 0.8.44-rc.

## What is this change?

- Use the same writer to serialize the subkeys under the entity name so that the depth of indentation is maintained.

## How does this change fix the issue?
- `WriteRawValue` writes the json string argument provided as is without doing any additional formatting on it. It doesn't utilize the `_currentDepth` private member of the writer to determine how to indent.

- Prior to this change, we were generating the inner json string first then writing the generated inner json "as is". While generating that json on line 29

https://github.com/Azure/data-api-builder/blob/31b754251832ffebf4c4ce36ffcbead9baff6355/src/Config/Converters/RuntimeEntitiesConverter.cs#L29

Line 29 in [31b7542](https://github.com/Azure/data-api-builder/commit/31b754251832ffebf4c4ce36ffcbead9baff6355)

a new writer is being used by the `JsonSerializer.Serialize()` function, effectively resetting the `_currentDepth`. The `_currentDepth` of the writer in context was not getting honored.

## How was this tested?

- Manual test, building solution and using `dab add` to simulate automatic writing of an entity to the config file. With the change, the indentation is fixed.

![image](https://github.com/Azure/data-api-builder/assets/3513779/bf708ecc-4fa2-4711-ba88-844c24922b81)

