### PR TITLE
Remove redundant logging of found config file

### DIFF
--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -949,7 +949,7 @@ namespace Cli
         /// It will use the config provided by the user, else based on the environment value
         /// it will either merge the config if base config and environmentConfig is present
         /// else it will choose a single config based on precedence (left to right) of
-        /// overrides &lt; environmentConfig &lt; defaultConfig
+        /// overrides > environmentConfig > defaultConfig
         /// Also preforms validation to check connection string is not null or empty.
         /// </summary>
         public static bool TryStartEngineWithOptions(StartOptions options, FileSystemRuntimeConfigLoader loader, IFileSystem fileSystem)
@@ -966,7 +966,7 @@ namespace Cli
                 return false;
             }
 
-            loader.UpdateBaseConfigFileName(runtimeConfigFile);
+            loader.UpdateConfigFileName(runtimeConfigFile);
 
             // Validates that config file has data and follows the correct json schema
             // Replaces all the environment variables while deserializing when starting DAB.

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -972,8 +972,12 @@ namespace Cli
             // Replaces all the environment variables while deserializing when starting DAB.
             if (!loader.TryLoadKnownConfig(out RuntimeConfig? deserializedRuntimeConfig, replaceEnvVar: true))
             {
-                _logger.LogError("Failed to parse the config file: {configFile}.", runtimeConfigFile);
+                _logger.LogError("Failed to parse the config file: {runtimeConfigFile}.", runtimeConfigFile);
                 return false;
+            }
+            else
+            {
+                _logger.LogInformation("Loaded config file: {runtimeConfigFile}", runtimeConfigFile);
             }
 
             if (string.IsNullOrWhiteSpace(deserializedRuntimeConfig.DataSource.ConnectionString))

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -25,6 +25,8 @@ namespace Azure.DataApiBuilder.Config;
 /// </remarks>
 public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
 {
+    // This stores either the default config name or user provided config.
+    // e.g. dab-config.json
     private string _baseConfigFileName;
 
     private readonly IFileSystem _fileSystem;
@@ -42,13 +44,20 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     /// </summary>
     public const string DEFAULT_CONFIG_FILE_NAME = $"{CONFIGFILE_NAME}{CONFIG_EXTENSION}";
 
-    public string ConfigFileName => GetFileNameForEnvironment(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"), false);
+    /// <summary>
+    /// Stores the config file name actually loaded by the engine.
+    /// It could be the base config file (e.g. dab-config.json), any of its derivatives with
+    /// environment specific suffixes (e.g. dab-config.Development.json) or the user provided
+    /// config file name.
+    /// </summary>
+    public string ConfigFileName { get; internal set; }
 
     public FileSystemRuntimeConfigLoader(IFileSystem fileSystem, string baseConfigFileName = DEFAULT_CONFIG_FILE_NAME, string? connectionString = null)
         : base(connectionString)
     {
         _fileSystem = fileSystem;
         _baseConfigFileName = baseConfigFileName;
+        ConfigFileName = GetFileNameForEnvironment(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"), false);
     }
 
     /// <summary>
@@ -251,11 +260,13 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     }
 
     /// <summary>
-    /// Allows the base config file name to be updated. This is commonly done when the CLI is starting up.
+    /// Allows the base config file and the actually loaded config file name(tracked by the property ConfigFileName)
+    /// to be updated. This is commonly done when the CLI is starting up.
     /// </summary>
     /// <param name="fileName"></param>
-    public void UpdateBaseConfigFileName(string fileName)
+    public void UpdateConfigFileName(string fileName)
     {
         _baseConfigFileName = fileName;
+        ConfigFileName = fileName;
     }
 }

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -187,21 +187,7 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     public bool DoesFileExistInCurrentDirectory(string fileName)
     {
         string currentDir = _fileSystem.Directory.GetCurrentDirectory();
-        // Unable to use ILogger because this code is invoked before LoggerFactory
-        // is instantiated.
-        if (_fileSystem.File.Exists(_fileSystem.Path.Combine(currentDir, fileName)))
-        {
-            // This config file is logged as being found, but may not actually be used!
-            Console.WriteLine($"Found config file: {fileName}.");
-            return true;
-        }
-        else
-        {
-            // Unable to use ILogger because this code is invoked before LoggerFactory
-            // is instantiated.
-            Console.WriteLine($"Unable to find config file: {fileName} does not exist.");
-            return false;
-        }
+        return _fileSystem.File.Exists(_fileSystem.Path.Combine(currentDir, fileName));
     }
 
     /// <summary>

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -102,6 +102,25 @@ public abstract class RuntimeConfigLoader
             config = null;
             return false;
         }
+        catch (DataApiBuilderException ex)
+        {
+            string errorMessage = $"Internal exception occurred.\n" +
+                        $"Message:\n {ex.Message}\n" +
+                        $"Stack Trace:\n {ex.StackTrace}";
+
+            if (logger is null)
+            {
+                // logger can be null when called from CLI
+                Console.Error.WriteLine(errorMessage);
+            }
+            else
+            {
+                logger.LogError(ex, errorMessage);
+            }
+
+            config = null;
+            return false;
+        }
 
         return true;
     }

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -294,10 +294,6 @@ namespace Azure.DataApiBuilder.Service
             {
                 // Config provided before starting the engine.
                 isRuntimeReady = PerformOnConfigChangeAsync(app).Result;
-                if (_logger is not null)
-                {
-                    _logger.LogDebug("Loaded config file from {filePath}", fileSystemRuntimeConfigLoader.ConfigFileName);
-                }
 
                 if (!isRuntimeReady)
                 {


### PR DESCRIPTION
## Why make this change?
- With the overhaul of config system PR #1402 , we started seeing redundant logs about which config file is being used.

## What is this change?

- Store the environment based config file name found at construction time in the property `ConfigFileName`. 
- Remove Console writeline statements while checking for existence of file since this leads to multiple logs - one from CLI before starting the engine and second from within the engine itself when calling TryPargeConfig
- Add a single log of the loaded file in CLI
- Also catch exception for incorrect connection string parsing

## How was this tested?

Before:

After:
![image](https://github.com/Azure/data-api-builder/assets/3513779/62f65222-de59-4525-b0b1-ead407d43b4e)


