### PR TITLE
[Cherry pick] Remove redundant logging of found config file

### DIFF
--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -948,7 +948,7 @@ namespace Cli
         /// It will use the config provided by the user, else based on the environment value
         /// it will either merge the config if base config and environmentConfig is present
         /// else it will choose a single config based on precedence (left to right) of
-        /// overrides < environmentConfig < defaultConfig
+        /// overrides > environmentConfig > defaultConfig
         /// Also preforms validation to check connection string is not null or empty.
         /// </summary>
         public static bool TryStartEngineWithOptions(StartOptions options, FileSystemRuntimeConfigLoader loader, IFileSystem fileSystem)
@@ -965,14 +965,18 @@ namespace Cli
                 return false;
             }
 
-            loader.UpdateBaseConfigFileName(runtimeConfigFile);
+            loader.UpdateConfigFileName(runtimeConfigFile);
 
             // Validates that config file has data and follows the correct json schema
             // Replaces all the environment variables while deserializing when starting DAB.
             if (!loader.TryLoadKnownConfig(out RuntimeConfig? deserializedRuntimeConfig, replaceEnvVar: true))
             {
-                _logger.LogError("Failed to parse the config file: {configFile}.", runtimeConfigFile);
+                _logger.LogError("Failed to parse the config file: {runtimeConfigFile}.", runtimeConfigFile);
                 return false;
+            }
+            else
+            {
+                _logger.LogInformation("Loaded config file: {runtimeConfigFile}", runtimeConfigFile);
             }
 
             if (string.IsNullOrWhiteSpace(deserializedRuntimeConfig.DataSource.ConnectionString))

--- a/src/Service.Tests/Configuration/AuthenticationConfigValidatorUnitTests.cs
+++ b/src/Service.Tests/Configuration/AuthenticationConfigValidatorUnitTests.cs
@@ -45,6 +45,10 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 new MockFileData(config.ToJson())
             );
 
+            // Since we added the config file to the filesystem above after the config loader was initialized
+            // in TestInitialize, we need to update the ConfigfileName, otherwise it will be an empty string.
+            _runtimeConfigLoader.UpdateConfigFileName(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME);
+
             try
             {
                 _runtimeConfigValidator.ValidateConfig();
@@ -71,6 +75,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 new MockFileData(config.ToJson())
             );
 
+            _runtimeConfigLoader.UpdateConfigFileName(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME);
+
             try
             {
                 _runtimeConfigValidator.ValidateConfig();
@@ -89,6 +95,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME,
                 new MockFileData(config.ToJson())
             );
+
+            _runtimeConfigLoader.UpdateConfigFileName(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME);
 
             try
             {
@@ -116,6 +124,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME,
                 new MockFileData(config.ToJson())
             );
+
+            _runtimeConfigLoader.UpdateConfigFileName(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME);
 
             Assert.ThrowsException<NotSupportedException>(() =>
             {
@@ -149,6 +159,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME,
                 new MockFileData(config.ToJson())
             );
+
+            _runtimeConfigLoader.UpdateConfigFileName(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME);
 
             Assert.ThrowsException<NotSupportedException>(() =>
             {

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -294,10 +294,6 @@ namespace Azure.DataApiBuilder.Service
             {
                 // Config provided before starting the engine.
                 isRuntimeReady = PerformOnConfigChangeAsync(app).Result;
-                if (_logger is not null)
-                {
-                    _logger.LogDebug("Loaded config file from {filePath}", fileSystemRuntimeConfigLoader.ConfigFileName);
-                }
 
                 if (!isRuntimeReady)
                 {


### PR DESCRIPTION
Cherry picking #1669 

Original description:

## Why make this change?
- With the overhaul of config system PR #1402 , we started seeing redundant logs about which config file is being used.

## What is this change?

- Store the environment based config file name found at construction time in the property `ConfigFileName`. 
- Remove Console writeline statements while checking for existence of file since this leads to multiple logs - one from CLI before starting the engine and second from within the engine itself when calling TryPargeConfig
- Add a single log of the loaded file in CLI

## How was this tested?
- Manually, using the `start` command of CLI as well as triggering the engine directly with argument: `--ConfigFileName`

1. Starting with default config:
**Before**:
![image](https://github.com/Azure/data-api-builder/assets/3513779/a29d4aff-19db-49c7-a745-b6bbdb5c62cc)

**After**:
![image](https://github.com/Azure/data-api-builder/assets/3513779/62f65222-de59-4525-b0b1-ead407d43b4e)

2. Starting with user provided config:
**Before**:
![image](https://github.com/Azure/data-api-builder/assets/3513779/b762c873-ade6-47bb-b094-44960176d90f)

**After**:
![image](https://github.com/Azure/data-api-builder/assets/3513779/2f977a72-bfdf-43fb-9cc9-806ea717b546)

3. Trying to start with missing file name - same behvior as before
![image](https://github.com/Azure/data-api-builder/assets/3513779/5a80f62e-8a06-4e7c-aa22-c120dade6801)

