### PR TITLE
Parsing parameters based on ApiType

### DIFF
--- a/src/Core/Resolvers/BaseQueryStructure.cs
+++ b/src/Core/Resolvers/BaseQueryStructure.cs
@@ -130,16 +130,16 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 DbType? dbTypeForParam = sourceDefinition.GetDbTypeForParam(paramName);
                 Type systemTypeForParam = sourceDefinition.GetSystemTypeForParam(paramName);
 
-                if (dbTypeForParam is not null && ApiType is not ApiType.GraphQL && systemTypeForParam != typeof(DateTime))
+                if (dbTypeForParam is null || ApiType is ApiType.GraphQL && systemTypeForParam == typeof(DateTime))
                 {
-                    // For GraphQL, we don't populate the DbType for System.DateTime parameters when the backend database is MsSql.
+                    // For GraphQL, we don't populate the DbType for System.DateTime parameters.
                     // This is because we parse them as System.DateTimeOffset and hence the DbType of the parameters and the parameters' value
                     // fall out of sync.
-                    Parameters.Add(encodedParamName, new(value, dbTypeForParam));
+                    Parameters.Add(encodedParamName, new(value));
                 }
                 else
                 {
-                    Parameters.Add(encodedParamName, new(value));
+                    Parameters.Add(encodedParamName, new(value, dbTypeForParam));
                 }
             }
 

--- a/src/Core/Resolvers/BaseQueryStructure.cs
+++ b/src/Core/Resolvers/BaseQueryStructure.cs
@@ -126,13 +126,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             }
             else
             {
-                DatabaseType databaseType = MetadataProvider.GetDatabaseType();
                 SourceDefinition sourceDefinition = GetUnderlyingSourceDefinition();
-
                 DbType? dbTypeForParam = sourceDefinition.GetDbTypeForParam(paramName);
                 Type systemTypeForParam = sourceDefinition.GetSystemTypeForParam(paramName);
 
-                if (dbTypeForParam is not null && (databaseType is not DatabaseType.MSSQL || ApiType is not ApiType.GraphQL || systemTypeForParam != typeof(DateTime)))
+                if (dbTypeForParam is not null && ApiType is not ApiType.GraphQL && systemTypeForParam != typeof(DateTime))
                 {
                     // For GraphQL, we don't populate the DbType for System.DateTime parameters when the backend database is MsSql.
                     // This is because we parse them as System.DateTimeOffset and hence the DbType of the parameters and the parameters' value

--- a/src/Core/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/BaseSqlQueryStructure.cs
@@ -352,9 +352,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             {
                 if (ApiType is ApiType.GraphQL)
                 {
+                    // To continue supporting 'Z' notation for GraphQL, we parse datetime values as datetimeoffset.
                     return DateTimeOffset.Parse(param, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal);
                 }
 
+                // For other APIs (current REST), we parse the datetime values as it is since we don't need to support 'Z' notation.
                 return DateTime.Parse(param);
             }
 
@@ -370,7 +372,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 "Double" => double.Parse(param),
                 "Decimal" => decimal.Parse(param),
                 "Boolean" => bool.Parse(param),
-                "DateTime" => DateTime.Parse(param),
                 "DateTimeOffset" => DateTimeOffset.Parse(param, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal),
                 "Date" => DateOnly.Parse(param),
                 "Guid" => Guid.Parse(param),

--- a/src/Core/Resolvers/Sql Query Structures/SqlDeleteQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlDeleteQueryStructure.cs
@@ -23,11 +23,13 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             IAuthorizationResolver authorizationResolver,
             GQLFilterParser gQLFilterParser,
             IDictionary<string, object?> mutationParams,
-            HttpContext httpContext)
+            HttpContext httpContext,
+            ApiType apiType)
         : base(
               metadataProvider: sqlMetadataProvider,
               authorizationResolver: authorizationResolver,
               gQLFilterParser: gQLFilterParser,
+              apiType: apiType,
               entityName: entityName,
               httpContext: httpContext,
               operationType: EntityActionOperation.Delete)

--- a/src/Core/Resolvers/Sql Query Structures/SqlExecuteQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlExecuteQueryStructure.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config.DatabasePrimitives;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Service.Exceptions;
@@ -31,8 +32,9 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             ISqlMetadataProvider sqlMetadataProvider,
             IAuthorizationResolver authorizationResolver,
             GQLFilterParser gQLFilterParser,
-            IDictionary<string, object?> requestParams)
-        : base(sqlMetadataProvider, authorizationResolver, gQLFilterParser, entityName: entityName)
+            IDictionary<string, object?> requestParams,
+            ApiType apiType)
+        : base(sqlMetadataProvider, authorizationResolver, gQLFilterParser, entityName: entityName, apiType: apiType)
         {
             StoredProcedureDefinition storedProcedureDefinition = GetUnderlyingStoredProcedureDefinition();
             ProcedureParameters = new();

--- a/src/Core/Resolvers/Sql Query Structures/SqlInsertQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlInsertQueryStructure.cs
@@ -59,7 +59,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             GQLFilterParser gQLFilterParser,
             IDictionary<string, object?> mutationParams,
             HttpContext httpContext,
-            ApiType apiType = ApiType.REST
+            ApiType apiType
             )
         : base(
               metadataProvider: sqlMetadataProvider,

--- a/src/Core/Resolvers/Sql Query Structures/SqlInsertQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlInsertQueryStructure.cs
@@ -48,7 +48,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             authorizationResolver,
             gQLFilterParser,
             GQLMutArgumentToDictParams(context, CreateMutationBuilder.INPUT_ARGUMENT_NAME, mutationParams),
-            httpContext)
+            httpContext,
+            ApiType.GraphQL)
         { }
 
         public SqlInsertStructure(
@@ -57,12 +58,14 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             IAuthorizationResolver authorizationResolver,
             GQLFilterParser gQLFilterParser,
             IDictionary<string, object?> mutationParams,
-            HttpContext httpContext
+            HttpContext httpContext,
+            ApiType apiType = ApiType.REST
             )
         : base(
               metadataProvider: sqlMetadataProvider,
               authorizationResolver: authorizationResolver,
               gQLFilterParser: gQLFilterParser,
+              apiType: apiType,
               entityName: entityName,
               httpContext: httpContext,
               operationType: EntityActionOperation.Create)

--- a/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -138,7 +138,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 predicates: null,
                 entityName: context.EntityName,
                 counter: new IncrementingInteger(),
-                httpContext: httpContext)
+                httpContext: httpContext,
+                apiType: ApiType.REST)
         {
             IsListQuery = context.IsMany;
             SourceAlias = $"{DatabaseObject.SchemaName}_{DatabaseObject.Name}";
@@ -260,7 +261,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                   gQLFilterParser,
                   predicates: null,
                   entityName: entityName,
-                  counter: counter
+                  counter: counter,
+                  apiType: ApiType.GraphQL
                   )
         {
             _ctx = ctx;
@@ -415,13 +417,16 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             ISqlMetadataProvider metadataProvider,
             IAuthorizationResolver authorizationResolver,
             GQLFilterParser gQLFilterParser,
+            ApiType apiType,
             List<Predicate>? predicates = null,
             string entityName = "",
             IncrementingInteger? counter = null,
             HttpContext? httpContext = null)
             : base(metadataProvider,
                   authorizationResolver,
-                  gQLFilterParser, predicates,
+                  gQLFilterParser,
+                  apiType,
+                  predicates,
                   entityName,
                   counter,
                   httpContext,

--- a/src/Core/Resolvers/Sql Query Structures/SqlUpdateQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlUpdateQueryStructure.cs
@@ -36,11 +36,13 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             GQLFilterParser gQLFilterParser,
             IDictionary<string, object?> mutationParams,
             HttpContext httpContext,
+            ApiType apiType,
             bool isIncrementalUpdate)
         : base(
               metadataProvider: sqlMetadataProvider,
               authorizationResolver: authorizationResolver,
               gQLFilterParser: gQLFilterParser,
+              apiType: apiType,
               entityName: entityName,
               httpContext: httpContext,
               operationType: EntityActionOperation.Update)
@@ -100,6 +102,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                   metadataProvider: sqlMetadataProvider,
                   authorizationResolver: authorizationResolver,
                   gQLFilterParser: gQLFilterParser,
+                  apiType: ApiType.GraphQL,
                   entityName: entityName,
                   httpContext: httpContext,
                   operationType: EntityActionOperation.Update)

--- a/src/Core/Resolvers/Sql Query Structures/SqlUpsertQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlUpsertQueryStructure.cs
@@ -69,6 +69,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
               metadataProvider: sqlMetadataProvider,
               authorizationResolver: authorizationResolver,
               gQLFilterParser: gQLFilterParser,
+              apiType: ApiType.REST,
               entityName: entityName,
               operationType: EntityActionOperation.Upsert,
               httpContext: httpContext)

--- a/src/Core/Resolvers/SqlExistsQueryStructure.cs
+++ b/src/Core/Resolvers/SqlExistsQueryStructure.cs
@@ -37,6 +37,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                   metadataProvider,
                   authorizationResolver,
                   gQLFilterParser,
+                  ApiType.GraphQL,
                   predicates,
                   entityName,
                   counter,

--- a/src/Core/Resolvers/SqlMutationEngine.cs
+++ b/src/Core/Resolvers/SqlMutationEngine.cs
@@ -526,6 +526,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="operationType">The type of mutation operation.
         /// This cannot be Delete, Upsert or UpsertIncremental since those operations have dedicated functions.</param>
         /// <param name="parameters">The parameters of the mutation query.</param>
+        /// <param name="apiType">Type of API (GraphQL/REST).</param>
         /// <param name="context">In the case of GraphQL, the HotChocolate library's middleware context.</param>
         /// <returns>Single row read from DbDataReader.</returns>
         private async Task<DbResultSetRow?>
@@ -533,7 +534,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 string entityName,
                 EntityActionOperation operationType,
                 IDictionary<string, object?> parameters,
-                ApiType apiType = ApiType.REST,
+                ApiType apiType,
                 IMiddlewareContext? context = null)
         {
             string queryString;
@@ -549,7 +550,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             _authorizationResolver,
                             _gQLFilterParser,
                             parameters,
-                            GetHttpContext())
+                            GetHttpContext(),
+                            apiType)
                         : new(
                             context,
                             entityName,

--- a/src/Core/Resolvers/SqlQueryEngine.cs
+++ b/src/Core/Resolvers/SqlQueryEngine.cs
@@ -98,7 +98,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     _sqlMetadataProvider,
                     _authorizationResolver,
                     _gQLFilterParser,
-                    parameters);
+                    parameters,
+                    ApiType.GraphQL);
 
                 return new Tuple<IEnumerable<JsonDocument>, IMetadata?>(
                         FormatStoredProcedureResultAsJsonList(await ExecuteAsync(sqlExecuteStructure)),
@@ -163,7 +164,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 _sqlMetadataProvider,
                 _authorizationResolver,
                 _gQLFilterParser,
-                context.ResolvedParameters);
+                context.ResolvedParameters,
+                ApiType.REST);
             using JsonDocument? queryJson = await ExecuteAsync(structure);
             // queryJson is null if dbreader had no rows to return
             // If no rows/empty result set, return an empty json array


### PR DESCRIPTION
## Why make this change?

Per this comment: https://github.com/Azure/data-api-builder/pull/1636#issuecomment-1695050975, need to differently parse `System.DateTime` values for GQL/REST. Specifically:

1. For REST, parse `System.DateTime` values using `System.DateTime` class and populate the `DbType` while passing the parsed value to the database.
2. For GQL, parse `System.DateTime` values using `System.DateTimeOffset` class and don't populate the `DbType` while passing the parsed value to the database so as to avoid mismatch between the parsed value type (`System.DateTimeOffset`) and passed DbType (`DbType.DateTime`/`DbType.DateTime2`/`DbType.Date`/`DbType.SmallDateTime`). (Since `smalldatetime`, `date`, `datetime`,  `datetime2` types in MsSql map to .NET type of `System.DateTime`.)

## What is this change?
1. Based on the ApiType, differently parse System.DateTime values for REST/GQL in `BaseSqlQueryStructure.ParseParamAsSystemType` method.
2. Avoid populate DbType for System.DateTime for GQL in `BaseQueryStructure.MakeDbConnectionParam()` method.

## How was this tested?
Passing of existing test cases confirms the refactor.