### PR TITLE
[Configuration] Initialize optional properties with defaults

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -161,7 +161,7 @@
             "mode": {
               "description": "Set if running in Development or Production mode",
               "type": "string",
-              "default": "production",
+              "default": "development",
               "enum": [
                 "production",
                 "development"

--- a/src/Cli.Tests/TestHelper.cs
+++ b/src/Cli.Tests/TestHelper.cs
@@ -868,7 +868,7 @@ namespace Cli.Tests
           ""graphql"": {
             ""path"": ""/graphql"",
             ""enabled"": true,
-            ""allow-introspection"": true
+            ""allow-introspection"": false
           },
           ""host"": {
             ""mode"": ""production"",
@@ -915,11 +915,6 @@ namespace Cli.Tests
           ""connection-string"": ""localhost:5000;User ID={USER_NAME};Password={USER_PASSWORD};MultipleActiveResultSets=False;""
         },
         ""runtime"": {
-          ""graphql"": {
-            ""path"": ""/graphql"",
-            ""enabled"": true,
-            ""allow-introspection"": true
-          },
           ""host"": {
             ""mode"": ""production"",
             ""cors"": {
@@ -988,7 +983,7 @@ namespace Cli.Tests
           ""graphql"": {
             ""path"": ""/graphql"",
             ""enabled"": true,
-            ""allow-introspection"": true
+            ""allow-introspection"": false
           },
           ""host"": {
             ""mode"": ""production"",

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -205,50 +205,6 @@ namespace Cli
         }
 
         /// <summary>
-        /// Returns the default host Global Settings
-        /// If the user doesn't specify host mode. Default value to be used is Production.
-        /// Sample:
-        // "host": {
-        //     "mode": "production",
-        //     "cors": {
-        //         "origins": [],
-        //         "allow-credentials": true
-        //     },
-        //     "authentication": {
-        //         "provider": "StaticWebApps"
-        //     }
-        // }
-        /// </summary>
-        public static HostOptions GetDefaultHostOptions(
-            HostMode hostMode,
-            IEnumerable<string>? corsOrigin,
-            string authenticationProvider,
-            string? audience,
-            string? issuer)
-        {
-            string[]? corsOriginArray = corsOrigin is null ? new string[] { } : corsOrigin.ToArray();
-            CorsOptions cors = new(Origins: corsOriginArray);
-            AuthenticationOptions AuthenticationOptions;
-            if (Enum.TryParse<EasyAuthType>(authenticationProvider, ignoreCase: true, out _)
-                || AuthenticationOptions.SIMULATOR_AUTHENTICATION.Equals(authenticationProvider))
-            {
-                AuthenticationOptions = new(Provider: authenticationProvider, null);
-            }
-            else
-            {
-                AuthenticationOptions = new(
-                    Provider: authenticationProvider,
-                    Jwt: new(audience, issuer)
-                );
-            }
-
-            return new(
-                Mode: hostMode,
-                Cors: cors,
-                Authentication: AuthenticationOptions);
-        }
-
-        /// <summary>
         /// Returns an object of type Policy
         /// If policyRequest or policyDatabase is provided. Otherwise, returns null.
         /// </summary>

--- a/src/Config/Converters/RuntimeEntitiesConverter.cs
+++ b/src/Config/Converters/RuntimeEntitiesConverter.cs
@@ -26,9 +26,8 @@ class RuntimeEntitiesConverter : JsonConverter<RuntimeEntities>
         writer.WriteStartObject();
         foreach ((string key, Entity entity) in value.Entities)
         {
-            string json = JsonSerializer.Serialize(entity, options);
             writer.WritePropertyName(key);
-            writer.WriteRawValue(json);
+            JsonSerializer.Serialize(writer, entity, options);
         }
 
         writer.WriteEndObject();

--- a/src/Config/ObjectModel/AuthenticationOptions.cs
+++ b/src/Config/ObjectModel/AuthenticationOptions.cs
@@ -11,7 +11,7 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 /// </param>
 /// <param name="Jwt">Settings enabling validation of the received JWT token.
 /// Required only when Provider is other than EasyAuth.</param>
-public record AuthenticationOptions(string Provider, JwtOptions? Jwt)
+public record AuthenticationOptions(string Provider = nameof(EasyAuthType.StaticWebApps), JwtOptions? Jwt = null)
 {
     public const string SIMULATOR_AUTHENTICATION = "Simulator";
     public const string CLIENT_PRINCIPAL_HEADER = "X-MS-CLIENT-PRINCIPAL";

--- a/src/Config/ObjectModel/CorsOptions.cs
+++ b/src/Config/ObjectModel/CorsOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 namespace Azure.DataApiBuilder.Config.ObjectModel;
 
 /// <summary>
@@ -9,4 +11,16 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 /// <param name="Origins">List of allowed origins.</param>
 /// <param name="AllowCredentials">
 /// Whether to set Access-Control-Allow-Credentials CORS header.</param>
-public record CorsOptions(string[] Origins, bool AllowCredentials = false);
+public record CorsOptions
+{
+    public string[] Origins;
+
+    public bool AllowCredentials;
+
+    [JsonConstructor]
+    public CorsOptions(string[]? Origins, bool AllowCredentials = false)
+    {
+        this.Origins = Origins is null ? new string[] { } : Origins.ToArray();
+        this.AllowCredentials = AllowCredentials;
+    }
+}

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -3,4 +3,49 @@
 
 namespace Azure.DataApiBuilder.Config.ObjectModel;
 
-public record HostOptions(CorsOptions? Cors, AuthenticationOptions? Authentication, HostMode Mode = HostMode.Development);
+public record HostOptions(CorsOptions? Cors, AuthenticationOptions? Authentication, HostMode Mode = HostMode.Development)
+{
+    /// <summary>
+    /// Returns the default host Global Settings
+    /// If the user doesn't specify host mode. Default value to be used is Development.
+    /// Sample:
+    // "host": {
+    //     "mode": "development",
+    //     "cors": {
+    //         "origins": [],
+    //         "allow-credentials": true
+    //     },
+    //     "authentication": {
+    //         "provider": "StaticWebApps"
+    //     }
+    // }
+    /// </summary>
+    public static HostOptions GetDefaultHostOptions(
+        HostMode hostMode,
+        IEnumerable<string>? corsOrigin,
+        string authenticationProvider,
+        string? audience,
+        string? issuer)
+    {
+        string[]? corsOriginArray = corsOrigin is null ? new string[] { } : corsOrigin.ToArray();
+        CorsOptions cors = new(Origins: corsOriginArray);
+        AuthenticationOptions AuthenticationOptions;
+        if (Enum.TryParse<EasyAuthType>(authenticationProvider, ignoreCase: true, out _)
+            || AuthenticationOptions.SIMULATOR_AUTHENTICATION.Equals(authenticationProvider))
+        {
+            AuthenticationOptions = new(Provider: authenticationProvider, null);
+        }
+        else
+        {
+            AuthenticationOptions = new(
+                Provider: authenticationProvider,
+                Jwt: new(audience, issuer)
+            );
+        }
+
+        return new(
+            Mode: hostMode,
+            Cors: cors,
+            Authentication: AuthenticationOptions);
+    }
+}

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -33,7 +33,7 @@ public record HostOptions(CorsOptions? Cors, AuthenticationOptions? Authenticati
         if (Enum.TryParse<EasyAuthType>(authenticationProvider, ignoreCase: true, out _)
             || AuthenticationOptions.SIMULATOR_AUTHENTICATION.Equals(authenticationProvider))
         {
-            AuthenticationOptions = new(Provider: authenticationProvider, null);
+            AuthenticationOptions = new(Provider: authenticationProvider, Jwt: null);
         }
         else
         {

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -6,12 +6,32 @@ using System.Text.Json.Serialization;
 
 namespace Azure.DataApiBuilder.Config.ObjectModel;
 
-public record RuntimeConfig(
-    [property: JsonPropertyName("$schema")] string Schema,
-    DataSource DataSource,
-    RuntimeOptions Runtime,
-    RuntimeEntities Entities)
+public record RuntimeConfig
 {
+    [JsonPropertyName("$schema")]
+    public string Schema;
+
+    public DataSource DataSource;
+
+    public RuntimeOptions Runtime;
+
+    public RuntimeEntities Entities;
+
+    [JsonConstructor]
+    public RuntimeConfig(string Schema, DataSource DataSource, RuntimeEntities Entities, RuntimeOptions? Runtime = null)
+    {
+        this.Schema = Schema;
+
+        this.DataSource = DataSource;
+        this.Runtime = Runtime ??
+            new RuntimeOptions(
+                new RestRuntimeOptions(Enabled: DataSource.DatabaseType != DatabaseType.CosmosDB_NoSQL),
+                GraphQL: null, // even though we pass null here, the constructor will take care of initializing with defaults.
+                Host: null); 
+
+        this.Entities = Entities;
+    }
+
     /// <summary>
     /// Serializes the RuntimeConfig object to JSON for writing to file.
     /// </summary>

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -11,6 +11,8 @@ public record RuntimeConfig
     [JsonPropertyName("$schema")]
     public string Schema;
 
+    public const string DEFAULT_CONFIG_SCHEMA_LINK = "https://github.com/Azure/data-api-builder/releases/download/vmajor.minor.patch/dab.draft.schema.json";
+
     public DataSource DataSource;
 
     public RuntimeOptions Runtime;
@@ -18,9 +20,9 @@ public record RuntimeConfig
     public RuntimeEntities Entities;
 
     [JsonConstructor]
-    public RuntimeConfig(string Schema, DataSource DataSource, RuntimeEntities Entities, RuntimeOptions? Runtime = null)
+    public RuntimeConfig(string? Schema, DataSource DataSource, RuntimeEntities Entities, RuntimeOptions? Runtime = null)
     {
-        this.Schema = Schema;
+        this.Schema = Schema ?? DEFAULT_CONFIG_SCHEMA_LINK;
 
         this.DataSource = DataSource;
         this.Runtime = Runtime ??

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -27,7 +27,7 @@ public record RuntimeConfig
             new RuntimeOptions(
                 new RestRuntimeOptions(Enabled: DataSource.DatabaseType != DatabaseType.CosmosDB_NoSQL),
                 GraphQL: null, // even though we pass null here, the constructor will take care of initializing with defaults.
-                Host: null); 
+                Host: null);
 
         this.Entities = Entities;
     }

--- a/src/Config/ObjectModel/RuntimeOptions.cs
+++ b/src/Config/ObjectModel/RuntimeOptions.cs
@@ -1,6 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 namespace Azure.DataApiBuilder.Config.ObjectModel;
 
-public record RuntimeOptions(RestRuntimeOptions Rest, GraphQLRuntimeOptions GraphQL, HostOptions Host, string? BaseRoute = null);
+public record RuntimeOptions
+{
+    public RestRuntimeOptions Rest;
+    public GraphQLRuntimeOptions GraphQL;
+    public HostOptions Host;
+    public string? BaseRoute;
+
+    [JsonConstructor]
+    public RuntimeOptions(RestRuntimeOptions? Rest, GraphQLRuntimeOptions? GraphQL, HostOptions? Host, string? BaseRoute = null)
+    {
+        this. Rest = Rest ?? new RestRuntimeOptions();
+        this.GraphQL = GraphQL ?? new GraphQLRuntimeOptions();
+        this.Host = Host ?? HostOptions.GetDefaultHostOptions(
+            HostMode.Development,
+            corsOrigin: null,
+            EasyAuthType.StaticWebApps.ToString(),
+            audience: null, issuer: null);
+    }
+}

--- a/src/Config/ObjectModel/RuntimeOptions.cs
+++ b/src/Config/ObjectModel/RuntimeOptions.cs
@@ -22,5 +22,6 @@ public record RuntimeOptions
             corsOrigin: null,
             EasyAuthType.StaticWebApps.ToString(),
             audience: null, issuer: null);
+        this.BaseRoute = BaseRoute;
     }
 }

--- a/src/Config/ObjectModel/RuntimeOptions.cs
+++ b/src/Config/ObjectModel/RuntimeOptions.cs
@@ -15,7 +15,7 @@ public record RuntimeOptions
     [JsonConstructor]
     public RuntimeOptions(RestRuntimeOptions? Rest, GraphQLRuntimeOptions? GraphQL, HostOptions? Host, string? BaseRoute = null)
     {
-        this. Rest = Rest ?? new RestRuntimeOptions();
+        this.Rest = Rest ?? new RestRuntimeOptions();
         this.GraphQL = GraphQL ?? new GraphQLRuntimeOptions();
         this.Host = Host ?? HostOptions.GetDefaultHostOptions(
             HostMode.Development,

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -64,8 +64,6 @@ public abstract class RuntimeConfigLoader
             {
                 config = config with { DataSource = config.DataSource with { ConnectionString = connectionString } };
             }
-
-            config = GetConfigWithDefaultsForNullProps(config);
         }
         catch (JsonException ex)
         {
@@ -88,36 +86,6 @@ public abstract class RuntimeConfigLoader
         }
 
         return true;
-    }
-
-    public static RuntimeConfig GetConfigWithDefaultsForNullProps(RuntimeConfig config)
-    {
-        // For Cosmos DB NoSQL database type, DAB CLI v0.8.49+ generates a REST property within the Runtime section of the config file. However
-        // v0.7.6- does not generate this property. So, when the config file generated using v0.7.6- is used to start the engine with v0.8.49+, the absence
-        // of the REST property causes the engine to throw exceptions. This is the only difference in the way Runtime section of the config file is created
-        // between these two versions.
-        // To avoid the NullReference Exceptions, the REST property is added when absent in the config file.
-        // Other properties within the Runtime section are also populated with default values to account for the cases where
-        // the properties could be removed manually from the config file.
-        if (config.Runtime is not null)
-        {
-            if (config.Runtime.Rest is null)
-            {
-                config = config with { Runtime = config.Runtime with { Rest = (config.DataSource.DatabaseType is DatabaseType.CosmosDB_NoSQL) ? new RestRuntimeOptions(Enabled: false) : new RestRuntimeOptions(Enabled: false) } };
-            }
-
-            if (config.Runtime.GraphQL is null)
-            {
-                config = config with { Runtime = config.Runtime with { GraphQL = new GraphQLRuntimeOptions(AllowIntrospection: false) } };
-            }
-
-            if (config.Runtime.Host is null)
-            {
-                config = config with { Runtime = config.Runtime with { Host = new HostOptions(Cors: null, Authentication: new AuthenticationOptions(Provider: EasyAuthType.StaticWebApps.ToString(), Jwt: null), Mode: HostMode.Production) } };
-            }
-        }
-
-        return config;
     }
 
     /// <summary>

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -1994,7 +1994,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             }
             else if (configurationEndpoint == CONFIGURATION_ENDPOINT_V2)
             {
-                RuntimeConfig overrides = new(null, new DataSource(DatabaseType.MSSQL, connectionString, new()), null, null);
+                RuntimeConfig overrides = new(null, new DataSource(DatabaseType.MSSQL, connectionString, new()),
+                    Entities: null, runtimeConfig.Runtime);
 
                 ConfigurationPostParametersV2 returnParams = new(
                     Configuration: serializedConfiguration,

--- a/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
@@ -325,6 +325,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             Assert.IsTrue(parsedConfig.Runtime.GraphQL.Enabled);
             Assert.AreEqual(GraphQLRuntimeOptions.DEFAULT_PATH, parsedConfig.Runtime.GraphQL.Path);
             Assert.IsTrue(parsedConfig.Runtime.GraphQL.AllowIntrospection);
+            Assert.IsNull(parsedConfig.Runtime.BaseRoute);
             Assert.AreEqual(HostMode.Development, parsedConfig.Runtime.Host.Mode);
             if (isHostSpecifiedButEmpty)
             {


### PR DESCRIPTION
## Why make this change?

- As per the JSON config schema, not all properties in the config file are mandatory. 
- With #1402, in versions 0.8.49+ those properties that are not explicitly set, are initialized with defaults before writing to the file system. 
- However, config files generated using version 0.7.6 or lesser, may not have these properties initialized to their defaults when writing to the file system. Using config files generated with <= 0.7.6, to start engine with 0.8.49 would therefore lead to null reference exceptions when the optional properties are dereferenced.
- This PR is to ensure such null reference exceptions are avoided when starting engine with configs that don't have optional properties

## What is this change?
- Modify object model constructors to accept nullable arguments for optional properties - represented as fields in the record types. If passed in argument is null, initialize the field with default values. Do this recursively for sub-properties.
- To force JSON deserializer to pick up the custom constructor, add `IncludeFields = true` to `JsonSerializerOptions`
- Default value of host mode is changed to `development` since `allow-introspection` has a default value of `true`

## How was this tested?
- Removed optional properties from config and ensured engine could be started without them.
- [X] Unit Tests

## Sample Request(s)

- remove `runtime` section from config, starting engine with 0.8.49 leads to NullReferenceException. 
- After the fix, starting engine is successful even when `runtime` section is absent in the config. 