### PR TITLE
Multiple dataSources support

### DIFF
--- a/src/Core/Resolvers/CosmosMutationEngine.cs
+++ b/src/Core/Resolvers/CosmosMutationEngine.cs
@@ -8,6 +8,7 @@ using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Authorization;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Services;
+using Azure.DataApiBuilder.Core.Services.MetadataProviders;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Queries;
@@ -23,20 +24,20 @@ namespace Azure.DataApiBuilder.Core.Resolvers
     public class CosmosMutationEngine : IMutationEngine
     {
         private readonly CosmosClientProvider _clientProvider;
-        private readonly ISqlMetadataProvider _metadataProvider;
+        private readonly IMetadataProviderFactory _metadataProviderFactory;
         private readonly IAuthorizationResolver _authorizationResolver;
 
         public CosmosMutationEngine(
             CosmosClientProvider clientProvider,
-            ISqlMetadataProvider metadataProvider,
+            IMetadataProviderFactory metadataProviderFactory,
             IAuthorizationResolver authorizationResolver)
         {
             _clientProvider = clientProvider;
-            _metadataProvider = metadataProvider;
+            _metadataProviderFactory = metadataProviderFactory;
             _authorizationResolver = authorizationResolver;
         }
 
-        private async Task<JObject> ExecuteAsync(IMiddlewareContext context, IDictionary<string, object?> queryArgs, CosmosOperationMetadata resolver, string dataSourceName = "")
+        private async Task<JObject> ExecuteAsync(IMiddlewareContext context, IDictionary<string, object?> queryArgs, CosmosOperationMetadata resolver, string dataSourceName)
         {
             // TODO: add support for all mutation types
             // we only support CreateOrUpdate (Upsert) for now
@@ -45,11 +46,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             {
                 // TODO: in which scenario the queryArgs is empty
                 throw new ArgumentNullException(nameof(queryArgs));
-            }
-
-            if (string.IsNullOrEmpty(dataSourceName))
-            {
-                dataSourceName = _clientProvider.RuntimeConfigProvider.GetConfig().GetDefaultDataSourceName();
             }
 
             CosmosClient? client = _clientProvider.Clients[dataSourceName];
@@ -64,9 +60,10 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             Container container = client.GetDatabase(resolver.DatabaseName)
                                         .GetContainer(resolver.ContainerName);
 
+            ISqlMetadataProvider metadataProvider = _metadataProviderFactory.GetMetadataProvider(dataSourceName);
             // If authorization fails, an exception will be thrown and request execution halts.
             string graphQLType = context.Selection.Field.Type.NamedType().Name.Value;
-            string entityName = _metadataProvider.GetEntityName(graphQLType);
+            string entityName = metadataProvider.GetEntityName(graphQLType);
             AuthorizeMutationFields(context, queryArgs, entityName, resolver.OperationType);
 
             ItemResponse<JObject>? response = resolver.OperationType switch
@@ -307,14 +304,17 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         /// <param name="context">context of graphql mutation</param>
         /// <param name="parameters">parameters in the mutation query.</param>
+        /// <param name="dataSourceName">dataSourceName to execute against.</param>
         /// <returns>JSON object result</returns>
         public async Task<Tuple<JsonDocument?, IMetadata?>> ExecuteAsync(IMiddlewareContext context,
-            IDictionary<string, object?> parameters)
+            IDictionary<string, object?> parameters,
+            string dataSourceName)
         {
+            ISqlMetadataProvider metadataProvider = _metadataProviderFactory.GetMetadataProvider(dataSourceName);
             string graphQLType = context.Selection.Field.Type.NamedType().Name.Value;
-            string entityName = _metadataProvider.GetEntityName(graphQLType);
-            string databaseName = _metadataProvider.GetSchemaName(entityName);
-            string containerName = _metadataProvider.GetDatabaseObjectName(entityName);
+            string entityName = metadataProvider.GetEntityName(graphQLType);
+            string databaseName = metadataProvider.GetSchemaName(entityName);
+            string containerName = metadataProvider.GetDatabaseObjectName(entityName);
 
             string graphqlMutationName = context.Selection.Field.Name.Value;
             EntityActionOperation mutationOperation =
@@ -323,7 +323,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             CosmosOperationMetadata mutation = new(databaseName, containerName, mutationOperation);
             // TODO: we are doing multiple round of serialization/deserialization
             // fixme
-            JObject jObject = await ExecuteAsync(context, parameters, mutation);
+            JObject jObject = await ExecuteAsync(context, parameters, mutation, dataSourceName);
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             return new Tuple<JsonDocument?, IMetadata?>((jObject is null) ? null! : JsonDocument.Parse(jObject.ToString()), null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
@@ -340,7 +340,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         }
 
         /// <inheritdoc/>
-        public Task<IActionResult?> ExecuteAsync(StoredProcedureRequestContext context)
+        public Task<IActionResult?> ExecuteAsync(StoredProcedureRequestContext context, string dataSourceName)
         {
             throw new NotImplementedException();
         }

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -184,7 +184,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         }
 
         /// <inheritdoc />
-        public Task<IActionResult> ExecuteAsync(FindRequestContext context, string dataSourceName = "")
+        public Task<IActionResult> ExecuteAsync(FindRequestContext context)
         {
             throw new NotImplementedException();
         }

--- a/src/Core/Resolvers/DbExceptionParser.cs
+++ b/src/Core/Resolvers/DbExceptionParser.cs
@@ -66,5 +66,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="e">The exception thrown as a result of execution of the request.</param>
         /// <returns>status code to be returned in the response.</returns>
         public abstract HttpStatusCode GetHttpStatusCodeForException(DbException e);
+
+        /// <summary>
+        /// Derives the database type
+        /// </summary>
+        /// <returns>DatabaseType.</returns>
+        public abstract DatabaseType DeriveDatabaseType();
     }
 }

--- a/src/Core/Resolvers/IMutationEngine.cs
+++ b/src/Core/Resolvers/IMutationEngine.cs
@@ -19,9 +19,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         /// <param name="context">Middleware context of the mutation</param>
         /// <param name="parameters">parameters in the mutation query.</param>
+        /// <param name="dataSourceName">dataSourceName to execute against.</param>
         /// <returns>JSON object result and a metadata object required to resolve the result</returns>
         public Task<Tuple<JsonDocument?, IMetadata?>> ExecuteAsync(IMiddlewareContext context,
-            IDictionary<string, object?> parameters);
+            IDictionary<string, object?> parameters,
+            string dataSourceName);
 
         /// <summary>
         /// Executes the mutation query and returns result as JSON object asynchronously.
@@ -34,7 +36,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// Executes the stored procedure as a mutation query and returns result as JSON asynchronously.
         /// Execution will be identical regardless of mutation operation, but result returned will differ
         /// </summary>
-        public Task<IActionResult?> ExecuteAsync(StoredProcedureRequestContext context);
+        public Task<IActionResult?> ExecuteAsync(StoredProcedureRequestContext context, string dataSourceName);
 
         /// <summary>
         /// Authorization check on mutation fields provided in a GraphQL Mutation request.

--- a/src/Core/Resolvers/IMutationEngineFactory.cs
+++ b/src/Core/Resolvers/IMutationEngineFactory.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.DataApiBuilder.Config.ObjectModel;
+
+namespace Azure.DataApiBuilder.Core.Resolvers
+{
+    /// <summary>
+    /// MutationEngineFactory interface.
+    /// Used in DI container to get the IMutationEngine based on database type.
+    /// </summary>
+    public interface IMutationEngineFactory
+    {
+        /// <summary>
+        /// Gets the MutationEngine based on database type.
+        /// </summary>
+        /// <param name="databaseType">databaseType.</param>
+        /// <returns>IMutationEngine based on database type..</returns>
+        public IMutationEngine GetMutationEngine(DatabaseType databaseType);
+    }
+}

--- a/src/Core/Resolvers/IQueryBuilder.cs
+++ b/src/Core/Resolvers/IQueryBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.DataApiBuilder.Config.ObjectModel;
+
 namespace Azure.DataApiBuilder.Core.Resolvers
 {
     // <summary>
@@ -63,6 +65,12 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="databaseObjectName">Name of stored-procedure</param>
         /// <returns></returns>
         public string BuildStoredProcedureResultDetailsQuery(string databaseObjectName);
+
+        /// <summary>
+        /// Derives the database type of the query builder.
+        /// </summary>
+        /// <returns>databaseType.</returns>
+        public DatabaseType DeriveDatabaseType();
 
         /// <summary>
         /// Adds database specific quotes to string identifier

--- a/src/Core/Resolvers/IQueryEngine.cs
+++ b/src/Core/Resolvers/IQueryEngine.cs
@@ -34,7 +34,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <summary>
         /// Given the RestRequestContext, obtains the query text and executes it against the backend.
         /// </summary>
-        public Task<IActionResult> ExecuteAsync(FindRequestContext context, string dataSourceName = "");
+        public Task<IActionResult> ExecuteAsync(FindRequestContext context);
 
         /// <summary>
         /// Given the StoredProcedureRequestContext, obtains the query text and executes it against the backend.
@@ -50,6 +50,5 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// Resolves a jsonElement representing a list type based on the field's schema and metadata
         /// </summary>
         public object? ResolveListType(JsonElement element, IObjectField fieldSchema, ref IMetadata metadata);
-
     }
 }

--- a/src/Core/Resolvers/IQueryEngineFactory.cs
+++ b/src/Core/Resolvers/IQueryEngineFactory.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.DataApiBuilder.Config.ObjectModel;
+
+namespace Azure.DataApiBuilder.Core.Resolvers
+{
+    /// <summary>
+    /// QueryEngineFactory interface.
+    /// Used in DI container to retrieve appropriate queryEngine
+    /// </summary>
+    public interface IQueryEngineFactory
+    {
+        /// <summary>
+        /// Gets the QueryEngine based on database type.
+        /// </summary>
+        /// <param name="databaseType">databaseType.</param>
+        /// <returns>QueryEngine based on database type.</returns>
+        public IQueryEngine GetQueryEngine(DatabaseType databaseType);
+    }
+}

--- a/src/Core/Resolvers/IQueryExecutor.cs
+++ b/src/Core/Resolvers/IQueryExecutor.cs
@@ -3,6 +3,7 @@
 
 using System.Data.Common;
 using System.Text.Json.Nodes;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Models;
 using Microsoft.AspNetCore.Http;
 
@@ -119,5 +120,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="parameterEntry">Entry corresponding to current database parameter to be created.</param>
         /// <param name="parameter">Parameter sent to database.</param>
         public void PopulateDbTypeForParameter(KeyValuePair<string, DbConnectionParam> parameterEntry, DbParameter parameter);
+
+        /// <summary>
+        /// Gets the database type for the current query executor.
+        /// </summary>
+        /// <returns>database type.</returns>
+        public DatabaseType DeriveDatabaseType();
     }
 }

--- a/src/Core/Resolvers/IQueryManagerFactory.cs
+++ b/src/Core/Resolvers/IQueryManagerFactory.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Azure.DataApiBuilder.Config.ObjectModel;
+
+namespace Azure.DataApiBuilder.Core.Resolvers
+{
+    /// <summary>
+    /// QueryManager Factory.
+    /// Used to get IQueryBuilder,IQueryExecutor and DbExceptionParser based on database type.
+    /// </summary>
+    public interface IQueryManagerFactory
+    {
+        /// <summary>
+        /// Gets Query Builder based on database type.
+        /// </summary>
+        /// <param name="databaseType">databaseType.</param>
+        /// <returns>IQuerybuilder based on databaseType.</returns>
+        public IQueryBuilder GetQueryBuilder(DatabaseType databaseType);
+
+        /// <summary>
+        /// Gets Query Executor based on database type.
+        /// </summary>
+        /// <param name="databaseType">databaseType.</param>
+        /// <returns>IQueryExecutor based on databaseType.</returns>
+        public IQueryExecutor GetQueryExecutor(DatabaseType databaseType);
+
+        /// <summary>
+        /// Gets DbExceptionParser based on database type.
+        /// </summary>
+        /// <param name="databaseType">databaseType.</param>
+        /// <returns>DBExceptionParser based on databaseType</returns>
+        public DbExceptionParser GetDbExceptionParser(DatabaseType databaseType);
+    }
+}

--- a/src/Core/Resolvers/MsSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MsSqlDbExceptionParser.cs
@@ -3,6 +3,7 @@
 
 using System.Data.Common;
 using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Microsoft.Data.SqlClient;
 
@@ -84,6 +85,12 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         {
             string errorNumber = ((SqlException)e).Number.ToString();
             return TransientExceptionCodes.Contains(errorNumber);
+        }
+
+        /// <inheritdoc />
+        public override DatabaseType DeriveDatabaseType()
+        {
+            return DatabaseType.MSSQL;
         }
     }
 }

--- a/src/Core/Resolvers/MsSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/MsSqlQueryBuilder.cs
@@ -256,5 +256,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             "WHERE is_hidden is not NULL AND is_hidden = 0";
             return query;
         }
+
+        /// <inheritdoc />
+        public DatabaseType DeriveDatabaseType()
+        {
+            return DatabaseType.MSSQL;
+        }
     }
 }

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -70,7 +70,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             : base(dbExceptionParser,
                   logger,
                   runtimeConfigProvider,
-                  httpContextAccessor)
+                  httpContextAccessor,
+                  DatabaseType.MSSQL)
         {
             RuntimeConfig runtimeConfig = runtimeConfigProvider.GetConfig();
             IEnumerable<KeyValuePair<string, DataSource>> mssqldbs = runtimeConfig.GetDataSourceNamesToDataSourcesIterator().Where(x => x.Value.DatabaseType == DatabaseType.MSSQL);

--- a/src/Core/Resolvers/MutationEngineFactory.cs
+++ b/src/Core/Resolvers/MutationEngineFactory.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Service.Exceptions;
+
+namespace Azure.DataApiBuilder.Core.Resolvers
+{
+    /// <summary>
+    /// MutationEngineFactory class.
+    /// Used to get the IMutationEngine based on database type.
+    /// </summary>
+    public class MutationEngineFactory : IMutationEngineFactory
+    {
+        private readonly IEnumerable<IMutationEngine> _mutationEngines;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MutationEngineFactory"/> class.
+        /// </summary>
+        /// <param name="mutationEngines">mutationEngines from DI container</param>
+        public MutationEngineFactory(IEnumerable<IMutationEngine> mutationEngines)
+        {
+            _mutationEngines = mutationEngines;
+        }
+
+        /// <summary>
+        /// Gets the MutationEngine based on database type.
+        /// </summary>
+        /// <param name="databaseType">databaseType.</param>
+        /// <returns>IMutationEngine.</returns>
+        /// <exception cref="DataApiBuilderException">Exception if databaseType not found.</exception>
+        public IMutationEngine GetMutationEngine(DatabaseType databaseType)
+        {
+            IMutationEngine mutationEngine = databaseType switch
+            {
+                DatabaseType.CosmosDB_NoSQL or DatabaseType.CosmosDB_PostgreSQL => _mutationEngines.First(engine => engine.GetType() == typeof(CosmosMutationEngine)),
+                DatabaseType.MySQL or DatabaseType.MSSQL or DatabaseType.PostgreSQL => _mutationEngines.First(engine => engine.GetType() == typeof(SqlMutationEngine)),
+                _ => throw new DataApiBuilderException($"{nameof(databaseType)}:{databaseType} could not be found within the config", HttpStatusCode.BadRequest, DataApiBuilderException.SubStatusCodes.DataSourceNotFound)
+            };
+
+            return mutationEngine;
+        }
+    }
+}

--- a/src/Core/Resolvers/MySqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MySqlDbExceptionParser.cs
@@ -3,6 +3,7 @@
 
 using System.Data.Common;
 using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using MySqlConnector;
 
@@ -87,6 +88,12 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             }
 
             return HttpStatusCode.InternalServerError;
+        }
+
+        /// <inheritdoc />
+        public override DatabaseType DeriveDatabaseType()
+        {
+            return DatabaseType.MySQL;
         }
     }
 }

--- a/src/Core/Resolvers/MySqlQueryBuilder.cs
+++ b/src/Core/Resolvers/MySqlQueryBuilder.cs
@@ -328,5 +328,11 @@ WHERE
         {
             throw new NotImplementedException();
         }
+
+        /// <inheritdoc />
+        public DatabaseType DeriveDatabaseType()
+        {
+            return DatabaseType.MySQL;
+        }
     }
 }

--- a/src/Core/Resolvers/MySqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MySqlQueryExecutor.cs
@@ -59,7 +59,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             : base(dbExceptionParser,
                   logger,
                   runtimeConfigProvider,
-                  httpContextAccessor)
+                  httpContextAccessor,
+                  DatabaseType.MySQL)
         {
             _dataSourceAccessTokenUsage = new Dictionary<string, bool>();
             _accessTokensFromConfiguration = runtimeConfigProvider.ManagedIdentityAccessToken;

--- a/src/Core/Resolvers/PostgreSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/PostgreSqlDbExceptionParser.cs
@@ -3,6 +3,7 @@
 
 using System.Data.Common;
 using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 
 namespace Azure.DataApiBuilder.Core.Resolvers
@@ -120,6 +121,12 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             }
 
             return HttpStatusCode.InternalServerError;
+        }
+
+        /// <inheritdoc />
+        public override DatabaseType DeriveDatabaseType()
+        {
+            return DatabaseType.PostgreSQL;
         }
     }
 }

--- a/src/Core/Resolvers/PostgreSqlExecutor.cs
+++ b/src/Core/Resolvers/PostgreSqlExecutor.cs
@@ -60,7 +60,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             : base(dbExceptionParser,
                   logger,
                   runtimeConfigProvider,
-                  httpContextAccessor)
+                  httpContextAccessor,
+                  DatabaseType.PostgreSQL)
         {
             IEnumerable<KeyValuePair<string, DataSource>> postgresqldbs = runtimeConfigProvider.GetConfig().GetDataSourceNamesToDataSourcesIterator().Where(x => x.Value.DatabaseType == DatabaseType.PostgreSQL);
             _dataSourceAccessTokenUsage = new Dictionary<string, bool>();

--- a/src/Core/Resolvers/PostgresQueryBuilder.cs
+++ b/src/Core/Resolvers/PostgresQueryBuilder.cs
@@ -224,5 +224,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         {
             throw new NotImplementedException();
         }
+
+        /// <inheritdoc />
+        public DatabaseType DeriveDatabaseType()
+        {
+            return DatabaseType.PostgreSQL;
+        }
     }
 }

--- a/src/Core/Resolvers/QueryEngineFactory.cs
+++ b/src/Core/Resolvers/QueryEngineFactory.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Service.Exceptions;
+
+namespace Azure.DataApiBuilder.Core.Resolvers
+{
+    /// <summary>
+    /// QueryEngineFactory class.
+    /// Used to get the appropriate queryEngine based on database type.
+    /// </summary>
+    public class QueryEngineFactory : IQueryEngineFactory
+    {
+        private readonly IEnumerable<IQueryEngine> _queryEngines;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryEngineFactory"/> class.
+        /// </summary>
+        /// <param name="queryEngines">queryEngines.</param>
+        public QueryEngineFactory(IEnumerable<IQueryEngine> queryEngines)
+        {
+            _queryEngines = queryEngines;
+        }
+
+        /// <summary>
+        /// Gets the QueryEngine based on database type.
+        /// </summary>
+        /// <param name="databaseType">databaseType.</param>
+        /// <returns>IQueryEngine</returns>
+        /// <exception cref="DataApiBuilderException">exception thrown if databaseType not found.</exception>
+        public IQueryEngine GetQueryEngine(DatabaseType databaseType)
+        {
+            IQueryEngine queryEngine = databaseType switch
+            {
+                DatabaseType.CosmosDB_NoSQL or DatabaseType.CosmosDB_PostgreSQL => _queryEngines.First(engine => engine.GetType() == typeof(CosmosQueryEngine)),
+                DatabaseType.MySQL or DatabaseType.MSSQL or DatabaseType.PostgreSQL => _queryEngines.First(engine => engine.GetType() == typeof(SqlQueryEngine)),
+                _ => throw new DataApiBuilderException($"{nameof(databaseType)}:{databaseType} could not be found within the config", HttpStatusCode.BadRequest, DataApiBuilderException.SubStatusCodes.DataSourceNotFound)
+            };
+
+            return queryEngine;
+        }
+    }
+}

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Service.Exceptions;
@@ -34,6 +35,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
         private AsyncRetryPolicy _retryPolicy;
 
+        private DatabaseType _databaseType;
+
         /// <summary>
         /// Dictionary that stores dataSourceName to its corresponding connection string builder.
         /// </summary>
@@ -42,13 +45,15 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         public QueryExecutor(DbExceptionParser dbExceptionParser,
                              ILogger<IQueryExecutor> logger,
                              RuntimeConfigProvider configProvider,
-                             IHttpContextAccessor httpContextAccessor)
+                             IHttpContextAccessor httpContextAccessor,
+                             DatabaseType databaseType)
         {
             DbExceptionParser = dbExceptionParser;
             QueryExecutorLogger = logger;
             ConnectionStringBuilders = new Dictionary<string, DbConnectionStringBuilder>();
             ConfigProvider = configProvider;
             HttpContextAccessor = httpContextAccessor;
+            _databaseType = databaseType;
             _retryPolicy = Policy
             .Handle<DbException>(DbExceptionParser.IsTransientException)
             .WaitAndRetryAsync(
@@ -403,6 +408,12 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             }
 
             return jsonString.ToString();
+        }
+
+        /// <inheritdoc />
+        public DatabaseType DeriveDatabaseType()
+        {
+            return _databaseType;
         }
     }
 }

--- a/src/Core/Resolvers/QueryManagerFactory.cs
+++ b/src/Core/Resolvers/QueryManagerFactory.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Service.Exceptions;
+
+namespace Azure.DataApiBuilder.Core.Resolvers
+{
+    /// <summary>
+    /// QueryManagerFactory interface.
+    /// Used to get the appropriate query builder, query executor and exception parser and  based on the database type.
+    /// </summary>
+    public class QueryManagerFactory : IQueryManagerFactory
+    {
+        private readonly IDictionary<DatabaseType, IQueryBuilder> _queryBuilders;
+        private readonly IDictionary<DatabaseType, IQueryExecutor> _queryExecutors;
+        private readonly IDictionary<DatabaseType, DbExceptionParser> _dbExceptionsParsers;
+
+        /// <summary>
+        /// Initiates an instance of QueryManagerFactory
+        /// </summary>
+        /// <param name="queryBuilders">queryBuilders.</param>
+        /// <param name="queryExecutors">queryExecutors.</param>
+        /// <param name="dbExceptionsParsers">dbExceptionParsers.</param>
+        public QueryManagerFactory(IEnumerable<IQueryBuilder> queryBuilders,
+            IEnumerable<IQueryExecutor> queryExecutors,
+            IEnumerable<DbExceptionParser> dbExceptionsParsers)
+        {
+            _queryBuilders = queryBuilders.ToDictionary(provider => provider.DeriveDatabaseType(), provider => provider);
+            _queryExecutors = queryExecutors.ToDictionary(provider => provider.DeriveDatabaseType(), provider => provider);
+            _dbExceptionsParsers = dbExceptionsParsers.ToDictionary(provider => provider.DeriveDatabaseType(), provider => provider);
+        }
+
+        /// <inheritdoc />
+        public IQueryBuilder GetQueryBuilder(DatabaseType databaseType)
+        {
+            if (!_queryBuilders.ContainsKey(databaseType))
+            {
+                throw new DataApiBuilderException($"{nameof(DatabaseType)}:{databaseType} could not be found within the config", HttpStatusCode.BadRequest, DataApiBuilderException.SubStatusCodes.DataSourceNotFound);
+            }
+
+            return _queryBuilders[databaseType];
+        }
+
+        /// <inheritdoc />
+        public IQueryExecutor GetQueryExecutor(DatabaseType databaseType)
+        {
+            if (!_queryExecutors.ContainsKey(databaseType))
+            {
+                throw new DataApiBuilderException($"{nameof(databaseType)}:{databaseType} could not be found within the config", HttpStatusCode.BadRequest, DataApiBuilderException.SubStatusCodes.DataSourceNotFound);
+            }
+
+            return _queryExecutors[databaseType];
+        }
+
+        /// <inheritdoc />
+        public DbExceptionParser GetDbExceptionParser(DatabaseType databaseType)
+        {
+            if (!_dbExceptionsParsers.ContainsKey(databaseType))
+            {
+                throw new DataApiBuilderException($"{nameof(databaseType)}:{databaseType} could not be found within the config", HttpStatusCode.BadRequest, DataApiBuilderException.SubStatusCodes.DataSourceNotFound);
+            }
+
+            return _dbExceptionsParsers[databaseType];
+        }
+
+    }
+}

--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -349,5 +349,11 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
         {
             return _runtimeConfig.Runtime.Host.Mode is HostMode.Development;
         }
+
+        /// <inheritdoc />
+        public string GetDatabaseSourceName()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Core/Services/MetadataProviders/IMetadataProviderFactory.cs
+++ b/src/Core/Services/MetadataProviders/IMetadataProviderFactory.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
+{
+    /// <summary>
+    /// IMetadataProviderFactory class.
+    /// Used to get the appropriate metadata provider based on the data source name.
+    /// </summary>
+    public interface IMetadataProviderFactory
+    {
+        /// <summary>
+        /// Gets the appropriate metadata provider based on the data source name.
+        /// </summary>
+        /// <param name="dataSourceName">dataSourceName.</param>
+        /// <returns>ISqlMetadataProvider.</returns>
+        public ISqlMetadataProvider GetMetadataProvider(string dataSourceName);
+
+        /// <summary>
+        /// Initializes the metadata providers.
+        /// </summary>
+        /// <returns>Task.</returns>
+        public Task InitializeAsync();
+    }
+}

--- a/src/Core/Services/MetadataProviders/ISqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/ISqlMetadataProvider.cs
@@ -174,5 +174,11 @@ namespace Azure.DataApiBuilder.Core.Services
         /// mode, it returns false.
         /// </summary>
         public bool IsDevelopmentMode();
+
+        /// <summary>
+        /// Returns the name of the dataSource.
+        /// </summary>
+        /// <returns>DataSourceName</returns>
+        public string GetDatabaseSourceName();
     }
 }

--- a/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
+++ b/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using Azure.DataApiBuilder.Service.Exceptions;
+
+namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
+{
+    /// <inheritdoc />
+    public class MetadataProviderFactory : IMetadataProviderFactory
+    {
+        private readonly IDictionary<string, ISqlMetadataProvider> _metadataProviders;
+
+        public MetadataProviderFactory(IEnumerable<ISqlMetadataProvider> metadataProviders)
+        {
+            _metadataProviders = metadataProviders.ToDictionary(provider => provider.GetDatabaseSourceName(), provider => provider);
+        }
+
+        /// <inheritdoc />
+        public ISqlMetadataProvider GetMetadataProvider(string dataSourceName)
+        {
+            if (!_metadataProviders.ContainsKey(dataSourceName))
+            {
+                throw new DataApiBuilderException($"{nameof(dataSourceName)}:{dataSourceName} could not be found within the config", HttpStatusCode.BadRequest, DataApiBuilderException.SubStatusCodes.DataSourceNotFound);
+            }
+
+            return _metadataProviders[dataSourceName];
+        }
+
+        /// <inheritdoc />
+        public async Task InitializeAsync()
+        {
+            foreach ((_, ISqlMetadataProvider provider) in _metadataProviders)
+            {
+                await provider.InitializeAsync();
+            }
+        }
+    }
+}

--- a/src/Core/Services/MetadataProviders/MsSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/MsSqlMetadataProvider.cs
@@ -4,6 +4,7 @@
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Resolvers;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Azure.DataApiBuilder.Core.Services
@@ -17,12 +18,18 @@ namespace Azure.DataApiBuilder.Core.Services
     public class MsSqlMetadataProvider :
         SqlMetadataProvider<SqlConnection, SqlDataAdapter, SqlCommand>
     {
+        public MsSqlMetadataProvider(IServiceProvider serviceProvider, string dataSourceName)
+            : base(serviceProvider.GetRequiredService<RuntimeConfigProvider>(), serviceProvider.GetRequiredService<IQueryManagerFactory>(), serviceProvider.GetRequiredService<ILogger<ISqlMetadataProvider>>(), dataSourceName)
+        {
+
+        }
+
         public MsSqlMetadataProvider(
             RuntimeConfigProvider runtimeConfigProvider,
-            IQueryExecutor queryExecutor,
-            IQueryBuilder sqlQueryBuilder,
-            ILogger<ISqlMetadataProvider> logger)
-            : base(runtimeConfigProvider, queryExecutor, sqlQueryBuilder, logger)
+            IQueryManagerFactory engineFactory,
+            ILogger<ISqlMetadataProvider> logger,
+            string dataSourceName)
+            : base(runtimeConfigProvider, engineFactory, logger, dataSourceName)
         {
         }
 

--- a/src/Core/Services/MetadataProviders/PostgreSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/PostgreSqlMetadataProvider.cs
@@ -5,6 +5,7 @@ using System.Net;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Resolvers;
 using Azure.DataApiBuilder.Service.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 
@@ -19,12 +20,17 @@ namespace Azure.DataApiBuilder.Core.Services
     public class PostgreSqlMetadataProvider :
         SqlMetadataProvider<NpgsqlConnection, NpgsqlDataAdapter, NpgsqlCommand>
     {
+        public PostgreSqlMetadataProvider(IServiceProvider serviceProvider, string dataSourceName)
+            : base(serviceProvider.GetRequiredService<RuntimeConfigProvider>(), serviceProvider.GetRequiredService<IQueryManagerFactory>(), serviceProvider.GetRequiredService<ILogger<ISqlMetadataProvider>>(), dataSourceName)
+        {
+        }
+
         public PostgreSqlMetadataProvider(
             RuntimeConfigProvider runtimeConfigProvider,
-            IQueryExecutor queryExecutor,
-            IQueryBuilder sqlQueryBuilder,
-            ILogger<ISqlMetadataProvider> logger)
-            : base(runtimeConfigProvider, queryExecutor, sqlQueryBuilder, logger)
+            IQueryManagerFactory engineFactory,
+            ILogger<ISqlMetadataProvider> logger,
+            string dataSourceName)
+            : base(runtimeConfigProvider, engineFactory, logger, dataSourceName)
         {
         }
 

--- a/src/Core/Services/ResolverMiddleware.cs
+++ b/src/Core/Services/ResolverMiddleware.cs
@@ -3,9 +3,12 @@
 
 using System.Globalization;
 using System.Text.Json;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Resolvers;
+using Azure.DataApiBuilder.Service.GraphQLBuilder;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.CustomScalars;
 using HotChocolate.Execution;
 using HotChocolate.Language;
@@ -26,16 +29,19 @@ namespace Azure.DataApiBuilder.Core.Services
     {
         private static readonly string _contextMetadata = "metadata";
         internal readonly FieldDelegate _next;
-        internal readonly IQueryEngine _queryEngine;
-        internal readonly IMutationEngine _mutationEngine;
+        internal readonly IQueryEngineFactory _queryEngineFactory;
+        internal readonly IMutationEngineFactory _mutationEngineFactory;
+        internal readonly RuntimeConfigProvider _runtimeConfigProvider;
 
         public ResolverMiddleware(FieldDelegate next,
-            IQueryEngine queryEngine,
-            IMutationEngine mutationEngine)
+            IQueryEngineFactory queryEngineFactory,
+            IMutationEngineFactory mutationEngineFactory,
+            RuntimeConfigProvider runtimeConfigProvider)
         {
             _next = next;
-            _queryEngine = queryEngine;
-            _mutationEngine = mutationEngine;
+            _queryEngineFactory = queryEngineFactory;
+            _mutationEngineFactory = mutationEngineFactory;
+            _runtimeConfigProvider = runtimeConfigProvider;
         }
 
         /// <summary>
@@ -50,6 +56,11 @@ namespace Azure.DataApiBuilder.Core.Services
         public async Task InvokeAsync(IMiddlewareContext context)
         {
             JsonElement jsonElement;
+            string dataSourceName = GraphQLUtils.GetDataSourceNameFromGraphQLContext(context, _runtimeConfigProvider.GetConfig());
+            DataSource ds = _runtimeConfigProvider.GetConfig().GetDataSourceFromDataSourceName(dataSourceName);
+
+            IQueryEngine queryEngine = _queryEngineFactory.GetQueryEngine(ds.DatabaseType);
+
             if (context.ContextData.TryGetValue("HttpContext", out object? value))
             {
                 if (value is not null)
@@ -63,18 +74,18 @@ namespace Azure.DataApiBuilder.Core.Services
             if (context.Selection.Field.Coordinate.TypeName.Value == "Mutation")
             {
                 IDictionary<string, object?> parameters = GetParametersFromContext(context);
-
                 // Only Stored-Procedure has ListType as returnType for Mutation
                 if (context.Selection.Type.IsListType())
                 {
                     // Both Query and Mutation execute the same SQL statement for Stored Procedure.
-                    Tuple<IEnumerable<JsonDocument>, IMetadata?> result = await _queryEngine.ExecuteListAsync(context, parameters);
+                    Tuple<IEnumerable<JsonDocument>, IMetadata?> result = await queryEngine.ExecuteListAsync(context, parameters, dataSourceName);
                     context.Result = GetListOfClonedElements(result.Item1);
                     SetNewMetadata(context, result.Item2);
                 }
                 else
                 {
-                    Tuple<JsonDocument?, IMetadata?> result = await _mutationEngine.ExecuteAsync(context, parameters);
+                    IMutationEngine mutationEngine = _mutationEngineFactory.GetMutationEngine(ds.DatabaseType);
+                    Tuple<JsonDocument?, IMetadata?> result = await mutationEngine.ExecuteAsync(context, parameters, dataSourceName);
                     SetContextResult(context, result.Item1);
                     SetNewMetadata(context, result.Item2);
                 }
@@ -85,13 +96,13 @@ namespace Azure.DataApiBuilder.Core.Services
 
                 if (context.Selection.Type.IsListType())
                 {
-                    Tuple<IEnumerable<JsonDocument>, IMetadata?> result = await _queryEngine.ExecuteListAsync(context, parameters);
+                    Tuple<IEnumerable<JsonDocument>, IMetadata?> result = await queryEngine.ExecuteListAsync(context, parameters, dataSourceName);
                     context.Result = GetListOfClonedElements(result.Item1);
                     SetNewMetadata(context, result.Item2);
                 }
                 else
                 {
-                    Tuple<JsonDocument?, IMetadata?> result = await _queryEngine.ExecuteAsync(context, parameters);
+                    Tuple<JsonDocument?, IMetadata?> result = await queryEngine.ExecuteAsync(context, parameters, dataSourceName);
                     SetContextResult(context, result.Item1);
                     SetNewMetadata(context, result.Item2);
                 }
@@ -114,7 +125,7 @@ namespace Azure.DataApiBuilder.Core.Services
                 if (TryGetPropertyFromParent(context, out jsonElement))
                 {
                     IMetadata metadata = GetMetadata(context);
-                    using JsonDocument? innerObject = _queryEngine.ResolveInnerObject(jsonElement, context.Selection.Field, ref metadata);
+                    using JsonDocument? innerObject = queryEngine.ResolveInnerObject(jsonElement, context.Selection.Field, ref metadata);
                     if (innerObject is not null)
                     {
                         context.Result = innerObject.RootElement.Clone();
@@ -136,7 +147,7 @@ namespace Azure.DataApiBuilder.Core.Services
                 if (TryGetPropertyFromParent(context, out jsonElement))
                 {
                     IMetadata metadata = GetMetadata(context);
-                    context.Result = _queryEngine.ResolveListType(jsonElement, context.Selection.Field, ref metadata);
+                    context.Result = queryEngine.ResolveListType(jsonElement, context.Selection.Field, ref metadata);
                     SetNewMetadata(context, metadata);
                 }
             }

--- a/src/Service.GraphQLBuilder/GraphQLUtils.cs
+++ b/src/Service.GraphQLBuilder/GraphQLUtils.cs
@@ -9,8 +9,10 @@ using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.CustomScalars;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Directives;
+using Azure.DataApiBuilder.Service.GraphQLBuilder.Queries;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Sql;
 using HotChocolate.Language;
+using HotChocolate.Resolvers;
 using HotChocolate.Types;
 using HotChocolate.Types.NodaTime;
 using NodaTime.Text;
@@ -265,6 +267,64 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
                         subStatusCode: DataApiBuilderException.SubStatusCodes.GraphQLMapping,
                         innerException: error);
             }
+        }
+
+        /// <summary>
+        /// Generates the entity name from the GraphQL context.
+        /// </summary>
+        /// <param name="context">Middleware context.</param>
+        /// <returns></returns>
+        public static string GetDataSourceNameFromGraphQLContext(IMiddlewareContext context, RuntimeConfig runtimeConfig)
+        {
+            string rootNode = context.Selection.Field.Coordinate.TypeName.Value;
+            string dataSourceName;
+
+            if (string.Equals(rootNode, "mutation", StringComparison.OrdinalIgnoreCase) || string.Equals(rootNode, "query", StringComparison.OrdinalIgnoreCase))
+            {
+                // we are at the root query node - need to determine return type and store on context.
+                // Output type below would be the graphql object return type - Books,BooksConnectionObject.
+                IOutputType outputType = context.Selection.Field.Type;
+                string entityName = outputType.TypeName();
+
+                // Below is only needed if say we have an Array return type or items object for plural case.
+                ObjectType underlyingFieldType = GraphQLUtils.UnderlyingGraphQLEntityType(outputType);
+
+                // Example: CustomersConnectionObject - for get all scenarios.
+                if (QueryBuilder.IsPaginationType(underlyingFieldType))
+                {
+                    IObjectField subField = GraphQLUtils.UnderlyingGraphQLEntityType(context.Selection.Field.Type).Fields[QueryBuilder.PAGINATION_FIELD_NAME];
+                    outputType = subField.Type;
+                    underlyingFieldType = GraphQLUtils.UnderlyingGraphQLEntityType(outputType);
+                    entityName = underlyingFieldType.Name;
+                }
+
+                // if name on schema is different from name in config.
+                // Due to possibility of rename functionality, entityName on runtimeConfig could be different from exposed schema name.
+                if (GraphQLUtils.TryExtractGraphQLFieldModelName(underlyingFieldType.Directives, out string? modelName))
+                {
+                    entityName = modelName;
+                }
+
+                dataSourceName = runtimeConfig.GetDataSourceNameFromEntityName(entityName);
+
+                // Store dataSourceName on context for later use.
+                context.ContextData.TryAdd(GenerateDataSourceNameKeyFromPath(context), dataSourceName);
+            }
+            else
+            {
+                // Derive node from path - e.g. /books/{id} - node would be books.
+                // for this queryNode path we have stored the datasourceName needed to retrieve query and mutation engine of inner objects
+                object? obj = context.ContextData[GenerateDataSourceNameKeyFromPath(context)];
+                dataSourceName = obj?.ToString()!;
+            }
+
+            return dataSourceName;
+        }
+
+        private static string GenerateDataSourceNameKeyFromPath(IMiddlewareContext context)
+        {
+            // prefix added to ensure uniqueness.
+            return $"Node_{context.Path.ToList().First()}";
         }
     }
 }


### PR DESCRIPTION
## Why make this change?
This change brings the functionality of multiple datasource support to core engine of DAB.

## What is this change?
1. changes to DI - introducting factory classes where applicable as for multiple db's we have multiple instances of various class objects
2. Document generation handling for multiple dbs.
3. Routing Queries/Mutations to appropriate db using db name pulled from entityName.

## How was this tested?
UnitTests:
1. Added runtimeConfig loader tests for multi-datasource loading. Both positive and negative tests. 
2. Deserialization tests for Data-Source Files converter.
3. Query and mutation builder tests
Integration test:
1. Single db integration test done.
2. multiple db integration test:
<img width="748" alt="image" src="https://github.com/Azure/data-api-builder/assets/124841904/dc304edb-509b-4d60-b23d-2bf79bd7157e">

In the above books belongs to one mssql db and authors belongs to another mssql db.