### PR TITLE
Ports the patch fix for missing global REST section in config file (for 0.8.* version) to the main branch

### DIFF
--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -118,6 +118,32 @@ public abstract class RuntimeConfigLoader
                 }
 
             }
+
+            // For Cosmos DB NoSQL database type, DAB CLI v0.8.49+ generates a REST property within the Runtime section of the config file. However
+            // v0.7.6- does not generate this property. So, when the config file generated using v0.7.6- is used to start the engine with v0.8.49+, the absence
+            // of the REST property causes the engine to throw exceptions. This is the only difference in the way Runtime section of the config file is created
+            // between these two versions.
+            // To avoid the NullReference Exceptions, the REST property is added when absent in the config file.
+            // Other properties within the Runtime section are also populated with default values to account for the cases where
+            // the properties could be removed manually from the config file.
+            if (config.Runtime is not null)
+            {
+                if (config.Runtime.Rest is null)
+                {
+                    config = config with { Runtime = config.Runtime with { Rest = (config.DataSource.DatabaseType is DatabaseType.CosmosDB_NoSQL) ? new RestRuntimeOptions(Enabled: false) : new RestRuntimeOptions(Enabled: false) } };
+                }
+
+                if (config.Runtime.GraphQL is null)
+                {
+                    config = config with { Runtime = config.Runtime with { GraphQL = new GraphQLRuntimeOptions(AllowIntrospection: false) } };
+                }
+
+                if (config.Runtime.Host is null)
+                {
+                    config = config with { Runtime = config.Runtime with { Host = new HostOptions(Cors: null, Authentication: new AuthenticationOptions(Provider: EasyAuthType.StaticWebApps.ToString(), Jwt: null), Mode: HostMode.Production) } };
+                }
+            }
+
         }
         catch (JsonException ex)
         {


### PR DESCRIPTION
Ports the patch fix PR #1678 which was directly merged into `release/0.8` to the `main` branch so that it is avaiable for future versions

## Original PR description:

## Why make this change?

- Closes #1675 
  - For Cosmos DB NoSQL database type, DAB CLI v0.8.49 generates a REST property within the Runtime section of the config file. However v0.7.6 does not generate this property. So, when the config file generated using v0.7.6 is used to start the engine with v0.8.49, the absence of the REST property causes the engine to throw exceptions.

## What is this change?

 
- With `v0.8.49`, these values are assumed to have non-null values because the CLI explicitly writes out all the fields to the config files. So, `null` checks are not performed extensively in all the places.
- However, when a config file that is generated using `v0.7.6`  is used, it could be possible that some of the fields are `null`. The absence of `null` checks leads to `NullReferenceExceptions` in this case. 
- To avoid this, all the `Runtime` options - `Rest`, `GraphQL` and `Host` are initialized with default values when they are `null` after deserialization of the config file.

## How was this tested?

- [x] Existing Unit Tests and Integration Tests
- [x] Manual Tests

# Sample Requests

- Database Type: Cosmos DB NoSQL
- Config file (Runtime section):
```json
 "runtime": {
    "graphql": {
      "enabled": true,
      "path": "/graphql",
      "allow-introspection": true
    },
    "host": {
      "cors": {
        "origins": [
          "http://localhost:5000"
        ],
        "allow-credentials": false
      },
      "authentication": {
        "provider": "StaticWebApps"
      },
      "mode": "development"
    }
  }
```
- Engine starts successfully:
![image](https://github.com/Azure/data-api-builder/assets/11196553/dc8769d4-a01a-485d-8800-ef5a311f4554)

- GraphQL Requests work successfully:
![image](https://github.com/Azure/data-api-builder/assets/11196553/111de37d-172a-4bb8-b3c9-686ee4061608)

![image](https://github.com/Azure/data-api-builder/assets/11196553/b34bd5df-0c01-45b6-a708-7c1bcb5243b5)




Note: This PR is directly targeted towards `release/0.8` branch (and the branch to make these changes was snapped off of `release/0.8`) because the current `main` has additional changes that are related to `0.9` and porting it over to `release/0.8` branch might not be possible. 
