### PR TITLE
Fixes the bug #1680 that necessitated adding the 'name' parameter to the @model directive, regardless of the name of the GraphQL object type's name.

### DIFF
--- a/src/Service.GraphQLBuilder/GraphQLUtils.cs
+++ b/src/Service.GraphQLBuilder/GraphQLUtils.cs
@@ -186,10 +186,14 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
             {
                 if (dir.Name.Value == ModelDirectiveType.DirectiveName)
                 {
-                    dir.ToObject<ModelDirectiveType>();
-                    modelName = dir.GetArgument<string>(ModelDirectiveType.ModelNameArgument).ToString();
+                    ModelDirectiveType modelDirectiveType = dir.ToObject<ModelDirectiveType>();
 
-                    return modelName is not null;
+                    if (modelDirectiveType.Name.HasValue)
+                    {
+                        modelName = dir.GetArgument<string>(ModelDirectiveType.ModelNameArgument).ToString();
+                        return modelName is not null;
+                    }
+
                 }
             }
 

--- a/src/Service.Tests/CosmosTests/TestBase.cs
+++ b/src/Service.Tests/CosmosTests/TestBase.cs
@@ -29,6 +29,8 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests;
 public class TestBase
 {
     internal const string DATABASE_NAME = "graphqldb";
+    // Intentionally removed name attibute from Planet model to test scenario where the 'name' attribute
+    // is not explicitly added in the schema
     internal const string GRAPHQL_SCHEMA = @"
 type Character @model(name:""Character"") {
     id : ID,
@@ -39,7 +41,7 @@ type Character @model(name:""Character"") {
     star: Star
 }
 
-type Planet @model(name:""Planet"") {
+type Planet @model {
     id : ID!,
     name : String,
     character: Character,


### PR DESCRIPTION
## Why make this change?
- Closes #1680 
- Regression introduced in 0.8.49 caused required explicitly adding "name" directive for all the model/entity irrespective of whether we are using a different name than the one it originally has.
- Regression introduced in #1402 when we started using TryExtractGraphQLName as follows:
```
   string typeName = GraphQLUtils.TryExtractGraphQLFieldModelName(underlyingType.Directives, out string? modelName) ?
                    modelName :
                    underlyingType.Name;
```
      
## What is this change?
    Checking Directive "name" exists before accessing its value. 

## How was this tested?
- [x] Integration Tests

