### PR TITLE
bump readme reported version to 0.8.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation](https://img.shields.io/badge/docs-website-%23fc0)](https://learn.microsoft.com/azure/data-api-builder/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Latest stable version of Data API builder is **0.8.50** [What's new?](https://learn.microsoft.com/azure/data-api-builder/whats-new)
+Latest stable version of Data API builder is **0.8.51** [What's new?](https://learn.microsoft.com/azure/data-api-builder/whats-new)
 
 ## About
 


### PR DESCRIPTION
## Why make this change?

- Updates the README in the root of the repo to report the latest version of DAB `0.8.51`