### PR TITLE
Fix setting cosmos configuration at runtime by checking whether the graphql schema is set

### DIFF
--- a/src/Core/Configurations/RuntimeConfigValidator.cs
+++ b/src/Core/Configurations/RuntimeConfigValidator.cs
@@ -128,6 +128,8 @@ namespace Azure.DataApiBuilder.Core.Configurations
                         HttpStatusCode.ServiceUnavailable,
                         DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
 
+                // The schema is provided through GraphQLSchema and not the Schema file when the configuration
+                // is received after startup.
                 if (string.IsNullOrEmpty(cosmosDbNoSql.GraphQLSchema))
                 {
                     if (string.IsNullOrEmpty(cosmosDbNoSql.Schema))

--- a/src/Core/Configurations/RuntimeConfigValidator.cs
+++ b/src/Core/Configurations/RuntimeConfigValidator.cs
@@ -128,17 +128,20 @@ namespace Azure.DataApiBuilder.Core.Configurations
                         HttpStatusCode.ServiceUnavailable,
                         DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
 
-                if (string.IsNullOrEmpty(cosmosDbNoSql.Schema))
+                if (string.IsNullOrEmpty(cosmosDbNoSql.GraphQLSchema))
                 {
-                    throw new DataApiBuilderException(
-                        "No GraphQL schema file has been provided for CosmosDB_NoSql. Ensure you provide a GraphQL schema containing the GraphQL object types to expose.",
-                        HttpStatusCode.ServiceUnavailable,
-                        DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
-                }
+                    if (string.IsNullOrEmpty(cosmosDbNoSql.Schema))
+                    {
+                        throw new DataApiBuilderException(
+                            "No GraphQL schema file has been provided for CosmosDB_NoSql. Ensure you provide a GraphQL schema containing the GraphQL object types to expose.",
+                            HttpStatusCode.ServiceUnavailable,
+                            DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
+                    }
 
-                if (!fileSystem.File.Exists(cosmosDbNoSql.Schema))
-                {
-                    throw new FileNotFoundException($"The GraphQL schema file at '{cosmosDbNoSql.Schema}' could not be found. Ensure that it is a path relative to the runtime.");
+                    if (!fileSystem.File.Exists(cosmosDbNoSql.Schema))
+                    {
+                        throw new FileNotFoundException($"The GraphQL schema file at '{cosmosDbNoSql.Schema}' could not be found. Ensure that it is a path relative to the runtime.");
+                    }
                 }
             }
         }

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.IO.Abstractions;


### PR DESCRIPTION
## Why make this change?
Failing to set the configuration at runtime if there is not "schema" file set in the config. This is not required when setting the config at runtime since the graphql schema is set already.

## How was this tested?

- [x] Validated locally
- [x] Updated the tests so the schema property is removed from the config. Verified that the tests were failing before the fix and passing after.
