### PR TITLE
Unhandled Exception for malformed connection string bug fix

### DIFF
--- a/src/Cli.Tests/EnvironmentTests.cs
+++ b/src/Cli.Tests/EnvironmentTests.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using Azure.DataApiBuilder.Config.Converters;
+using Microsoft.Extensions.Hosting;
 
 namespace Cli.Tests;
 
@@ -157,7 +159,10 @@ public class EnvironmentTests
         );
 
         string? output = await process.StandardError.ReadLineAsync();
-        Assert.AreEqual(output, "Deserialization of the configuration file failed during a post-processing step.");
+        Assert.AreEqual("Deserialization of the configuration file failed during a post-processing step.", output);
+        output = await process.StandardError.ReadToEndAsync();
+        StringAssert.Contains(output, "Environmental Variable, "
+            + expectedEnvVarName + ", not found.", StringComparison.Ordinal);
         process.Kill();
     }
 

--- a/src/Cli.Tests/EnvironmentTests.cs
+++ b/src/Cli.Tests/EnvironmentTests.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using Azure.DataApiBuilder.Config.Converters;
-using Microsoft.Extensions.Hosting;
 
 namespace Cli.Tests;
 

--- a/src/Cli.Tests/EnvironmentTests.cs
+++ b/src/Cli.Tests/EnvironmentTests.cs
@@ -143,13 +143,6 @@ public class EnvironmentTests
     /// variable CONN_STRING. This will cause an exception during the post
     /// processing of the deserialization of the config. We verify the expected
     /// error message returns.
-    /// This test has been disabled as it is causing the build server to hang indefinitely.
-    /// There is something problematic with reading from stderr and stdout in this test
-    /// that is causing the issue. It's possible that the stream is not being flushed
-    /// by the process so when the test tries to read it, it hangs waiting for the stream
-    /// to be readable, but it will require more investigation to determine the root cause.
-    /// I feel confident that the overarching scenario is covered through other testing
-    /// so disabling temporarily while we investigate should be acceptable.
     /// </summary>
     [TestMethod]
     public async Task FailureToStartEngineWhenEnvVarNamedWrong()
@@ -164,7 +157,7 @@ public class EnvironmentTests
         );
 
         string? output = await process.StandardError.ReadLineAsync();
-        Assert.AreEqual(output, "Deserialization of the configuration file failed.");
+        Assert.AreEqual(output, "Deserialization of the configuration file failed during a post-processing step.");
         process.Kill();
     }
 

--- a/src/Cli.Tests/EnvironmentTests.cs
+++ b/src/Cli.Tests/EnvironmentTests.cs
@@ -140,7 +140,9 @@ public class EnvironmentTests
     /// Validates that engine startup fails when the CONN_STRING environment
     /// variable is not found. This test simulates this by defining the
     /// environment variable COMM_STRINGX and not setting the expected
-    /// variable CONN_STRING.
+    /// variable CONN_STRING. This will cause an exception during the post
+    /// processing of the deserialization of the config. We verify the expected
+    /// error message returns.
     /// This test has been disabled as it is causing the build server to hang indefinitely.
     /// There is something problematic with reading from stderr and stdout in this test
     /// that is causing the issue. It's possible that the stream is not being flushed
@@ -162,8 +164,7 @@ public class EnvironmentTests
         );
 
         string? output = await process.StandardError.ReadLineAsync();
-        StringAssert.Contains(output, "Environmental Variable, "
-            + expectedEnvVarName + ", not found.", StringComparison.Ordinal);
+        Assert.AreEqual(output, "Deserialization of the configuration file failed.");
         process.Kill();
     }
 

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -106,7 +106,7 @@ public record RuntimeConfig
                         // Errors could include duplicate datasource names, duplicate entity names, etc.
                         throw new DataApiBuilderException(
                             $"Error while loading datasource file {dataSourceFile} with exception {e.Message}",
-                            HttpStatusCode.InternalServerError,
+                            HttpStatusCode.ServiceUnavailable,
                             DataApiBuilderException.SubStatusCodes.ConfigValidationError,
                             e.InnerException);
                     }

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -145,7 +145,9 @@ public abstract class RuntimeConfigLoader
             }
 
         }
-        catch (JsonException ex)
+        catch (Exception ex) when (
+            ex is JsonException ||
+            ex is DataApiBuilderException)
         {
             string errorMessage = "Deserialization of the configuration file failed.";
 

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -149,7 +149,8 @@ public abstract class RuntimeConfigLoader
             ex is JsonException ||
             ex is DataApiBuilderException)
         {
-            string errorMessage = "Deserialization of the configuration file failed.";
+            string errorMessage = ex is JsonException ? "Deserialization of the configuration file failed." :
+                "Deserialization of the configuration file failed during a post-processing step.";
 
             // logger can be null when called from CLI
             if (logger is null)

--- a/src/Core/Configurations/RuntimeConfigProvider.cs
+++ b/src/Core/Configurations/RuntimeConfigProvider.cs
@@ -74,7 +74,7 @@ public class RuntimeConfigProvider
         {
             throw new DataApiBuilderException(
                 message: "Runtime config isn't setup.",
-                statusCode: HttpStatusCode.InternalServerError,
+                statusCode: HttpStatusCode.ServiceUnavailable,
                 subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
         }
 

--- a/src/Service.Tests/Configuration/RuntimeConfigLoaderTests.cs
+++ b/src/Service.Tests/Configuration/RuntimeConfigLoaderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -92,14 +93,13 @@ public class RuntimeConfigLoaderTests
 
         FileSystemRuntimeConfigLoader loader = new(fs);
 
-        try
-        {
-            loader.TryLoadConfig("dab-config.json", out RuntimeConfig _);
-            Assert.Fail("Should not load config with duplicate entity names.");
-        }
-        catch (DataApiBuilderException ex)
-        {
-            Assert.IsTrue(ex.StatusCode == System.Net.HttpStatusCode.InternalServerError);
-        }
+        StringWriter sw = new();
+        Console.SetError(sw);
+
+        loader.TryLoadConfig("dab-config.json", out RuntimeConfig _);
+        string error = sw.ToString();
+
+        Assert.IsTrue(error.StartsWith("Deserialization of the configuration file failed during a post-processing step."));
+        Assert.IsTrue(error.Contains("An item with the same key has already been added."));
     }
 }

--- a/src/Service.Tests/Configuration/RuntimeConfigLoaderTests.cs
+++ b/src/Service.Tests/Configuration/RuntimeConfigLoaderTests.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
-using Azure.DataApiBuilder.Service.Exceptions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 

--- a/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
@@ -159,7 +159,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         [DataRow("\"notsupporteddb\"", "")]
         [DataRow("\"mssql\"", "\"notsupportedconnectionstring\"")]
         [TestMethod("Validates that JSON deserialization failures are gracefully caught.")]
-        public void TestDeserializationFailures(string dbType, string connectionString)
+        public void TestDataSourceDeserializationFailures(string dbType, string connectionString)
         {
             string configJson = @"
 {

--- a/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
@@ -156,8 +156,10 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             Assert.ThrowsException<DataApiBuilderException>(() => JsonSerializer.Deserialize<StubJsonType>(json, options));
         }
 
-        [DataRow("\"notsupporteddb\"", "")]
-        [DataRow("\"mssql\"", "\"notsupportedconnectionstring\"")]
+        [DataRow("\"notsupporteddb\"", "",
+            DisplayName="Tests that a database type which will not deserialize correctly fails.")]
+        [DataRow("\"mssql\"", "\"notsupportedconnectionstring\"",
+            DisplayName="Tests that a malformed connection string fails during post-processing.")]
         [TestMethod("Validates that JSON deserialization failures are gracefully caught.")]
         public void TestDataSourceDeserializationFailures(string dbType, string connectionString)
         {
@@ -169,6 +171,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
     },
     ""entities"":{ }
 }";
+            // replaceEnvVar: true is needed to make sure we do post-processing for the connection string case
             Assert.IsFalse(RuntimeConfigLoader.TryParseConfig(configJson, out RuntimeConfig deserializedConfig, replaceEnvVar: true));
             Assert.IsNull(deserializedConfig);
         }

--- a/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
@@ -83,13 +83,13 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 if (replaceEnvVar)
                 {
                     Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(
-                        GetModifiedJsonString(repValues, @"""mssql"""), out expectedConfig, replaceEnvVar: replaceEnvVar),
+                        GetModifiedJsonString(repValues, @"""postgresql"""), out expectedConfig, replaceEnvVar: replaceEnvVar),
                         "Should read the expected config");
                 }
                 else
                 {
                     Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(
-                        GetModifiedJsonString(repKeys, @"""mssql"""), out expectedConfig, replaceEnvVar: replaceEnvVar),
+                        GetModifiedJsonString(repKeys, @"""postgresql"""), out expectedConfig, replaceEnvVar: replaceEnvVar),
                         "Should read the expected config");
                 }
 
@@ -204,7 +204,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             Environment.SetEnvironmentVariable($"'envVarName", $"_envVarValue");
             Environment.SetEnvironmentVariable($"envVarName'", $"envVarValue_");
             Environment.SetEnvironmentVariable($"'envVarName'", $"_envVarValue_");
-            Environment.SetEnvironmentVariable($"enumVarName", $"mssql");
+            Environment.SetEnvironmentVariable($"enumVarName", $"postgresql");
         }
 
         /// <summary>

--- a/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
@@ -157,9 +157,9 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         [DataRow("\"notsupporteddb\"", "",
-            DisplayName="Tests that a database type which will not deserialize correctly fails.")]
+            DisplayName = "Tests that a database type which will not deserialize correctly fails.")]
         [DataRow("\"mssql\"", "\"notsupportedconnectionstring\"",
-            DisplayName="Tests that a malformed connection string fails during post-processing.")]
+            DisplayName = "Tests that a malformed connection string fails during post-processing.")]
         [TestMethod("Validates that JSON deserialization failures are gracefully caught.")]
         public void TestDataSourceDeserializationFailures(string dbType, string connectionString)
         {

--- a/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
@@ -156,16 +156,20 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             Assert.ThrowsException<DataApiBuilderException>(() => JsonSerializer.Deserialize<StubJsonType>(json, options));
         }
 
+        [DataRow("\"notsupporteddb\"", "")]
+        [DataRow("\"mssql\"", "\"notsupportedconnectionstring\"")]
         [TestMethod("Validates that JSON deserialization failures are gracefully caught.")]
-        public void TestDeserializationFailures()
+        public void TestDeserializationFailures(string dbType, string connectionString)
         {
             string configJson = @"
 {
     ""data-source"": {
-        ""database-type"": ""notsupporteddb""
-     }
+        ""database-type"": " + dbType + @",
+        ""connection-string"": " + connectionString + @"
+    },
+    ""entities"":{ }
 }";
-            Assert.IsFalse(RuntimeConfigLoader.TryParseConfig(configJson, out RuntimeConfig deserializedConfig));
+            Assert.IsFalse(RuntimeConfigLoader.TryParseConfig(configJson, out RuntimeConfig deserializedConfig, replaceEnvVar: true));
             Assert.IsNull(deserializedConfig);
         }
 

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -192,15 +192,10 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 string error = sw is null ? ex.Message : sw.ToString();
                 Assert.IsTrue(error.Contains(DataApiBuilderException.CONNECTION_STRING_ERROR_MESSAGE));
                 Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ErrorInInitialization, ex.SubStatusCode);
+                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex.StatusCode);
                 if (sw is not null)
                 {
-                    Assert.IsTrue(sw.ToString().StartsWith("Deserialization of the configuration file failed during a post-processing step."));
-                    Assert.AreEqual(HttpStatusCode.InternalServerError, ex.StatusCode);
-                }
-                else
-                {
-                    Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex.StatusCode);
-
+                    Assert.IsTrue(error.StartsWith("Deserialization of the configuration file failed during a post-processing step."));
                 }
             }
 

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -77,7 +77,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         //[DataRow(";;;;;fooBarBAZ")]
         //[DataRow("!&^%*&$$%#$%@$%#@()")]
         //[DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
-        [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
+        //[DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
         [DataRow("")]
         public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString)

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -78,7 +78,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         //[DataRow("!&^%*&$$%#$%@$%#@()")]
         //[DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         //[DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
-        [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
+        //[DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
         [DataRow("")]
         public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString)
         {

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -79,12 +79,17 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         [DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
-        //[DataRow("")]
+        [DataRow("")]
         public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString)
         {
             // error message to test will be in std error so we redirect here
-            StringWriter sw = new();
-            Console.SetError(sw);
+            StringWriter sw = null;
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                sw = new();
+                Console.SetError(sw);
+            }
+
             DatabaseEngine = TestCategory.MSSQL;
             await CheckExceptionForBadConnectionStringHelperAsync(DatabaseEngine, connectionString, sw);
         }
@@ -186,7 +191,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 string error = sw is null ? ex.Message : sw.ToString();
                 Assert.IsTrue(error.Contains(DataApiBuilderException.CONNECTION_STRING_ERROR_MESSAGE));
                 Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ErrorInInitialization, ex.SubStatusCode);
-                if (databaseType is TestCategory.MSSQL)
+                if (sw is not null)
                 {
                     Assert.AreEqual(HttpStatusCode.InternalServerError, ex.StatusCode);
                 }

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -80,12 +80,12 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;", true)]
         [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests", true)]
         [DataRow("", false)]
-        public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString, bool invalidConnectionBuilderString)
+        public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString, bool isInvalidConnectionBuilderString)
         {
             StringWriter sw = null;
             // For strings that are an invalid format for the connection string builder, need to
             // redirect std error to a string writer for comparison to expected error messaging later.
-            if (invalidConnectionBuilderString)
+            if (isInvalidConnectionBuilderString)
             {
                 sw = new();
                 Console.SetError(sw);
@@ -194,6 +194,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ErrorInInitialization, ex.SubStatusCode);
                 if (sw is not null)
                 {
+                    Assert.IsTrue(sw.ToString().StartsWith("Deserialization of the configuration file failed during a post-processing step."));
                     Assert.AreEqual(HttpStatusCode.InternalServerError, ex.StatusCode);
                 }
                 else

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -75,10 +75,10 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         /// </summary>
         [DataTestMethod, TestCategory(TestCategory.MSSQL)]
         [DataRow(";;;;;fooBarBAZ")]
-        //[DataRow("!&^%*&$$%#$%@$%#@()")]
-        //[DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
-        //[DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
-        //[DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
+        [DataRow("!&^%*&$$%#$%@$%#@()")]
+        [DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
+        [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
+        [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
         //[DataRow("")]
         public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString)
         {

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -74,7 +74,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         /// <code>Check: </code>  Verify malformed connection string throws correct exception with MSSQL as the database.
         /// </summary>
         [DataTestMethod, TestCategory(TestCategory.MSSQL)]
-        [DataRow(";;;;;fooBarBAZ")]
+        //[DataRow(";;;;;fooBarBAZ")]
         [DataRow("!&^%*&$$%#$%@$%#@()")]
         [DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -14,7 +14,6 @@ using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.Tests.Configuration;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
-using Microsoft.Azure.Cosmos.Core;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -184,7 +183,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             {
                 // use contains to correctly cover db/user unique error messaging
                 // check standard error for underlying connection string message
-                string error = sw.ToString();   
+                string error = sw.ToString();
                 Assert.IsTrue(error.Contains(DataApiBuilderException.CONNECTION_STRING_ERROR_MESSAGE));
                 Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ErrorInInitialization, ex.SubStatusCode);
                 if (databaseType is TestCategory.MSSQL)

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -76,7 +76,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         [DataTestMethod, TestCategory(TestCategory.MSSQL)]
         //[DataRow(";;;;;fooBarBAZ")]
         //[DataRow("!&^%*&$$%#$%@$%#@()")]
-        [DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
+        //[DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
         [DataRow("")]

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -74,12 +74,12 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         /// <code>Check: </code>  Verify malformed connection string throws correct exception with MSSQL as the database.
         /// </summary>
         [DataTestMethod, TestCategory(TestCategory.MSSQL)]
-        //[DataRow(";;;;;fooBarBAZ")]
+        [DataRow(";;;;;fooBarBAZ")]
         //[DataRow("!&^%*&$$%#$%@$%#@()")]
         //[DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         //[DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         //[DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
-        [DataRow("")]
+        //[DataRow("")]
         public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString)
         {
             // error message to test will be in std error so we redirect here

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -75,7 +75,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         /// </summary>
         [DataTestMethod, TestCategory(TestCategory.MSSQL)]
         //[DataRow(";;;;;fooBarBAZ")]
-        [DataRow("!&^%*&$$%#$%@$%#@()")]
+        //[DataRow("!&^%*&$$%#$%@$%#@()")]
         [DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
         [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -183,7 +183,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             {
                 // use contains to correctly cover db/user unique error messaging
                 // check standard error for underlying connection string message
-                string error = sw.ToString();
+                string error = sw is null ? ex.Message : sw.ToString();
                 Assert.IsTrue(error.Contains(DataApiBuilderException.CONNECTION_STRING_ERROR_MESSAGE));
                 Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ErrorInInitialization, ex.SubStatusCode);
                 if (databaseType is TestCategory.MSSQL)

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -74,17 +74,18 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         /// <code>Check: </code>  Verify malformed connection string throws correct exception with MSSQL as the database.
         /// </summary>
         [DataTestMethod, TestCategory(TestCategory.MSSQL)]
-        [DataRow(";;;;;fooBarBAZ")]
-        [DataRow("!&^%*&$$%#$%@$%#@()")]
-        [DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
-        [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;")]
-        [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests")]
-        [DataRow("")]
-        public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString)
+        [DataRow(";;;;;fooBarBAZ", true)]
+        [DataRow("!&^%*&$$%#$%@$%#@()", true)]
+        [DataRow("Server=<>;Databases=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;", true)]
+        [DataRow("Servers=<>;Database=<>;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;", true)]
+        [DataRow("DO NOT EDIT, look at CONTRIBUTING.md on how to run tests", true)]
+        [DataRow("", false)]
+        public async Task CheckExceptionForBadConnectionStringForMsSql(string connectionString, bool invalidConnectionBuilderString)
         {
-            // error message to test will be in std error so we redirect here
             StringWriter sw = null;
-            if (!string.IsNullOrWhiteSpace(connectionString))
+            // For strings that are an invalid format for the connection string builder, need to
+            // redirect std error to a string writer for comparison to expected error messaging later.
+            if (invalidConnectionBuilderString)
             {
                 sw = new();
                 Console.SetError(sw);
@@ -187,7 +188,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             catch (DataApiBuilderException ex)
             {
                 // use contains to correctly cover db/user unique error messaging
-                // check standard error for underlying connection string message
+                // if sw is not null it holds the error messaging
                 string error = sw is null ? ex.Message : sw.ToString();
                 Assert.IsTrue(error.Contains(DataApiBuilderException.CONNECTION_STRING_ERROR_MESSAGE));
                 Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ErrorInInitialization, ex.SubStatusCode);


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/1736

When a connection string was not properly formed, in the case of `MSSQL` database types it was possible to have an exception when modifying the connection string as part of our normal code. However, that exception was not being handled and would cause an ungraceful crash of the application. We now handle this exception.

## What is this change?

Include `DataApiBuilderException` in the exception handling for where we modify the connection string in this particular case. And include a regression test case.

New error messaging can be seen here:

![image](https://github.com/Azure/data-api-builder/assets/93220300/887cb26e-dd88-4c48-b577-8b242ad06c82)


It should also be noted that some tests had expected behavior that did not account for our new exception handling. Some test cases have been changed to `postgresql` data base type to avoid conflicts with our new post processing error handling, when that new error handling is not relevant to what those tests were covering. Since the post processing only happens in the following conditional, this is an easy way to keep our test coverage without major changes.

![image](https://github.com/Azure/data-api-builder/assets/93220300/57d6cb73-8398-4a66-889a-a6c141677c75)



Our tests for error checking bad connection strings for mssql was also relying on having the actual exception available, but we now have exception handling that will catch that and return a different exception than the test is expecting. To keep this test working we redirect standard error and then checking against that messaging for those cases where we are both mssql db type and have a malformed connection string . The remaining difference for those cases that do not have valid connection strings and are mssql db type is that we have an `InternalServerError` as the status code now, so we modify the test to look for that instead in this case.

## How was this tested?

A regression test is added to the unit tests for the runtime config loader. This is where the change happened, and the new case covers a malformed connection string, verifying that we handle the exception correctly by validating that we return false from the function that was throwing the unhandled exception.

## Sample Request(s)


You can manually repro with the instructions from the linked issue this closes which are the following steps:

1. After building the solution, from the root of the repo: cd src\out\cli\net6.0
2. Microsoft.DataApiBuilder.exe init --database-type mssql --connection-string "abcd"
3. Microsoft.DataApiBuilder.exe add Book --source dbo.books --permissions "anonymous:*"
4. Microsoft.DataApiBuilder.exe start