### PR TITLE
Update minor version in build ci pipeline config to 0.10 in MAIN

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -22,7 +22,7 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
   major: 0
-  minor: 9
+  minor: 10
   # Maintain a separate patch value between CI and PR runs.
   # The counter is reset when the minor version is updated.
   patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 0)]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation](https://img.shields.io/badge/docs-website-%23fc0)](https://learn.microsoft.com/azure/data-api-builder/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-Latest stable version of Data API builder is **0.8.51** [What's new?](https://learn.microsoft.com/azure/data-api-builder/whats-new)
+Latest stable version of Data API builder is **0.8.52** [What's new?](https://learn.microsoft.com/azure/data-api-builder/whats-new)
 
 ## Community
 


### PR DESCRIPTION
# What is this change?

- Now that the `release/0.9` branch was created to track 0.9 release candidates/stable version bits, this PR updates the minor version in the build pipeline template to **0.10** to apply to the current state of main, and to be pulled into the future `release/0.10` branch when ready.
- Updates the 'latest version' number stated in the repo root readme to be 0.8.52 to reflect latest stable patch.