### PR TITLE
[Cherrypick] Fix setting cosmos configuration at runtime by checking whether the graphql schema is set

### DIFF
--- a/src/Core/Configurations/RuntimeConfigValidator.cs
+++ b/src/Core/Configurations/RuntimeConfigValidator.cs
@@ -133,17 +133,22 @@ namespace Azure.DataApiBuilder.Core.Configurations
                             HttpStatusCode.ServiceUnavailable,
                             DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
 
-                    if (string.IsNullOrEmpty(cosmosDbNoSql.Schema))
+                    // The schema is provided through GraphQLSchema and not the Schema file when the configuration
+                    // is received after startup.
+                    if (string.IsNullOrEmpty(cosmosDbNoSql.GraphQLSchema))
                     {
-                        throw new DataApiBuilderException(
-                            "No GraphQL schema file has been provided for CosmosDB_NoSql. Ensure you provide a GraphQL schema containing the GraphQL object types to expose.",
-                            HttpStatusCode.ServiceUnavailable,
-                            DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
-                    }
+                        if (string.IsNullOrEmpty(cosmosDbNoSql.Schema))
+                        {
+                            throw new DataApiBuilderException(
+                                "No GraphQL schema file has been provided for CosmosDB_NoSql. Ensure you provide a GraphQL schema containing the GraphQL object types to expose.",
+                                HttpStatusCode.ServiceUnavailable,
+                                DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
+                        }
 
-                    if (!fileSystem.File.Exists(cosmosDbNoSql.Schema))
-                    {
-                        throw new FileNotFoundException($"The GraphQL schema file at '{cosmosDbNoSql.Schema}' could not be found. Ensure that it is a path relative to the runtime.");
+                        if (!fileSystem.File.Exists(cosmosDbNoSql.Schema))
+                        {
+                            throw new FileNotFoundException($"The GraphQL schema file at '{cosmosDbNoSql.Schema}' could not be found. Ensure that it is a path relative to the runtime.");
+                        }
                     }
                 }
             }

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -2305,9 +2305,9 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
         private static ConfigurationPostParameters GetCosmosConfigurationParameters()
         {
-            string cosmosFile = $"{CONFIGFILE_NAME}.{COSMOS_ENVIRONMENT}{CONFIG_EXTENSION}";
+            RuntimeConfig configuration = ReadCosmosConfigurationFromFile();
             return new(
-                File.ReadAllText(cosmosFile),
+                configuration.ToJson(),
                 File.ReadAllText("schema.gql"),
                 $"AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;Database={COSMOS_DATABASE_NAME}",
                 AccessToken: null);
@@ -2315,7 +2315,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
         private static ConfigurationPostParametersV2 GetCosmosConfigurationParametersV2()
         {
-            string cosmosFile = $"{CONFIGFILE_NAME}.{COSMOS_ENVIRONMENT}{CONFIG_EXTENSION}";
+            RuntimeConfig configuration = ReadCosmosConfigurationFromFile();
             RuntimeConfig overrides = new(
                 Schema: null,
                 DataSource: new DataSource(DatabaseType.CosmosDB_NoSQL, $"AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;Database={COSMOS_DATABASE_NAME}", new()),
@@ -2323,10 +2323,25 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 Entities: new(new Dictionary<string, Entity>()));
 
             return new(
-                File.ReadAllText(cosmosFile),
+                configuration.ToJson(),
                 overrides.ToJson(),
                 File.ReadAllText("schema.gql"),
                 AccessToken: null);
+        }
+
+        private static RuntimeConfig ReadCosmosConfigurationFromFile()
+        {
+            string cosmosFile = $"{CONFIGFILE_NAME}.{COSMOS_ENVIRONMENT}{CONFIG_EXTENSION}";
+
+            string configurationFileContents = File.ReadAllText(cosmosFile);
+            if (!RuntimeConfigLoader.TryParseConfig(configurationFileContents, out RuntimeConfig config))
+            {
+                throw new Exception("Failed to parse configuration file.");
+            }
+
+            // The Schema file isn't provided in the configuration file when going through the configuration endpoint so we're removing it.
+            config.DataSource.Options.Remove("Schema");
+            return config;
         }
 
         /// <summary>


### PR DESCRIPTION
## Context
Cherry-picking #1739 from `release/0.8` to main and also resolved merge conflicts. Remainder of description copied from #1739 PR description.

## Why make this change?
Failing to set the configuration at runtime if there is not "schema" file set in the config. This is not required when setting the config at runtime since the graphql schema is set already.

## How was this tested?

- [x] Validated locally
- [x] Updated the tests so the schema property is removed from the config. Verified that the tests were failing before the fix and passing after.
