### PR TITLE
Ensuring correct population of second constructor in runtimeconfig.

### DIFF
--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -245,9 +245,9 @@ public record RuntimeConfig
     private void SetupDataSourcesUsed()
     {
         SqlDataSourceUsed = _dataSourceNameToDataSource.Values.Any
-            (x => x.DatabaseType == DatabaseType.MSSQL || x.DatabaseType == DatabaseType.PostgreSQL || x.DatabaseType == DatabaseType.MySQL);
+            (x => x.DatabaseType is DatabaseType.MSSQL || x.DatabaseType is DatabaseType.PostgreSQL || x.DatabaseType is DatabaseType.MySQL);
 
         CosmosDataSourceUsed = _dataSourceNameToDataSource.Values.Any
-            (x => x.DatabaseType == DatabaseType.CosmosDB_NoSQL);
+            (x => x.DatabaseType is DatabaseType.CosmosDB_NoSQL);
     }
 }

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -116,11 +116,7 @@ public record RuntimeConfig
             this.Entities = new RuntimeEntities(allEntities.ToDictionary(x => x.Key, x => x.Value));
         }
 
-        SqlDataSourceUsed = _dataSourceNameToDataSource.Values.Any
-            (x => x.DatabaseType == DatabaseType.MSSQL || x.DatabaseType == DatabaseType.PostgreSQL || x.DatabaseType == DatabaseType.MySQL);
-
-        CosmosDataSourceUsed = _dataSourceNameToDataSource.Values.Any
-                (x => x.DatabaseType == DatabaseType.CosmosDB_NoSQL);
+        SetupDataSourcesUsed();
 
     }
 
@@ -147,6 +143,8 @@ public record RuntimeConfig
         _dataSourceNameToDataSource = DataSourceNameToDataSource;
         _entityNameToDataSourceName = EntityNameToDataSourceName;
         this.DataSourceFiles = DataSourceFiles;
+
+        SetupDataSourcesUsed();
     }
 
     /// <summary>
@@ -242,5 +240,14 @@ public record RuntimeConfig
                 statusCode: HttpStatusCode.NotFound,
                 subStatusCode: DataApiBuilderException.SubStatusCodes.EntityNotFound);
         }
+    }
+
+    private void SetupDataSourcesUsed()
+    {
+        SqlDataSourceUsed = _dataSourceNameToDataSource.Values.Any
+            (x => x.DatabaseType == DatabaseType.MSSQL || x.DatabaseType == DatabaseType.PostgreSQL || x.DatabaseType == DatabaseType.MySQL);
+
+        CosmosDataSourceUsed = _dataSourceNameToDataSource.Values.Any
+            (x => x.DatabaseType == DatabaseType.CosmosDB_NoSQL);
     }
 }

--- a/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
@@ -2131,10 +2131,10 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 { entityName, sampleEntity1 }
             };
 
-            DataSource ds = new(DatabaseType: DatabaseType.MSSQL, "", Options: null);
+            DataSource testDataSource = new(DatabaseType: DatabaseType.MSSQL, "", Options: null);
             Dictionary<string, DataSource> dataSourceNameToDataSource = new()
             {
-                { dataSourceName, ds }
+                { dataSourceName, testDataSource }
             };
 
             Dictionary<string, string> entityNameToDataSourceName = new()
@@ -2144,7 +2144,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             RuntimeConfig runtimeConfig = new(
                 Schema: "UnitTestSchema",
-                DataSource: ds,
+                DataSource: testDataSource,
                 Runtime: new(
                     Rest: new(),
                     GraphQL: new(),
@@ -2156,7 +2156,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 EntityNameToDataSourceName: entityNameToDataSourceName
             );
 
-            Assert.AreEqual(ds, runtimeConfig.DataSource, "RuntimeConfig datasource must match datasource passed into constructor");
+            Assert.AreEqual(testDataSource, runtimeConfig.DataSource, "RuntimeConfig datasource must match datasource passed into constructor");
             Assert.AreEqual(dataSourceNameToDataSource.Count(), runtimeConfig.ListAllDataSources().Count(),
                 "RuntimeConfig datasource count must match datasource count passed into constructor");
             Assert.IsTrue(runtimeConfig.SqlDataSourceUsed,

--- a/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
@@ -2099,6 +2099,72 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             Assert.AreEqual(finalConfigFilePath, runtimeConfigLoader.ConfigFilePath);
         }
 
+        /// <summary>
+        /// Method to validate that runtimeConfig is successfully set up using constructor
+        /// where members are passed in without json config file.
+        /// RuntimeConfig has two constructors, one that loads from the config json and one that takes in all the members.
+        /// This test makes sure that the constructor that takes in all the members works as expected.
+        /// </summary>
+        [TestMethod]
+        public void TestRuntimeConfigSetupWithNonJsonConstructor()
+        {
+            EntitySource entitySource = new(
+                    Type: EntitySourceType.Table,
+                    Object: "sourceName",
+                    Parameters: null,
+                    KeyFields: null
+                );
+
+            Entity sampleEntity1 = new(
+                Source: entitySource,
+                GraphQL: null,
+                Rest: null,
+                Permissions: null,
+                Mappings: null,
+                Relationships: null);
+
+            string entityName = "SampleEntity1";
+            string dataSourceName = "Test1";
+
+            Dictionary<string, Entity> entityMap = new()
+            {
+                { entityName, sampleEntity1 }
+            };
+
+            DataSource ds = new(DatabaseType: DatabaseType.MSSQL, "", Options: null);
+            Dictionary<string, DataSource> dataSourceNameToDataSource = new()
+            {
+                { dataSourceName, ds }
+            };
+
+            Dictionary<string, string> entityNameToDataSourceName = new()
+            {
+                { entityName, dataSourceName }
+            };
+
+            RuntimeConfig runtimeConfig = new(
+                Schema: "UnitTestSchema",
+                DataSource: ds,
+                Runtime: new(
+                    Rest: new(),
+                    GraphQL: new(),
+                    Host: new(null, null)
+                ),
+                Entities: new RuntimeEntities(entityMap),
+                DefaultDataSourceName: dataSourceName,
+                DataSourceNameToDataSource: dataSourceNameToDataSource,
+                EntityNameToDataSourceName: entityNameToDataSourceName
+            );
+
+            Assert.AreEqual(ds, runtimeConfig.DataSource, "RuntimeConfig datasource must match datasource passed into constructor");
+            Assert.AreEqual(dataSourceNameToDataSource.Count(), runtimeConfig.ListAllDataSources().Count(),
+                "RuntimeConfig datasource count must match datasource count passed into constructor");
+            Assert.IsTrue(runtimeConfig.SqlDataSourceUsed,
+                $"Config has a sql datasource and member {nameof(runtimeConfig.SqlDataSourceUsed)} must be marked as true.");
+            Assert.IsFalse(runtimeConfig.CosmosDataSourceUsed,
+                $"Config does not have a cosmos datasource and member {nameof(runtimeConfig.CosmosDataSourceUsed)} must be marked as false.");
+        }
+
         private static RuntimeConfigValidator InitializeRuntimeConfigValidator()
         {
             MockFileSystem fileSystem = new();


### PR DESCRIPTION
## Why make this change?

Currently, the second constructor for runtimeConfig does not populate SqlDataSourceUsed and CosmosDataSourceUsed. This means that when the second constructor will get used, you will not register a queryEngine for the respective dbs.

## Tests
Added unit test for the same.