### PR TITLE
[CherryPick] Make optional object sub properties nullable patch

### DIFF
--- a/src/Cli.Tests/EndToEndTests.cs
+++ b/src/Cli.Tests/EndToEndTests.cs
@@ -61,7 +61,7 @@ public class EndToEndTests
         Assert.IsTrue(_runtimeConfigLoader!.TryLoadConfig(TEST_RUNTIME_CONFIG_FILE, out RuntimeConfig? runtimeConfig));
 
         Assert.IsNotNull(runtimeConfig);
-        Assert.IsTrue(runtimeConfig.Runtime.GraphQL.AllowIntrospection);
+        Assert.IsTrue(runtimeConfig.AllowIntrospection);
         Assert.AreEqual(DatabaseType.CosmosDB_NoSQL, runtimeConfig.DataSource.DatabaseType);
         CosmosDbNoSQLDataSourceOptions? cosmosDataSourceOptions = runtimeConfig.DataSource.GetTypedOptions<CosmosDbNoSQLDataSourceOptions>();
         Assert.IsNotNull(cosmosDataSourceOptions);
@@ -92,13 +92,17 @@ public class EndToEndTests
         Assert.IsNotNull(runtimeConfig);
         Assert.AreEqual(DatabaseType.CosmosDB_PostgreSQL, runtimeConfig.DataSource.DatabaseType);
         Assert.IsNotNull(runtimeConfig.Runtime);
+        Assert.IsNotNull(runtimeConfig.Runtime.Rest);
         Assert.AreEqual("/rest-api", runtimeConfig.Runtime.Rest.Path);
         Assert.IsTrue(runtimeConfig.Runtime.Rest.Enabled);
+        Assert.IsNotNull(runtimeConfig.Runtime.GraphQL);
         Assert.AreEqual("/graphql-api", runtimeConfig.Runtime.GraphQL.Path);
         Assert.IsTrue(runtimeConfig.Runtime.GraphQL.Enabled);
 
-        HostOptions hostGlobalSettings = runtimeConfig.Runtime.Host;
-        CollectionAssert.AreEqual(new string[] { "localhost:3000", "www.nolocalhost.com:80" }, hostGlobalSettings.Cors!.Origins);
+        HostOptions? hostGlobalSettings = runtimeConfig.Runtime?.Host;
+        Assert.IsNotNull(hostGlobalSettings);
+        Assert.IsNotNull(hostGlobalSettings.Cors);
+        CollectionAssert.AreEqual(new string[] { "localhost:3000", "www.nolocalhost.com:80" }, hostGlobalSettings.Cors.Origins);
     }
 
     /// <summary>
@@ -122,10 +126,10 @@ public class EndToEndTests
         Assert.IsNotNull(runtimeConfig);
         Assert.AreEqual(DatabaseType.MSSQL, runtimeConfig.DataSource.DatabaseType);
         Assert.IsNotNull(runtimeConfig.Runtime);
-        Assert.AreEqual("/rest-api", runtimeConfig.Runtime.Rest.Path);
-        Assert.IsFalse(runtimeConfig.Runtime.Rest.Enabled);
-        Assert.AreEqual("/graphql-api", runtimeConfig.Runtime.GraphQL.Path);
-        Assert.IsTrue(runtimeConfig.Runtime.GraphQL.Enabled);
+        Assert.AreEqual("/rest-api", runtimeConfig.Runtime.Rest?.Path);
+        Assert.IsFalse(runtimeConfig.Runtime.Rest?.Enabled);
+        Assert.AreEqual("/graphql-api", runtimeConfig.Runtime.GraphQL?.Path);
+        Assert.IsTrue(runtimeConfig.Runtime.GraphQL?.Enabled);
     }
 
     /// <summary>
@@ -143,7 +147,7 @@ public class EndToEndTests
         // Perform assertions on various properties.
         Assert.IsNotNull(runtimeConfig);
         Assert.AreEqual(0, runtimeConfig.Entities.Count()); // No entities
-        Assert.AreEqual(HostMode.Development, runtimeConfig.Runtime.Host.Mode);
+        Assert.AreEqual(HostMode.Development, runtimeConfig.Runtime?.Host?.Mode);
 
         string[] addArgs = {"add", "todo", "-c", TEST_RUNTIME_CONFIG_FILE, "--source", "s001.todo",
                             "--rest", "todo", "--graphql", "todo", "--permissions", "anonymous:*"};
@@ -179,6 +183,8 @@ public class EndToEndTests
         Assert.IsTrue(_runtimeConfigLoader!.TryLoadConfig(TEST_RUNTIME_CONFIG_FILE, out RuntimeConfig? runtimeConfig));
         Assert.IsNotNull(runtimeConfig);
 
+        Assert.IsNotNull(runtimeConfig.Runtime);
+        Assert.IsNotNull(runtimeConfig.Runtime.Host);
         Assert.AreEqual("AzureAD", runtimeConfig.Runtime.Host.Authentication?.Provider);
         Assert.AreEqual("aud-xxx", runtimeConfig.Runtime.Host.Authentication?.Jwt?.Audience);
         Assert.AreEqual("issuer-xxx", runtimeConfig.Runtime.Host.Authentication?.Jwt?.Issuer);
@@ -204,7 +210,7 @@ public class EndToEndTests
         if (expectSuccess)
         {
             Assert.IsNotNull(runtimeConfig);
-            Assert.AreEqual(hostModeEnumType, runtimeConfig.Runtime.Host.Mode);
+            Assert.AreEqual(hostModeEnumType, runtimeConfig.Runtime?.Host?.Mode);
         }
         else
         {
@@ -225,7 +231,7 @@ public class EndToEndTests
 
         Assert.IsNotNull(runtimeConfig);
         Assert.AreEqual(0, runtimeConfig.Entities.Count()); // No entities
-        Assert.AreEqual(HostMode.Production, runtimeConfig.Runtime.Host.Mode);
+        Assert.AreEqual(HostMode.Production, runtimeConfig.Runtime?.Host?.Mode);
 
         string[] addArgs = { "add", "book", "-c", TEST_RUNTIME_CONFIG_FILE, "--source", "s001.book", "--permissions", "anonymous:*" };
         Program.Execute(addArgs, _cliLogger!, _fileSystem!, _runtimeConfigLoader!);
@@ -765,6 +771,7 @@ public class EndToEndTests
         {
             Assert.IsTrue(_runtimeConfigLoader!.TryLoadConfig(TEST_RUNTIME_CONFIG_FILE, out RuntimeConfig? runtimeConfig));
             Assert.IsNotNull(runtimeConfig);
+            Assert.IsNotNull(runtimeConfig.Runtime);
             Assert.AreEqual("/base-route", runtimeConfig.Runtime.BaseRoute);
         }
     }
@@ -821,10 +828,14 @@ public class EndToEndTests
 
             if (apiType is ApiType.REST)
             {
+                Assert.IsNotNull(runtimeConfig.Runtime);
+                Assert.IsNotNull(runtimeConfig.Runtime.Rest);
                 Assert.AreEqual(expectedEnabledFlagValueInConfig, runtimeConfig.Runtime.Rest.Enabled);
             }
             else
             {
+                Assert.IsNotNull(runtimeConfig.Runtime);
+                Assert.IsNotNull(runtimeConfig.Runtime.GraphQL);
                 Assert.AreEqual(expectedEnabledFlagValueInConfig, runtimeConfig.Runtime.GraphQL.Enabled);
             }
         }
@@ -855,6 +866,8 @@ public class EndToEndTests
         Program.Execute(initArgs, _cliLogger!, _fileSystem!, _runtimeConfigLoader!);
 
         Assert.IsTrue(_runtimeConfigLoader!.TryLoadConfig(TEST_RUNTIME_CONFIG_FILE, out RuntimeConfig? runtimeConfig));
+        Assert.IsNotNull(runtimeConfig.Runtime);
+        Assert.IsNotNull(runtimeConfig.Runtime.Rest);
         Assert.AreEqual(isRequestBodyStrict, runtimeConfig.Runtime.Rest.RequestBodyStrict);
     }
 }

--- a/src/Cli.Tests/ModuleInitializer.cs
+++ b/src/Cli.Tests/ModuleInitializer.cs
@@ -19,6 +19,26 @@ static class ModuleInitializer
     {
         // Ignore the connection string from the output to avoid committing it.
         VerifierSettings.IgnoreMember<DataSource>(dataSource => dataSource.ConnectionString);
+        // Ignore the datasource files as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.DataSourceFiles);
+        // Ignore the CosmosDataSourceUsed as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.CosmosDataSourceUsed);
+        // Ignore the SqlDataSourceUsed as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.SqlDataSourceUsed);
+        // Ignore the IsRequestBodyStrict as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.IsRequestBodyStrict);
+        // Ignore the IsGraphQLEnabled as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.IsGraphQLEnabled);
+        // Ignore the IsRestEnabled as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.IsRestEnabled);
+        // Ignore the IsStaticWebAppsIdentityProvider as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.IsStaticWebAppsIdentityProvider);
+        // Ignore the RestPath as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.RestPath);
+        // Ignore the GraphQLPath as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.GraphQLPath);
+        // Ignore the AllowIntrospection as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.AllowIntrospection);
         // Ignore the JSON schema path as that's unimportant from a test standpoint.
         VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.Schema);
         // Ignore the message as that's not serialized in our config file anyway.

--- a/src/Cli.Tests/TestHelper.cs
+++ b/src/Cli.Tests/TestHelper.cs
@@ -870,7 +870,7 @@ namespace Cli.Tests
           ""graphql"": {
             ""path"": ""/graphql"",
             ""enabled"": true,
-            ""allow-introspection"": true
+            ""allow-introspection"": false
           },
           ""host"": {
             ""mode"": ""production"",
@@ -917,11 +917,6 @@ namespace Cli.Tests
           ""connection-string"": ""localhost:5000;User ID={USER_NAME};Password={USER_PASSWORD};MultipleActiveResultSets=False;""
         },
         ""runtime"": {
-          ""graphql"": {
-            ""path"": ""/graphql"",
-            ""enabled"": true,
-            ""allow-introspection"": true
-          },
           ""host"": {
             ""mode"": ""production"",
             ""cors"": {
@@ -990,7 +985,7 @@ namespace Cli.Tests
           ""graphql"": {
             ""path"": ""/graphql"",
             ""enabled"": true,
-            ""allow-introspection"": true
+            ""allow-introspection"": false
           },
           ""host"": {
             ""mode"": ""production"",

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -939,7 +939,7 @@ namespace Cli
             }
 
             // Add/Update of relationship is not allowed when GraphQL is disabled in Global Runtime Settings
-            if (!runtimeConfig.Runtime.GraphQL.Enabled)
+            if (!runtimeConfig.IsGraphQLEnabled)
             {
                 _logger.LogError("Cannot add/update relationship as GraphQL is disabled in the global runtime settings of the config.");
                 return false;
@@ -1073,7 +1073,7 @@ namespace Cli
             else
             {
                 minimumLogLevel = Startup.GetLogLevelBasedOnMode(deserializedRuntimeConfig);
-                HostMode hostModeType = deserializedRuntimeConfig.Runtime.Host.Mode;
+                HostMode hostModeType = deserializedRuntimeConfig.IsDevelopmentMode() ? HostMode.Development : HostMode.Production;
 
                 _logger.LogInformation("Setting default minimum LogLevel: {minimumLogLevel} for {hostMode} mode.", minimumLogLevel, hostModeType);
             }

--- a/src/Cli/Exporter.cs
+++ b/src/Cli/Exporter.cs
@@ -72,7 +72,7 @@ namespace Cli
             HttpClient client = new( // CodeQL[SM02185] Loading internal server connection
                                         new HttpClientHandler { ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator }
                                     )
-            { BaseAddress = new Uri($"https://localhost:5001{runtimeConfig.Runtime.GraphQL.Path}") };
+            { BaseAddress = new Uri($"https://localhost:5001{runtimeConfig.GraphQLPath}") };
 
             IntrospectionClient introspectionClient = new();
             Task<HotChocolate.Language.DocumentNode> response = introspectionClient.DownloadSchemaAsync(client);

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -178,50 +178,6 @@ namespace Cli
         }
 
         /// <summary>
-        /// Returns the default host Global Settings
-        /// If the user doesn't specify host mode. Default value to be used is Production.
-        /// Sample:
-        // "host": {
-        //     "mode": "production",
-        //     "cors": {
-        //         "origins": [],
-        //         "allow-credentials": true
-        //     },
-        //     "authentication": {
-        //         "provider": "StaticWebApps"
-        //     }
-        // }
-        /// </summary>
-        public static HostOptions GetDefaultHostOptions(
-            HostMode hostMode,
-            IEnumerable<string>? corsOrigin,
-            string authenticationProvider,
-            string? audience,
-            string? issuer)
-        {
-            string[]? corsOriginArray = corsOrigin is null ? new string[] { } : corsOrigin.ToArray();
-            CorsOptions cors = new(Origins: corsOriginArray);
-            AuthenticationOptions AuthenticationOptions;
-            if (Enum.TryParse<EasyAuthType>(authenticationProvider, ignoreCase: true, out _)
-                || AuthenticationOptions.SIMULATOR_AUTHENTICATION.Equals(authenticationProvider))
-            {
-                AuthenticationOptions = new(Provider: authenticationProvider, null);
-            }
-            else
-            {
-                AuthenticationOptions = new(
-                    Provider: authenticationProvider,
-                    Jwt: new(audience, issuer)
-                );
-            }
-
-            return new(
-                Mode: hostMode,
-                Cors: cors,
-                Authentication: AuthenticationOptions);
-        }
-
-        /// <summary>
         /// Returns an object of type Policy
         /// If policyRequest or policyDatabase is provided. Otherwise, returns null.
         /// </summary>

--- a/src/Config/Converters/GraphQLRuntimeOptionsConverterFactory.cs
+++ b/src/Config/Converters/GraphQLRuntimeOptionsConverterFactory.cs
@@ -25,12 +25,12 @@ internal class GraphQLRuntimeOptionsConverterFactory : JsonConverterFactory
     {
         public override GraphQLRuntimeOptions? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.True)
+            if (reader.TokenType == JsonTokenType.True || reader.TokenType == JsonTokenType.Null)
             {
                 return new GraphQLRuntimeOptions();
             }
 
-            if (reader.TokenType == JsonTokenType.Null || reader.TokenType == JsonTokenType.False)
+            if (reader.TokenType == JsonTokenType.False)
             {
                 return new GraphQLRuntimeOptions(Enabled: false);
             }

--- a/src/Config/Converters/RestRuntimeOptionsConverterFactory.cs
+++ b/src/Config/Converters/RestRuntimeOptionsConverterFactory.cs
@@ -25,12 +25,12 @@ internal class RestRuntimeOptionsConverterFactory : JsonConverterFactory
     {
         public override RestRuntimeOptions? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            if (reader.TokenType == JsonTokenType.True)
+            if (reader.TokenType == JsonTokenType.True || reader.TokenType == JsonTokenType.Null)
             {
                 return new RestRuntimeOptions();
             }
 
-            if (reader.TokenType == JsonTokenType.Null || reader.TokenType == JsonTokenType.False)
+            if (reader.TokenType == JsonTokenType.False)
             {
                 return new RestRuntimeOptions(Enabled: false);
             }

--- a/src/Config/ObjectModel/AuthenticationOptions.cs
+++ b/src/Config/ObjectModel/AuthenticationOptions.cs
@@ -11,7 +11,7 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 /// </param>
 /// <param name="Jwt">Settings enabling validation of the received JWT token.
 /// Required only when Provider is other than EasyAuth.</param>
-public record AuthenticationOptions(string Provider, JwtOptions? Jwt)
+public record AuthenticationOptions(string Provider = nameof(EasyAuthType.StaticWebApps), JwtOptions? Jwt = null)
 {
     public const string SIMULATOR_AUTHENTICATION = "Simulator";
     public const string CLIENT_PRINCIPAL_HEADER = "X-MS-CLIENT-PRINCIPAL";
@@ -36,10 +36,4 @@ public record AuthenticationOptions(string Provider, JwtOptions? Jwt)
     /// </summary>
     /// <returns>True if the provider is enabled for JWT, otherwise false.</returns>
     public bool IsJwtConfiguredIdentityProvider() => !IsEasyAuthAuthenticationProvider() && !IsAuthenticationSimulatorEnabled();
-
-    /// <summary>
-    /// A shorthand method to determine whether Static Web Apps is configured for the current authentication provider.
-    /// </summary>
-    /// <returns>True if the provider is enabled for Static Web Apps, otherwise false.</returns>
-    public bool IsStaticWebAppsIdentityProvider() => EasyAuthType.StaticWebApps.ToString().Equals(Provider, StringComparison.OrdinalIgnoreCase);
 };

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -3,4 +3,4 @@
 
 namespace Azure.DataApiBuilder.Config.ObjectModel;
 
-public record HostOptions(CorsOptions? Cors, AuthenticationOptions? Authentication, HostMode Mode = HostMode.Development);
+public record HostOptions(CorsOptions? Cors, AuthenticationOptions? Authentication, HostMode Mode = HostMode.Production);

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -13,11 +13,111 @@ public record RuntimeConfig
     [JsonPropertyName("$schema")]
     public string Schema { get; init; }
 
+    public const string DEFAULT_CONFIG_SCHEMA_LINK = "https://github.com/Azure/data-api-builder/releases/download/vmajor.minor.patch/dab.draft.schema.json";
+
     public DataSource DataSource { get; init; }
 
-    public RuntimeOptions Runtime { get; init; }
+    public RuntimeOptions? Runtime { get; init; }
 
     public RuntimeEntities Entities { get; init; }
+
+    public DataSourceFiles? DataSourceFiles { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    public bool CosmosDataSourceUsed { get; private set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    public bool SqlDataSourceUsed { get; private set; }
+
+    /// <summary>
+    /// Retrieves the value of runtime.rest.request-body-strict property if present, default is true.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsRequestBodyStrict =>
+        Runtime is null ||
+        Runtime.Rest is null ||
+        Runtime.Rest.RequestBodyStrict;
+
+    /// <summary>
+    /// Retrieves the value of runtime.graphql.enabled property if present, default is true.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsGraphQLEnabled => Runtime is null ||
+        Runtime.GraphQL is null ||
+        Runtime.GraphQL.Enabled;
+
+    /// <summary>
+    /// Retrieves the value of runtime.rest.enabled property if present, default is true if its not cosmosdb.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsRestEnabled =>
+        (Runtime is null ||
+         Runtime.Rest is null ||
+         Runtime.Rest.Enabled) &&
+         DataSource.DatabaseType != DatabaseType.CosmosDB_NoSQL;
+
+    /// <summary>
+    /// A shorthand method to determine whether Static Web Apps is configured for the current authentication provider.
+    /// </summary>
+    /// <returns>True if the authentication provider is enabled for Static Web Apps, otherwise false.</returns>
+    [JsonIgnore]
+    public bool IsStaticWebAppsIdentityProvider =>
+        Runtime is null ||
+        Runtime.Host is null ||
+        Runtime.Host.Authentication is null ||
+        EasyAuthType.StaticWebApps.ToString().Equals(Runtime.Host.Authentication.Provider, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The path at which Rest APIs are available
+    /// </summary>
+    [JsonIgnore]
+    public string RestPath
+    {
+        get
+        {
+            if (Runtime is null || Runtime.Rest is null)
+            {
+                return RestRuntimeOptions.DEFAULT_PATH;
+            }
+            else
+            {
+                return Runtime.Rest.Path;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The path at which GraphQL API is available
+    /// </summary>
+    [JsonIgnore]
+    public string GraphQLPath
+    {
+        get
+        {
+            if (Runtime is null || Runtime.GraphQL is null)
+            {
+                return GraphQLRuntimeOptions.DEFAULT_PATH;
+            }
+            else
+            {
+                return Runtime.GraphQL.Path;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Indicates whether introspection is allowed or not.
+    /// </summary>
+    [JsonIgnore]
+    public bool AllowIntrospection
+    {
+        get
+        {
+            return Runtime is null ||
+                Runtime.GraphQL is null ||
+                Runtime.GraphQL.AllowIntrospection;
+        }
+    }
 
     private string _defaultDataSourceName;
 
@@ -47,12 +147,13 @@ public record RuntimeConfig
     /// </summary>
     /// <param name="Schema">schema.</param>
     /// <param name="DataSource">Default datasource.</param>
-    /// <param name="Runtime">Runtime settings.</param>
     /// <param name="Entities">Entities</param>
+    /// <param name="Runtime">Runtime settings.</param>
+    /// <param name="DataSourceFiles">List of datasource files for multiple db scenario. Null for single db scenario.</param>
     [JsonConstructor]
-    public RuntimeConfig(string Schema, DataSource DataSource, RuntimeOptions Runtime, RuntimeEntities Entities)
+    public RuntimeConfig(string? Schema, DataSource DataSource, RuntimeEntities Entities, RuntimeOptions? Runtime = null, DataSourceFiles? DataSourceFiles = null)
     {
-        this.Schema = Schema;
+        this.Schema = Schema ?? DEFAULT_CONFIG_SCHEMA_LINK;
         this.DataSource = DataSource;
         this.Runtime = Runtime;
         this.Entities = Entities;
@@ -195,6 +296,10 @@ public record RuntimeConfig
         jsonSerializerOptions = jsonSerializerOptions ?? RuntimeConfigLoader.GetSerializationOptions();
         return JsonSerializer.Serialize(this, jsonSerializerOptions);
     }
+
+    public bool IsDevelopmentMode() =>
+        Runtime is not null && Runtime.Host is not null
+        && Runtime.Host.Mode is HostMode.Development;
 
     private void CheckDataSourceNamePresent(string dataSourceName)
     {

--- a/src/Config/ObjectModel/RuntimeOptions.cs
+++ b/src/Config/ObjectModel/RuntimeOptions.cs
@@ -4,8 +4,8 @@
 namespace Azure.DataApiBuilder.Config.ObjectModel;
 
 public record RuntimeOptions(
-    RestRuntimeOptions Rest,
-    GraphQLRuntimeOptions GraphQL,
-    HostOptions Host,
+    RestRuntimeOptions? Rest,
+    GraphQLRuntimeOptions? GraphQL,
+    HostOptions? Host,
     string? BaseRoute = null,
     TelemetryOptions? Telemetry = null);

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -117,34 +117,7 @@ public abstract class RuntimeConfigLoader
                 {
                     config = config with { DataSource = ds };
                 }
-
             }
-
-            // For Cosmos DB NoSQL database type, DAB CLI v0.8.49+ generates a REST property within the Runtime section of the config file. However
-            // v0.7.6- does not generate this property. So, when the config file generated using v0.7.6- is used to start the engine with v0.8.49+, the absence
-            // of the REST property causes the engine to throw exceptions. This is the only difference in the way Runtime section of the config file is created
-            // between these two versions.
-            // To avoid the NullReference Exceptions, the REST property is added when absent in the config file.
-            // Other properties within the Runtime section are also populated with default values to account for the cases where
-            // the properties could be removed manually from the config file.
-            if (config.Runtime is not null)
-            {
-                if (config.Runtime.Rest is null)
-                {
-                    config = config with { Runtime = config.Runtime with { Rest = (config.DataSource.DatabaseType is DatabaseType.CosmosDB_NoSQL) ? new RestRuntimeOptions(Enabled: false) : new RestRuntimeOptions(Enabled: false) } };
-                }
-
-                if (config.Runtime.GraphQL is null)
-                {
-                    config = config with { Runtime = config.Runtime with { GraphQL = new GraphQLRuntimeOptions(AllowIntrospection: false) } };
-                }
-
-                if (config.Runtime.Host is null)
-                {
-                    config = config with { Runtime = config.Runtime with { Host = new HostOptions(Cors: null, Authentication: new AuthenticationOptions(Provider: EasyAuthType.StaticWebApps.ToString(), Jwt: null), Mode: HostMode.Production) } };
-                }
-            }
-
         }
         catch (JsonException ex)
         {

--- a/src/Core/Configurations/RuntimeConfigValidator.cs
+++ b/src/Core/Configurations/RuntimeConfigValidator.cs
@@ -74,18 +74,18 @@ namespace Azure.DataApiBuilder.Core.Configurations
             ValidateAuthenticationOptions(runtimeConfig);
             ValidateGlobalEndpointRouteConfig(runtimeConfig);
 
-            // Running these graphQL validations only in development mode to ensure
-            // fast startup of engine in production mode.
-            if (runtimeConfig.Runtime.Host.Mode is HostMode.Development)
-            {
-                ValidateEntityConfiguration(runtimeConfig);
+        // Running these graphQL validations only in development mode to ensure
+        // fast startup of engine in production mode.
+        if (runtimeConfig.IsDevelopmentMode())
+        {
+            ValidateEntityConfiguration(runtimeConfig);
 
-                if (runtimeConfig.Runtime.GraphQL.Enabled)
-                {
-                    ValidateEntitiesDoNotGenerateDuplicateQueriesOrMutation(runtimeConfig.Entities);
-                }
+            if (runtimeConfig.IsGraphQLEnabled)
+            {
+                ValidateEntitiesDoNotGenerateDuplicateQueriesOrMutation(runtimeConfig.Entities);
             }
         }
+    }
 
         /// <summary>
         /// Throws exception if Invalid connection-string or database type
@@ -251,34 +251,34 @@ namespace Azure.DataApiBuilder.Core.Configurations
             // Stores the unique rest paths configured for different entities present in the config.
             HashSet<string> restPathsForEntities = new();
 
-            foreach ((string entityName, Entity entity) in runtimeConfig.Entities)
+        foreach ((string entityName, Entity entity) in runtimeConfig.Entities)
+        {
+            if (runtimeConfig.IsRestEnabled && entity.Rest is not null && entity.Rest.Enabled)
             {
-                if (runtimeConfig.Runtime.Rest.Enabled && entity.Rest is not null && entity.Rest.Enabled)
+                // If no custom rest path is defined for the entity, we default it to the entityName.
+                string pathForEntity = entity.Rest.Path is not null ? entity.Rest.Path.TrimStart('/') : entityName;
+                ValidateRestPathSettingsForEntity(entityName, pathForEntity);
+                if (!restPathsForEntities.Add(pathForEntity))
                 {
-                    // If no custom rest path is defined for the entity, we default it to the entityName.
-                    string pathForEntity = entity.Rest.Path is not null ? entity.Rest.Path.TrimStart('/') : entityName;
-                    ValidateRestPathSettingsForEntity(entityName, pathForEntity);
-                    if (!restPathsForEntities.Add(pathForEntity))
-                    {
-                        // Presence of multiple entities having the same rest path configured causes conflict.
-                        throw new DataApiBuilderException(
-                            message: $"The rest path: {pathForEntity} specified for entity: {entityName} is already used by another entity.",
-                            statusCode: HttpStatusCode.ServiceUnavailable,
-                            subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError
-                            );
-                    }
+                    // Presence of multiple entities having the same rest path configured causes conflict.
+                    throw new DataApiBuilderException(
+                        message: $"The rest path: {pathForEntity} specified for entity: {entityName} is already used by another entity.",
+                        statusCode: HttpStatusCode.ServiceUnavailable,
+                        subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError
+                        );
+                }
 
                     ValidateRestMethods(entity, entityName);
                 }
 
-                // If GraphQL endpoint is enabled globally and at entity level, then only we perform the validations related to it.
-                if (runtimeConfig.Runtime.GraphQL.Enabled && entity.GraphQL is not null && entity.GraphQL.Enabled)
-                {
-                    ValidateNameRequirements(entity.GraphQL.Singular);
-                    ValidateNameRequirements(entity.GraphQL.Plural);
-                }
+            // If GraphQL endpoint is enabled globally and at entity level, then only we perform the validations related to it.
+            if (runtimeConfig.IsGraphQLEnabled && entity.GraphQL is not null && entity.GraphQL.Enabled)
+            {
+                ValidateNameRequirements(entity.GraphQL.Singular);
+                ValidateNameRequirements(entity.GraphQL.Plural);
             }
         }
+    }
 
         /// <summary>
         /// Helper method to validate and let users know whether insignificant properties are present in the REST field.
@@ -336,34 +336,34 @@ namespace Azure.DataApiBuilder.Core.Configurations
             }
         }
 
-        /// <summary>
-        /// Ensure the global REST and GraphQL endpoints do not conflict if both
-        /// are enabled.
-        /// </summary>
-        /// <param name="runtimeConfig">The config that will be validated.</param>
-        public static void ValidateGlobalEndpointRouteConfig(RuntimeConfig runtimeConfig)
+    /// <summary>
+    /// Ensure the global REST and GraphQL endpoints do not conflict if both
+    /// are enabled.
+    /// </summary>
+    /// <param name="runtimeConfig">The config that will be validated.</param>
+    public static void ValidateGlobalEndpointRouteConfig(RuntimeConfig runtimeConfig)
+    {
+        // Both REST and GraphQL endpoints cannot be disabled at the same time.
+        if (!runtimeConfig.IsRestEnabled && !runtimeConfig.IsGraphQLEnabled)
         {
-            // Both REST and GraphQL endpoints cannot be disabled at the same time.
-            if (!runtimeConfig.Runtime.Rest.Enabled && !runtimeConfig.Runtime.GraphQL.Enabled)
+            throw new DataApiBuilderException(
+                message: $"Both GraphQL and REST endpoints are disabled.",
+                statusCode: HttpStatusCode.ServiceUnavailable,
+                subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
+        }
+
+        string? runtimeBaseRoute = runtimeConfig.Runtime?.BaseRoute;
+
+        // Ensure that the runtime base-route is only configured when authentication provider is StaticWebApps.
+        if (runtimeBaseRoute is not null)
+        {
+            if (!runtimeConfig.IsStaticWebAppsIdentityProvider)
             {
                 throw new DataApiBuilderException(
-                    message: $"Both GraphQL and REST endpoints are disabled.",
+                    message: "Runtime base-route can only be used when the authentication provider is Static Web Apps.",
                     statusCode: HttpStatusCode.ServiceUnavailable,
                     subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
             }
-
-            string? runtimeBaseRoute = runtimeConfig.Runtime.BaseRoute;
-
-            // Ensure that the runtime base-route is only configured when authentication provider is StaticWebApps.
-            if (runtimeBaseRoute is not null)
-            {
-                if (runtimeConfig.Runtime.Host.Authentication is null || !runtimeConfig.Runtime.Host.Authentication.IsStaticWebAppsIdentityProvider())
-                {
-                    throw new DataApiBuilderException(
-                        message: "Runtime base-route can only be used when the authentication provider is Static Web Apps.",
-                        statusCode: HttpStatusCode.ServiceUnavailable,
-                        subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
-                }
 
                 if (!TryValidateUriComponent(runtimeBaseRoute, out string exceptionMsgSuffix))
                 {
@@ -374,25 +374,25 @@ namespace Azure.DataApiBuilder.Core.Configurations
                 }
             }
 
-            ValidateRestURI(runtimeConfig);
-            ValidateGraphQLURI(runtimeConfig);
-            // Do not check for conflicts if GraphQL or REST endpoints are disabled.
-            if (!runtimeConfig.Runtime.Rest.Enabled || !runtimeConfig.Runtime.GraphQL.Enabled)
-            {
-                return;
-            }
-
-            if (string.Equals(
-                a: runtimeConfig.Runtime.Rest.Path,
-                b: runtimeConfig.Runtime.GraphQL.Path,
-                comparisonType: StringComparison.OrdinalIgnoreCase))
-            {
-                throw new DataApiBuilderException(
-                    message: $"Conflicting GraphQL and REST path configuration.",
-                    statusCode: HttpStatusCode.ServiceUnavailable,
-                    subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
-            }
+        ValidateRestURI(runtimeConfig);
+        ValidateGraphQLURI(runtimeConfig);
+        // Do not check for conflicts if GraphQL or REST endpoints are disabled.
+        if (!runtimeConfig.IsRestEnabled || !runtimeConfig.IsGraphQLEnabled)
+        {
+            return;
         }
+
+        if (string.Equals(
+            a: runtimeConfig.RestPath,
+            b: runtimeConfig.GraphQLPath,
+            comparisonType: StringComparison.OrdinalIgnoreCase))
+        {
+            throw new DataApiBuilderException(
+                message: $"Conflicting GraphQL and REST path configuration.",
+                statusCode: HttpStatusCode.ServiceUnavailable,
+                subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
+        }
+    }
 
         /// <summary>
         /// Method to validate that the REST URI (REST path prefix, REST base route).
@@ -407,33 +407,33 @@ namespace Azure.DataApiBuilder.Core.Configurations
                 return;
             }
 
-            // validate the rest path.
-            string restPath = runtimeConfig.Runtime.Rest.Path;
-            if (!TryValidateUriComponent(restPath, out string exceptionMsgSuffix))
-            {
-                throw new DataApiBuilderException(
-                    message: $"{ApiType.REST} path {exceptionMsgSuffix}",
-                    statusCode: HttpStatusCode.ServiceUnavailable,
-                    subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
-            }
-
-        }
-
-        /// <summary>
-        /// Method to validate that the GraphQL URI (GraphQL path prefix).
-        /// </summary>
-        /// <param name="runtimeConfig"></param>
-        public static void ValidateGraphQLURI(RuntimeConfig runtimeConfig)
+        // validate the rest path.
+        string restPath = runtimeConfig.RestPath;
+        if (!TryValidateUriComponent(restPath, out string exceptionMsgSuffix))
         {
-            string graphqlPath = runtimeConfig.Runtime.GraphQL.Path;
-            if (!TryValidateUriComponent(graphqlPath, out string exceptionMsgSuffix))
-            {
-                throw new DataApiBuilderException(
-                    message: $"{ApiType.GraphQL} path {exceptionMsgSuffix}",
-                    statusCode: HttpStatusCode.ServiceUnavailable,
-                    subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
-            }
+            throw new DataApiBuilderException(
+                message: $"{ApiType.REST} path {exceptionMsgSuffix}",
+                statusCode: HttpStatusCode.ServiceUnavailable,
+                subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
         }
+
+        }
+
+    /// <summary>
+    /// Method to validate that the GraphQL URI (GraphQL path prefix).
+    /// </summary>
+    /// <param name="runtimeConfig"></param>
+    public static void ValidateGraphQLURI(RuntimeConfig runtimeConfig)
+    {
+        string graphqlPath = runtimeConfig.GraphQLPath;
+        if (!TryValidateUriComponent(graphqlPath, out string exceptionMsgSuffix))
+        {
+            throw new DataApiBuilderException(
+                message: $"{ApiType.GraphQL} path {exceptionMsgSuffix}",
+                statusCode: HttpStatusCode.ServiceUnavailable,
+                subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
+        }
+    }
 
         /// <summary>
         /// Method to validate that the REST/GraphQL URI component is well formed and does not contain
@@ -477,13 +477,13 @@ namespace Azure.DataApiBuilder.Core.Configurations
             return _reservedUriCharsRgx.IsMatch(uriComponent);
         }
 
-        private static void ValidateAuthenticationOptions(RuntimeConfig runtimeConfig)
+    private static void ValidateAuthenticationOptions(RuntimeConfig runtimeConfig)
+    {
+        // Bypass validation of auth if there is no auth provided
+        if (runtimeConfig.Runtime?.Host?.Authentication is null)
         {
-            // Bypass validation of auth if there is no auth provided
-            if (runtimeConfig.Runtime.Host.Authentication is null)
-            {
-                return;
-            }
+            return;
+        }
 
             bool isAudienceSet = !string.IsNullOrEmpty(runtimeConfig.Runtime.Host.Authentication.Jwt?.Audience);
             bool isIssuerSet = !string.IsNullOrEmpty(runtimeConfig.Runtime.Host.Authentication.Jwt?.Issuer);
@@ -822,18 +822,17 @@ namespace Azure.DataApiBuilder.Core.Configurations
             }
         }
 
-        /// <summary>
-        /// Method to do different validations on claims in the policy.
-        /// </summary>
-        /// <param name="policy">The policy to be validated and processed.</param>
-        /// <returns>Processed policy</returns>
-        /// <exception cref="DataApiBuilderException">Throws exception when one or the other validations fail.</exception>
-        private static void ValidateClaimsInPolicy(string policy, RuntimeConfig runtimeConfig)
-        {
-            // Find all the claimTypes from the policy
-            MatchCollection claimTypes = GetClaimTypesInPolicy(policy);
-            bool isStaticWebAppsAuthConfigured = Enum.TryParse(runtimeConfig.Runtime.Host.Authentication?.Provider, ignoreCase: true, out EasyAuthType easyAuthMode) ?
-                easyAuthMode is EasyAuthType.StaticWebApps : false;
+    /// <summary>
+    /// Method to do different validations on claims in the policy.
+    /// </summary>
+    /// <param name="policy">The policy to be validated and processed.</param>
+    /// <returns>Processed policy</returns>
+    /// <exception cref="DataApiBuilderException">Throws exception when one or the other validations fail.</exception>
+    private static void ValidateClaimsInPolicy(string policy, RuntimeConfig runtimeConfig)
+    {
+        // Find all the claimTypes from the policy
+        MatchCollection claimTypes = GetClaimTypesInPolicy(policy);
+        bool isStaticWebAppsAuthConfigured = runtimeConfig.IsStaticWebAppsIdentityProvider;
 
             foreach (Match claimType in claimTypes)
             {

--- a/src/Core/Parsers/IntrospectionInterceptor.cs
+++ b/src/Core/Parsers/IntrospectionInterceptor.cs
@@ -51,7 +51,7 @@ namespace Azure.DataApiBuilder.Core.Parsers
             IQueryRequestBuilder requestBuilder,
             CancellationToken cancellationToken)
         {
-            if (_runtimeConfigProvider.GetConfig().Runtime.GraphQL.AllowIntrospection)
+            if (_runtimeConfigProvider.GetConfig().AllowIntrospection)
             {
                 requestBuilder.AllowIntrospection();
             }

--- a/src/Core/Resolvers/DbExceptionParser.cs
+++ b/src/Core/Resolvers/DbExceptionParser.cs
@@ -3,7 +3,6 @@
 
 using System.Data.Common;
 using System.Net;
-using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Service.Exceptions;
 
@@ -28,7 +27,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
         public DbExceptionParser(RuntimeConfigProvider configProvider)
         {
-            _developerMode = configProvider.GetConfig().Runtime.Host.Mode is HostMode.Development;
+            _developerMode = configProvider.GetConfig().IsDevelopmentMode();
             BadRequestExceptionCodes = new();
             TransientExceptionCodes = new();
             ConflictExceptionCodes = new();

--- a/src/Core/Resolvers/SqlMutationEngine.cs
+++ b/src/Core/Resolvers/SqlMutationEngine.cs
@@ -1053,7 +1053,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         private static string GetBaseRouteFromConfig(RuntimeConfig? config)
         {
-            if (config is not null && config.Runtime is not null && config.Runtime.BaseRoute is not null)
+            if (config?.Runtime?.BaseRoute is not null)
             {
                 return config.Runtime.BaseRoute;
             }

--- a/src/Core/Resolvers/SqlPaginationUtil.cs
+++ b/src/Core/Resolvers/SqlPaginationUtil.cs
@@ -5,7 +5,6 @@ using System.Collections.Specialized;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Services;
@@ -343,7 +342,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 // keys of afterDeserialized do not correspond to the primary key
                 // values given for the primary keys are of incorrect format
                 // duplicate column names in the after token and / or the orderby columns
-                string errorMessage = runtimeConfigProvider.GetConfig().Runtime.Host.Mode is HostMode.Development ? $"{e.Message}\n{e.StackTrace}" :
+                string errorMessage = runtimeConfigProvider.GetConfig().IsDevelopmentMode() ? $"{e.Message}\n{e.StackTrace}" :
                     $"{afterJsonString} is not a valid pagination token.";
                 throw new DataApiBuilderException(
                     message: errorMessage,

--- a/src/Core/Resolvers/SqlResponseHelpers.cs
+++ b/src/Core/Resolvers/SqlResponseHelpers.cs
@@ -91,7 +91,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             string path = UriHelper.GetEncodedUrl(httpContext!.Request).Split('?')[0];
 
             // If the base route is not empty, we need to insert it into the URI before the rest path.
-            string? baseRoute = runtimeConfig.Runtime.BaseRoute;
+            string? baseRoute = runtimeConfig.Runtime?.BaseRoute;
             if (!string.IsNullOrWhiteSpace(baseRoute))
             {
                 HttpRequest request = httpContext!.Request;

--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -347,7 +347,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
 
         public bool IsDevelopmentMode()
         {
-            return _runtimeConfig.Runtime.Host.Mode is HostMode.Development;
+            return _runtimeConfig.IsDevelopmentMode();
         }
     }
 }

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -84,10 +84,10 @@ namespace Azure.DataApiBuilder.Core.Services
             _logger = logger;
             foreach ((string entityName, Entity entityMetatdata) in _entities)
             {
-                if (runtimeConfig.Runtime.Rest.Enabled)
+                if (runtimeConfig.IsRestEnabled)
                 {
                     string restPath = entityMetatdata.Rest?.Path ?? entityName;
-                    _logger.LogInformation("[{entity}] REST path: {globalRestPath}/{entityRestPath}", entityName, runtimeConfig.Runtime.Rest.Path, restPath);
+                    _logger.LogInformation("[{entity}] REST path: {globalRestPath}/{entityRestPath}", entityName, runtimeConfig.RestPath, restPath);
                 }
                 else
                 {
@@ -381,7 +381,7 @@ namespace Azure.DataApiBuilder.Core.Services
         private void GenerateRestPathToEntityMap()
         {
             RuntimeConfig runtimeConfig = _runtimeConfigProvider.GetConfig();
-            string graphQLGlobalPath = runtimeConfig.Runtime.GraphQL.Path;
+            string graphQLGlobalPath = runtimeConfig.GraphQLPath;
 
             foreach ((string entityName, Entity entity) in _entities)
             {
@@ -1001,9 +1001,9 @@ namespace Azure.DataApiBuilder.Core.Services
             {
                 string columnName = columnInfoFromAdapter["ColumnName"].ToString()!;
 
-                if (runtimeConfig.Runtime.GraphQL.Enabled
+                if (runtimeConfig.IsGraphQLEnabled
                     && entity is not null
-                    && IsGraphQLReservedName(entity, columnName, graphQLEnabledGlobally: runtimeConfig.Runtime.GraphQL.Enabled))
+                    && IsGraphQLReservedName(entity, columnName, graphQLEnabledGlobally: runtimeConfig.IsGraphQLEnabled))
                 {
                     throw new DataApiBuilderException(
                        message: $"The column '{columnName}' violates GraphQL name restrictions.",
@@ -1598,7 +1598,7 @@ namespace Azure.DataApiBuilder.Core.Services
 
         public bool IsDevelopmentMode()
         {
-            return _runtimeConfigProvider.GetConfig().Runtime.Host.Mode is HostMode.Development;
+            return _runtimeConfigProvider.GetConfig().IsDevelopmentMode();
         }
     }
 }

--- a/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
+++ b/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
@@ -103,7 +103,7 @@ namespace Azure.DataApiBuilder.Core.Services
                     subStatusCode: DataApiBuilderException.SubStatusCodes.OpenApiDocumentAlreadyExists);
             }
 
-            if (!_runtimeConfig.Runtime.Rest.Enabled)
+            if (!_runtimeConfig.IsRestEnabled)
             {
                 throw new DataApiBuilderException(
                     message: DOCUMENT_CREATION_UNSUPPORTED_ERROR,
@@ -113,8 +113,8 @@ namespace Azure.DataApiBuilder.Core.Services
 
             try
             {
-                string restEndpointPath = _runtimeConfig.Runtime.Rest.Path;
-                string? runtimeBaseRoute = _runtimeConfig.Runtime.BaseRoute;
+                string restEndpointPath = _runtimeConfig.RestPath;
+                string? runtimeBaseRoute = _runtimeConfig.Runtime?.BaseRoute;
                 string url = string.IsNullOrEmpty(runtimeBaseRoute) ? restEndpointPath : runtimeBaseRoute + "/" + restEndpointPath;
                 OpenApiComponents components = new()
                 {

--- a/src/Core/Services/OpenAPI/SwaggerEndpointMapper.cs
+++ b/src/Core/Services/OpenAPI/SwaggerEndpointMapper.cs
@@ -38,7 +38,7 @@ namespace Azure.DataApiBuilder.Core.Services.OpenAPI
         public IEnumerator<UrlDescriptor> GetEnumerator()
         {
             RuntimeConfig? config = _runtimeConfigProvider?.GetConfig();
-            string configuredRestPath = config?.Runtime.Rest.Path ?? RestRuntimeOptions.DEFAULT_PATH;
+            string configuredRestPath = config?.RestPath ?? RestRuntimeOptions.DEFAULT_PATH;
             yield return new UrlDescriptor { Name = "DataApibuilder-OpenAPI-PREVIEW", Url = $"{configuredRestPath}/{OpenApiDocumentor.OPENAPI_ROUTE}" };
         }
 

--- a/src/Core/Services/PathRewriteMiddleware.cs
+++ b/src/Core/Services/PathRewriteMiddleware.cs
@@ -98,9 +98,9 @@ namespace Azure.DataApiBuilder.Core.Services
         private bool TryGetGraphQLRouteFromConfig([NotNullWhen(true)] out string? graphQLRoute)
         {
             if (_runtimeConfigurationProvider.TryGetLoadedConfig(out RuntimeConfig? config) &&
-                config.Runtime.GraphQL.Enabled)
+                config.IsGraphQLEnabled)
             {
-                graphQLRoute = config.Runtime.GraphQL.Path;
+                graphQLRoute = config.GraphQLPath;
                 return true;
             }
 
@@ -120,13 +120,13 @@ namespace Azure.DataApiBuilder.Core.Services
             PathString requestPath = httpContext.Request.Path;
             if (_runtimeConfigurationProvider.TryGetLoadedConfig(out RuntimeConfig? config))
             {
-                string restPath = config.Runtime.Rest.Path;
-                string graphQLPath = config.Runtime.GraphQL.Path;
+                string restPath = config.RestPath;
+                string graphQLPath = config.GraphQLPath;
                 bool isRestRequest = requestPath.StartsWithSegments(restPath, comparisonType: StringComparison.OrdinalIgnoreCase);
                 bool isGraphQLRequest = requestPath.StartsWithSegments(graphQLPath, comparisonType: StringComparison.OrdinalIgnoreCase);
 
-                if ((isRestRequest && !config.Runtime.Rest.Enabled)
-                    || (isGraphQLRequest && !config.Runtime.GraphQL.Enabled))
+                if ((isRestRequest && !config.IsRestEnabled)
+                    || (isGraphQLRequest && !config.IsGraphQLEnabled))
                 {
                     httpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
                     return true;

--- a/src/Core/Services/RequestValidator.cs
+++ b/src/Core/Services/RequestValidator.cs
@@ -558,7 +558,7 @@ namespace Azure.DataApiBuilder.Core.Services
         {
             if (_runtimeConfigProvider.TryGetConfig(out RuntimeConfig? runtimeConfig))
             {
-                return runtimeConfig.Runtime.Rest.RequestBodyStrict;
+                return runtimeConfig.IsRequestBodyStrict;
             }
 
             return true;

--- a/src/Core/Services/RestService.cs
+++ b/src/Core/Services/RestService.cs
@@ -375,7 +375,7 @@ namespace Azure.DataApiBuilder.Core.Services
         /// does not match the configured REST path or the global REST endpoint is disabled.</exception>
         public string GetRouteAfterPathBase(string route)
         {
-            string configuredRestPathBase = _runtimeConfigProvider.GetConfig().Runtime.Rest.Path;
+            string configuredRestPathBase = _runtimeConfigProvider.GetConfig().RestPath;
 
             // Strip the leading '/' from the REST path provided in the runtime configuration
             // because the input argument 'route' has no starting '/'.
@@ -405,9 +405,9 @@ namespace Azure.DataApiBuilder.Core.Services
         public bool TryGetRestRouteFromConfig([NotNullWhen(true)] out string? configuredRestRoute)
         {
             if (_runtimeConfigProvider.TryGetConfig(out RuntimeConfig? config) &&
-                config.Runtime.Rest.Enabled)
+                config.IsRestEnabled)
             {
-                configuredRestRoute = config.Runtime.Rest.Path;
+                configuredRestRoute = config.RestPath;
                 return true;
             }
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -1543,7 +1543,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             HostOptions staticWebAppsHostOptions = new(null, AuthenticationOptions);
 
             RuntimeOptions runtimeOptions = configuration.Runtime;
-            RuntimeOptions baseRouteEnabledRuntimeOptions = new(runtimeOptions.Rest, runtimeOptions.GraphQL, staticWebAppsHostOptions, "/data-api");
+            RuntimeOptions baseRouteEnabledRuntimeOptions = new(runtimeOptions?.Rest, runtimeOptions?.GraphQL, staticWebAppsHostOptions, "/data-api");
             RuntimeConfig baseRouteEnabledConfig = configuration with { Runtime = baseRouteEnabledRuntimeOptions };
             File.WriteAllText(CUSTOM_CONFIG, baseRouteEnabledConfig.ToJson());
 
@@ -1951,14 +1951,18 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             string swaggerEndpoint = "/swagger";
             DataSource dataSource = new(DatabaseType.MSSQL, GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), Options: null);
 
-            RuntimeConfig configuration = InitMinimalRuntimeConfig(dataSource: dataSource, new(), new(Path: customRestPath));
+            RuntimeConfig configuration = InitMinimalRuntimeConfig(
+                dataSource: dataSource,
+                graphqlOptions: new(),
+                restOptions: new(Path: customRestPath));
+
             configuration = configuration
                 with
             {
                 Runtime = configuration.Runtime
                 with
                 {
-                    Host = configuration.Runtime.Host
+                    Host = configuration.Runtime?.Host
                 with
                     { Mode = hostModeType }
                 }
@@ -2353,8 +2357,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 RuntimeConfig overrides = new(
                     Schema: null,
                     DataSource: new DataSource(DatabaseType.MSSQL, connectionString, new()),
-                    Runtime: null,
-                    Entities: new(new Dictionary<string, Entity>()));
+                    Entities: new(new Dictionary<string, Entity>()),
+                    Runtime: null);
 
                 ConfigurationPostParametersV2 returnParams = new(
                     Configuration: serializedConfiguration,
@@ -2506,7 +2510,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             return new(
                 Schema: "IntegrationTestMinimalSchema",
                 DataSource: dataSource,
-                Runtime: new(restOptions, graphqlOptions, new(null, null)),
+                Runtime: new(restOptions, graphqlOptions,
+                    Host: new(Cors: null, Authentication: null, Mode: HostMode.Development)),
                 Entities: new(entityMap)
             );
         }

--- a/src/Service.Tests/Configuration/CorsUnitTests.cs
+++ b/src/Service.Tests/Configuration/CorsUnitTests.cs
@@ -51,7 +51,7 @@ public class CorsUnitTests
         FileSystemRuntimeConfigLoader loader = new(fileSystem);
         Assert.IsTrue(loader.TryLoadConfig(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, out RuntimeConfig runtimeConfig), "Load runtime config.");
 
-        Config.ObjectModel.HostOptions hostGlobalSettings = runtimeConfig.Runtime.Host;
+        Config.ObjectModel.HostOptions hostGlobalSettings = runtimeConfig.Runtime?.Host;
         return Verify(hostGlobalSettings);
     }
 

--- a/src/Service.Tests/GraphQLRequestExecutor.cs
+++ b/src/Service.Tests/GraphQLRequestExecutor.cs
@@ -31,7 +31,7 @@ namespace Azure.DataApiBuilder.Service.Tests
                     variables
                 };
 
-            string graphQLEndpoint = configProvider.GetConfig().Runtime.GraphQL.Path;
+            string graphQLEndpoint = configProvider.GetConfig().GraphQLPath;
 
             HttpRequestMessage request = new(HttpMethod.Post, graphQLEndpoint)
             {

--- a/src/Service.Tests/ModuleInitializer.cs
+++ b/src/Service.Tests/ModuleInitializer.cs
@@ -25,6 +25,26 @@ static class ModuleInitializer
         VerifierSettings.IgnoreMember<DataSource>(dataSource => dataSource.ConnectionString);
         // Ignore the JSON schema path as that's unimportant from a test standpoint.
         VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.Schema);
+        // Ignore the datasource files as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.DataSourceFiles);
+        // Ignore the SqlDataSourceUsed as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.SqlDataSourceUsed);
+        // Ignore the CosmosDataSourceUsed as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.CosmosDataSourceUsed);
+        // Ignore the IsRequestBodyStrict as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.IsRequestBodyStrict);
+        // Ignore the IsGraphQLEnabled as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.IsGraphQLEnabled);
+        // Ignore the IsRestEnabled as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.IsRestEnabled);
+        // Ignore the IsStaticWebAppsIdentityProvider as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.IsStaticWebAppsIdentityProvider);
+        // Ignore the RestPath as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.RestPath);
+        // Ignore the GraphQLPath as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.GraphQLPath);
+        // Ignore the AllowIntrospection as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.AllowIntrospection);
         // Ignore the message as that's not serialized in our config file anyway.
         VerifierSettings.IgnoreMember<DataSource>(dataSource => dataSource.DatabaseTypeNotSupportedMessage);
         // Customise the path where we store snapshots, so they are easier to locate in a PR review.

--- a/src/Service.Tests/OpenApiDocumentor/OpenApiTestBootstrap.cs
+++ b/src/Service.Tests/OpenApiDocumentor/OpenApiTestBootstrap.cs
@@ -42,7 +42,7 @@ namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
             {
                 Runtime = config.Runtime with
                 {
-                    Host = config.Runtime.Host with { Mode = HostMode.Production }
+                    Host = config.Runtime?.Host with { Mode = HostMode.Production }
                 },
                 Entities = runtimeEntities
             };

--- a/src/Service.Tests/SqlTests/SqlTestBase.cs
+++ b/src/Service.Tests/SqlTests/SqlTestBase.cs
@@ -83,7 +83,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests
             // Setting the rest.request-body-strict flag as per the test fixtures.
             if (!isRestBodyStrict)
             {
-                runtimeConfig = runtimeConfig with { Runtime = runtimeConfig.Runtime with { Rest = runtimeConfig.Runtime.Rest with { RequestBodyStrict = isRestBodyStrict } } };
+                runtimeConfig = runtimeConfig with { Runtime = runtimeConfig.Runtime with { Rest = runtimeConfig.Runtime?.Rest with { RequestBodyStrict = isRestBodyStrict } } };
             }
 
             // Add magazines entity to the config

--- a/src/Service.Tests/TestHelper.cs
+++ b/src/Service.Tests/TestHelper.cs
@@ -217,7 +217,7 @@ namespace Azure.DataApiBuilder.Service.Tests
                     Runtime = config.Runtime
                 with
                     {
-                        Host = config.Runtime.Host
+                        Host = config.Runtime?.Host
                 with
                         { Mode = hostModeType },
                         BaseRoute = runtimeBaseRoute

--- a/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
+++ b/src/Service.Tests/Unittests/RuntimeConfigLoaderJsonDeserializerTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Data;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Text;
 using System.Text.Json;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.Converters;
@@ -15,8 +17,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 {
     /// <summary>
-    /// Unit tests for the environment variable
-    /// parser for the runtime configuration. These
+    /// Unit tests for deserializing the runtime configuration. These
     /// tests verify that we parse the config correctly
     /// when replacing environment variables. Also verify
     /// we throw the right exception when environment
@@ -125,6 +126,51 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                                     ""entities"":{ }
                                 }";
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(actualJson, out RuntimeConfig _), "Should not fail to parse with comments");
+        }
+
+        /// <summary>
+        /// Test to validate that optional properties
+        /// are nullable, don't contain defaults on serialization
+        /// but have the effect of default values when deserialized.
+        /// It starts with a minimal config and incrementally
+        /// adds the optional subproperties. At each step, tests for valid deserialization.
+        [TestMethod]
+        public void TestNullableOptionalProps()
+        {
+            // Test with no runtime property
+            StringBuilder minJson = new(@"
+                                ""data-source"": {
+                                    ""database-type"": ""mssql"",
+                                    ""connection-string"": ""@env('test-connection-string')""
+                                    },
+                                ""entities"": { }");
+
+            TryParseAndAssertOnDefaults("{" + minJson + "}", out _);
+
+            // Test with an empty runtime property
+            minJson.Append(@", ""runtime"": ");
+            string emptyRuntime = minJson + "{ }}";
+            TryParseAndAssertOnDefaults("{" + emptyRuntime, out _);
+
+            // Test with empty sub properties of runtime
+            minJson.Append(@"{ ""rest"": { }, ""graphql"": { },
+                            ""base-route"" : """",");
+            StringBuilder minJsonWithHostSubProps = new(minJson + @"""telemetry"" : { }, ""host"" : ");
+            StringBuilder minJsonWithTelemetrySubProps = new(minJson + @"""host"" : { }, ""telemetry"" : ");
+
+            string emptyRuntimeSubProps = minJsonWithHostSubProps + "{ } } }";
+            TryParseAndAssertOnDefaults("{" + emptyRuntimeSubProps, out _);
+
+            // Test with empty host sub-properties
+            minJsonWithHostSubProps.Append(@"{ ""cors"": { }, ""authentication"": { } } }");
+            string emptyHostSubProps = minJsonWithHostSubProps + "}";
+            TryParseAndAssertOnDefaults("{" + emptyHostSubProps, out _);
+
+            // Test with empty telemetry sub-properties
+            minJsonWithTelemetrySubProps.Append(@"{ ""application-insights"": { } } }");
+
+            string emptyTelemetrySubProps = minJsonWithTelemetrySubProps + "}";
+            TryParseAndAssertOnDefaults("{" + emptyTelemetrySubProps, out _);
         }
 
         #endregion Positive Tests
@@ -299,6 +345,23 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
   }
 }
 ";
+        }
+
+        private static bool TryParseAndAssertOnDefaults(string json, out RuntimeConfig parsedConfig)
+        {
+            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(json, out parsedConfig));
+            Assert.AreEqual(RuntimeConfig.DEFAULT_CONFIG_SCHEMA_LINK, parsedConfig.Schema);
+            Assert.IsTrue(parsedConfig.IsRestEnabled);
+            Assert.AreEqual(RestRuntimeOptions.DEFAULT_PATH, parsedConfig.RestPath);
+            Assert.IsTrue(parsedConfig.IsGraphQLEnabled);
+            Assert.AreEqual(GraphQLRuntimeOptions.DEFAULT_PATH, parsedConfig.GraphQLPath);
+            Assert.IsTrue(parsedConfig.AllowIntrospection);
+            Assert.IsFalse(parsedConfig.IsDevelopmentMode());
+            Assert.IsTrue(parsedConfig.IsStaticWebAppsIdentityProvider);
+            Assert.IsTrue(parsedConfig.IsRequestBodyStrict);
+            Assert.IsTrue(parsedConfig.Runtime?.Telemetry?.ApplicationInsights is null
+                || !parsedConfig.Runtime.Telemetry.ApplicationInsights.Enabled);
+            return true;
         }
 
         #endregion Helper Functions

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -355,7 +355,7 @@ namespace Azure.DataApiBuilder.Service
             // SwaggerUI visualization of the OpenAPI description document is only available
             // in developer mode in alignment with the restriction placed on ChilliCream's BananaCakePop IDE.
             // Consequently, SwaggerUI is not presented in a StaticWebApps (late-bound config) environment.
-            if (runtimeConfig?.Runtime.Host.Mode is HostMode.Development || env.IsDevelopment())
+            if (IsUIEnabled(runtimeConfig, env))
             {
                 app.UseSwaggerUI(c =>
                 {
@@ -366,7 +366,7 @@ namespace Azure.DataApiBuilder.Service
             app.UseRouting();
 
             // Adding CORS Middleware
-            if (runtimeConfig is not null && runtimeConfig.Runtime.Host.Cors is not null)
+            if (runtimeConfig is not null && runtimeConfig.Runtime?.Host?.Cors is not null)
             {
                 app.UseCors(CORSPolicyBuilder =>
                 {
@@ -426,7 +426,7 @@ namespace Azure.DataApiBuilder.Service
                     Tool = {
                         // Determines if accessing the endpoint from a browser
                         // will load the GraphQL Banana Cake Pop IDE.
-                        Enable = runtimeConfig?.Runtime.Host.Mode == HostMode.Development || env.IsDevelopment()
+                        Enable = IsUIEnabled(runtimeConfig, env)
                     }
                 });
 
@@ -449,7 +449,7 @@ namespace Azure.DataApiBuilder.Service
         /// </summary>
         public static LogLevel GetLogLevelBasedOnMode(RuntimeConfig runtimeConfig)
         {
-            if (runtimeConfig.Runtime.Host.Mode == HostMode.Development)
+            if (runtimeConfig.IsDevelopmentMode())
             {
                 return LogLevel.Debug;
             }
@@ -493,7 +493,8 @@ namespace Azure.DataApiBuilder.Service
         /// <param name="runtimeConfigurationProvider">The provider used to load runtime configuration.</param>
         private void ConfigureAuthentication(IServiceCollection services, RuntimeConfigProvider runtimeConfigurationProvider)
         {
-            if (runtimeConfigurationProvider.TryGetConfig(out RuntimeConfig? runtimeConfig) && runtimeConfig.Runtime.Host.Authentication is not null)
+            if (runtimeConfigurationProvider.TryGetConfig(out RuntimeConfig? runtimeConfig) &&
+                runtimeConfig.Runtime?.Host?.Authentication is not null)
             {
                 AuthenticationOptions authOptions = runtimeConfig.Runtime.Host.Authentication;
                 HostMode mode = runtimeConfig.Runtime.Host.Mode;
@@ -567,7 +568,7 @@ namespace Azure.DataApiBuilder.Service
         /// <seealso cref="https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core#enable-application-insights-telemetry-collection"/>
         private void ConfigureApplicationInsightsTelemetry(IApplicationBuilder app, RuntimeConfig runtimeConfig)
         {
-            if (runtimeConfig.Runtime.Telemetry is not null
+            if (runtimeConfig?.Runtime?.Telemetry is not null
                 && runtimeConfig.Runtime.Telemetry.ApplicationInsights is not null)
             {
                 AppInsightsOptions = runtimeConfig.Runtime.Telemetry.ApplicationInsights;
@@ -637,7 +638,7 @@ namespace Azure.DataApiBuilder.Service
 
                 runtimeConfigValidator.ValidateConfig();
 
-                if (runtimeConfig.Runtime.Host.Mode == HostMode.Development)
+                if (runtimeConfig.IsDevelopmentMode())
                 {
                     // Running only in developer mode to ensure fast and smooth startup in production.
                     RuntimeConfigValidator.ValidatePermissionsInConfig(runtimeConfig);
@@ -668,7 +669,7 @@ namespace Azure.DataApiBuilder.Service
                     _logger.LogError("Endpoint service initialization failed.");
                 }
 
-                if (runtimeConfig.Runtime.Host.Mode == HostMode.Development)
+                if (runtimeConfig.IsDevelopmentMode())
                 {
                     // Running only in developer mode to ensure fast and smooth startup in production.
                     runtimeConfigValidator.ValidateRelationshipsInConfig(runtimeConfig, sqlMetadataProvider!);
@@ -729,6 +730,14 @@ namespace Azure.DataApiBuilder.Service
                     .SetIsOriginAllowedToAllowWildcardSubdomains()
                     .Build();
             }
+        }
+
+        /// <summary>
+        /// Indicates whether to provide UI visualization of REST(via Swagger) or GraphQL (via Banana CakePop).
+        /// </summary>
+        private static bool IsUIEnabled(RuntimeConfig? runtimeConfig, IWebHostEnvironment env)
+        {
+            return (runtimeConfig is not null && runtimeConfig.IsDevelopmentMode()) || env.IsDevelopment();
         }
     }
 }


### PR DESCRIPTION
Cherry pick #1823 to 0.9 branch.

## Why make this change?

- As per the JSON config schema, not all properties in the config file are mandatory.
- With #1402, in versions 0.8.49-0.8.52 those properties that are not explicitly set, were initialized with defaults before writing to the file system.
- However, config files generated using version 0.7.6 or lesser, may not have these properties initialized to their defaults when writing to the file system. Using config files generated with <= 0.7.6, to start engine with 0.8.49 would therefore lead to null reference exceptions when the optional properties are dereferenced.
- With PR #1684 the optional properties were initialized with their default values to avoid the null reference, any config file that is created or modified using the CLI results in a fully expanded file. This is not a problem when a single config is used but leads to undesired behavior when using the merge configuration file feature. A fully expanded higher precedence config file when merged with a base config file will override the values set for the optional properties in the base file with their default values if those properties were not explicitly defined in the higher precedence config file to begin with. 
In order to retain the base config file values for the optional properties, the higher precedence file would have to define every single optional value exactly the same as in the base file if they desire those to not be overridden. That defeats the purpose of providing the higher precedence file which should ideally only have those properties that need to be overriden. For more details with examples, please refer to #1737.

- This PR fixes this problem by allowing optional properties to be null and ensures there are no null reference exceptions as well  when starting engine with configs that don't have optional properties. 

## What is this change?
- Modify object model constructors to accept nullable arguments for optional properties - represented as fields in the record types. The scalar optional properties have not been made nullable yet, will have a follow up PR for those.
- All references to optional properties check for nulls
- During merge of config files, null + non-null values will pick up non-null values. After the merge, if the value is still null, they are considered as default values. To easily get default values, added some properties to `RuntimeConfig`.
- Default value of Host.Mode is `Production`. Keep it that way. Default of GraphQL.AllowIntrospection is true currently - will have another PR to determine it based on host mode.

## How was this tested?
- Removed optional properties from config and ensured engine could be started without them.
- [X] Unit Tests for deserialization and serialization of nullable optional properties see `RuntimeConfigLoaderJsonDeserializerTests`
- [X] In the merge configuration tests, in `TestHelper`, modify base config to contain a non-default value, env based config to not specify that value and confirm the merged config file has the base-config value. 

## Sample Request(s)

- Before fix, remove `runtime` section from config, run dab start with 0.8.49 leads to NullReferenceException.
- After the fix, starting engine is successful even when `runtime` section is absent in the config.

// IN THE BASE config file
MISSING = use default
{ empty } = use default

// IN THE OVERRIDDEN config file 
MISSING = use base
{ empty } = use base

Examples:
// all subproperties are missing
base: "user": { "first": "jerry", "last": "nixon" }
override: "user": { empty } 
merged: "user": { "first": "jerry", "last": "nixon" }

// some sub properties are missing 
base: "user": { "first": "jerry", "last": "nixon" }
override: "user": { "first": "jerry" } 
merged: "user": { "first": "jerry", "last": "nixon" }

// parent object property is missing altogether
base: "user": { "first": "jerry", "last": "nixon" }
override: "user": MISSING (not specified in override)
merged: "user": { "first": "jerry", "last": "nixon" }

## TO DO for 0.10-rc
- A followup PR to make scalar optional properties nullable too.
- A followup PR that makes specifying an explicit NULL imply Default values