### PR TITLE
Access Token needs to be set according to the datasource name.

### DIFF
--- a/src/Core/Resolvers/IQueryExecutor.cs
+++ b/src/Core/Resolvers/IQueryExecutor.cs
@@ -101,7 +101,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <summary>
         /// Modified the properties of the supplied connection to support managed identity access.
         /// </summary>
-        public Task SetManagedIdentityAccessTokenIfAnyAsync(DbConnection conn, string dataSourceName = "");
+        public Task SetManagedIdentityAccessTokenIfAnyAsync(DbConnection conn, string dataSourceName);
 
         /// <summary>
         /// Method to generate the query to send user data to the underlying database which might be used
@@ -111,7 +111,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="parameters">Dictionary of parameters/value required to execute the query.</param>
         /// <param name="dataSourceName"> Db for which to generate query.</param>
         /// <returns>empty string / query to set session parameters for the connection.</returns>
-        public string GetSessionParamsQuery(HttpContext? httpContext, IDictionary<string, DbConnectionParam> parameters, string dataSourceName = "");
+        public string GetSessionParamsQuery(HttpContext? httpContext, IDictionary<string, DbConnectionParam> parameters, string dataSourceName);
 
         /// <summary>
         /// Helper method to populate DbType for parameter. Currently DbTypes for parameters are only populated for MsSql.

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -195,7 +195,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="dataSourceName">Name of datasource for which to set access token. Default dbName taken from config if null</param>
         /// <returns>empty string / query to set session parameters for the connection.</returns>
         /// <seealso cref="https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-set-session-context-transact-sql?view=sql-server-ver16"/>
-        public override string GetSessionParamsQuery(HttpContext? httpContext, IDictionary<string, DbConnectionParam> parameters, string dataSourceName = "")
+        public override string GetSessionParamsQuery(HttpContext? httpContext, IDictionary<string, DbConnectionParam> parameters, string dataSourceName)
         {
             if (string.IsNullOrEmpty(dataSourceName))
             {

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -103,7 +103,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         /// <param name="conn">The supplied connection to modify for managed identity access.</param>
         /// <param name="dataSourceName">Name of datasource for which to set access token. Default dbName taken from config if null</param>
-        public override async Task SetManagedIdentityAccessTokenIfAnyAsync(DbConnection conn, string dataSourceName = "")
+        public override async Task SetManagedIdentityAccessTokenIfAnyAsync(DbConnection conn, string dataSourceName)
         {
             // using default datasource name for first db - maintaining backward compatibility for single db scenario.
             if (string.IsNullOrEmpty(dataSourceName))

--- a/src/Core/Resolvers/MySqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MySqlQueryExecutor.cs
@@ -92,7 +92,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         /// <param name="conn">The supplied connection to modify for managed identity access.</param>
         /// <param name="dataSourceName">Name of datasource for which to set access token. Default dbName taken from config if null</param>
-        public override async Task SetManagedIdentityAccessTokenIfAnyAsync(DbConnection conn, string dataSourceName = "")
+        public override async Task SetManagedIdentityAccessTokenIfAnyAsync(DbConnection conn, string dataSourceName)
         {
             // using default datasource name for first db - maintaining backward compatibility for single db scenario.
             if (string.IsNullOrEmpty(dataSourceName))

--- a/src/Core/Resolvers/PostgreSqlExecutor.cs
+++ b/src/Core/Resolvers/PostgreSqlExecutor.cs
@@ -88,7 +88,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         /// <param name="conn">The supplied connection to modify for managed identity access.</param>
         /// <param name="dataSourceName">Name of datasource for which to set access token. Default dbName taken from config if null</param>
-        public override async Task SetManagedIdentityAccessTokenIfAnyAsync(DbConnection conn, string dataSourceName = "")
+        public override async Task SetManagedIdentityAccessTokenIfAnyAsync(DbConnection conn, string dataSourceName)
         {
             // using default datasource name for first db - maintaining backward compatibility for single db scenario.
             if (string.IsNullOrEmpty(dataSourceName))

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -99,7 +99,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                         QueryExecutorLogger.LogDebug("{correlationId} Executing query: {queryText}", correlationId, sqltext);
                     }
 
-                    TResult? result = await ExecuteQueryAgainstDbAsync(conn, sqltext, parameters, dataReaderHandler, httpContext, args);
+                    TResult? result = await ExecuteQueryAgainstDbAsync(conn, sqltext, parameters, dataReaderHandler, httpContext, dataSourceName, args);
 
                     if (retryAttempt > 1)
                     {
@@ -149,6 +149,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             IDictionary<string, DbConnectionParam> parameters,
             Func<DbDataReader, List<string>?, Task<TResult>>? dataReaderHandler,
             HttpContext? httpContext,
+            string dataSourceName,
             List<string>? args = null)
         {
             await conn.OpenAsync();
@@ -157,7 +158,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
             // Add query to send user data from DAB to the underlying database to enable additional security the user might have configured
             // at the database level.
-            string sessionParamsQuery = GetSessionParamsQuery(httpContext, parameters);
+            string sessionParamsQuery = GetSessionParamsQuery(httpContext, parameters, dataSourceName);
 
             cmd.CommandText = sessionParamsQuery + sqltext;
             if (parameters is not null)

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -85,7 +85,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 ConnectionString = ConnectionStringBuilders[dataSourceName].ConnectionString,
             };
 
-            await SetManagedIdentityAccessTokenIfAnyAsync(conn);
+            await SetManagedIdentityAccessTokenIfAnyAsync(conn, dataSourceName);
 
             return await _retryPolicy.ExecuteAsync(async () =>
             {

--- a/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
+++ b/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
@@ -179,7 +179,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
 
             RuntimeConfig mockConfig = new(
                Schema: "",
-               DataSource: new(DatabaseType.MSSQL, defaultSourceConnectionString, new()),
+               DataSource: new(DatabaseType.MSSQL, defaultSourceConnectionString, Options: new()),
                Runtime: new(
                    Rest: new(),
                    GraphQL: new(),

--- a/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
+++ b/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
@@ -16,11 +16,15 @@ using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Directives;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.GraphQLTypes;
 using Azure.DataApiBuilder.Service.Tests.GraphQLBuilder.Helpers;
+using Azure.Identity;
 using HotChocolate;
 using HotChocolate.Execution;
 using HotChocolate.Execution.Processing;
 using HotChocolate.Resolvers;
 using HotChocolate.Types;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -151,6 +155,63 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
             // validate that the data returend for the queries we did matches the moq data we set up for the respective query engines.
             Assert.AreEqual("db1", queryMap1[0].Value, $"Data returned for {queryName1} is incorrect for multi-source query");
             Assert.AreEqual("db2", queryMap2[0].Value, $"Data returned for {queryName2} is incorrect for multi-source query");
+        }
+
+        /// <summary>
+        /// Test to ensure that the correct access token is being set when multiple data sources are used.
+        /// </summary>
+        [TestMethod]
+        public async Task TestMultiSourceTokenSet()
+        {
+            string defaultSourceConnectionString = "Server =<>;Database=<>;";
+            string childConnectionString = "Server =child;Database=child;";
+
+            string dataSourceName1 = "db1";
+            string db1AccessToken = "AccessToken1";
+            string dataSourceName2 = "db2";
+            string db2AccessToken = "AccessToken2";
+
+            Dictionary<string, DataSource> dataSourceNameToDataSource = new()
+            {
+                { dataSourceName1, new(DatabaseType.MSSQL, defaultSourceConnectionString, new())},
+                { dataSourceName2, new(DatabaseType.MSSQL, childConnectionString, new()) }
+            };
+
+            RuntimeConfig mockConfig = new(
+               Schema: "",
+               DataSource: new(DatabaseType.MSSQL, defaultSourceConnectionString, new()),
+               Runtime: new(
+                   Rest: new(),
+                   GraphQL: new(),
+                   Host: new(null, null)
+               ),
+               DefaultDataSourceName: dataSourceName1,
+               DataSourceNameToDataSource: dataSourceNameToDataSource,
+               EntityNameToDataSourceName: new(),
+               Entities: new(new Dictionary<string, Entity>())
+               );
+
+            Mock<RuntimeConfigLoader> mockLoader = new(null);
+            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig, It.IsAny<bool>())).Returns(true);
+
+            RuntimeConfigProvider provider = new(mockLoader.Object);
+            provider.TryGetConfig(out RuntimeConfig _);
+            provider.TrySetAccesstoken(db1AccessToken, dataSourceName1);
+            provider.TrySetAccesstoken(db2AccessToken, dataSourceName2);
+
+            Mock<DbExceptionParser> dbExceptionParser = new(provider);
+            Mock<ILogger<MsSqlQueryExecutor>> queryExecutorLogger = new();
+            Mock<IHttpContextAccessor> httpContextAccessor = new();
+            MsSqlQueryExecutor msSqlQueryExecutor = new(provider, dbExceptionParser.Object, queryExecutorLogger.Object, httpContextAccessor.Object);
+
+            using SqlConnection conn = new(defaultSourceConnectionString);
+            await msSqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn, dataSourceName1);
+            Assert.AreEqual(expected: db1AccessToken, actual: conn.AccessToken, "Data source connection failed to be set with correct access token");
+
+            using SqlConnection conn2 = new(childConnectionString);
+            await msSqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn2, dataSourceName2);
+            Assert.AreEqual(expected: db2AccessToken, actual: conn2.AccessToken, "Data source connection failed to be set with correct access token");
+
         }
     }
 }

--- a/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
+++ b/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
@@ -212,6 +212,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
             await msSqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn2, dataSourceName2);
             Assert.AreEqual(expected: db2AccessToken, actual: conn2.AccessToken, "Data source connection failed to be set with correct access token");
 
+            await msSqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn, string.Empty);
+            Assert.AreEqual(expected: db1AccessToken, actual: conn.AccessToken, "Data source connection failed to be set with default access token when source name provided is empty.");
         }
     }
 }

--- a/src/Service.Tests/Unittests/MySqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/MySqlQueryExecutorUnitTests.cs
@@ -86,7 +86,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             }
 
             using MySqlConnection conn = new(connectionString);
-            await mySqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn);
+            await mySqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn, string.Empty);
             MySqlConnectionStringBuilder my = new(conn.ConnectionString);
 
             if (expectManagedIdentityAccessToken)

--- a/src/Service.Tests/Unittests/PostgreSqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/PostgreSqlQueryExecutorUnitTests.cs
@@ -94,7 +94,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             }
 
             using NpgsqlConnection conn = new(connectionString);
-            await postgreSqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn);
+            await postgreSqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn, string.Empty);
             NpgsqlConnectionStringBuilder connStringBuilder = new(conn.ConnectionString);
 
             if (expectManagedIdentityAccessToken)

--- a/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
@@ -113,7 +113,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             }
 
             using SqlConnection conn = new(connectionString);
-            await msSqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn);
+            await msSqlQueryExecutor.SetManagedIdentityAccessTokenIfAnyAsync(conn, string.Empty);
 
             if (expectManagedIdentityAccessToken)
             {
@@ -175,6 +175,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 It.IsAny<IDictionary<string, DbConnectionParam>>(),
                 It.IsAny<Func<DbDataReader, List<string>, Task<object>>>(),
                 It.IsAny<HttpContext>(),
+                provider.GetConfig().GetDefaultDataSourceName(),
                 It.IsAny<List<string>>()))
             .Throws(SqlTestHelper.CreateSqlException(ERRORCODE_SEMAPHORE_TIMEOUT));
 
@@ -230,6 +231,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 It.IsAny<IDictionary<string, DbConnectionParam>>(),
                 It.IsAny<Func<DbDataReader, List<string>, Task<object>>>(),
                 It.IsAny<HttpContext>(),
+                provider.GetConfig().GetDefaultDataSourceName(),
                 It.IsAny<List<string>>()))
             .Throws(SqlTestHelper.CreateSqlException(ERRORCODE_SEMAPHORE_TIMEOUT))
             .Throws(SqlTestHelper.CreateSqlException(ERRORCODE_SEMAPHORE_TIMEOUT))


### PR DESCRIPTION
Currently we are just using the default db's access token during query resolution. However, we should be using the access token of the datasource name that is being resolved in the query. 

For Sessions params as well, we should use the one for the specific datasource.