### PR TITLE
Upgrade HotChocolate

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -325,6 +325,11 @@
                       "required": [
                         "methods"
                       ]
+                    },
+                    {
+                      "required": [
+                        "enabled"
+                      ]
                     }
                   ]
                 }
@@ -363,6 +368,11 @@
                     {
                       "required": [
                         "operation"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "enabled"
                       ]
                     }
                   ]

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,10 +7,10 @@
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.msbuild" Version="3.2.0" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="HotChocolate" Version="12.18.0" />
-    <PackageVersion Include="HotChocolate.AspNetCore" Version="12.18.0" />
-    <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="12.18.0" />
-    <PackageVersion Include="HotChocolate.Types.NodaTime" Version="12.18.0" />
+    <PackageVersion Include="HotChocolate" Version="12.22.0" />
+    <PackageVersion Include="HotChocolate.AspNetCore" Version="12.22.0" />
+    <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="12.22.0" />
+    <PackageVersion Include="HotChocolate.Types.NodaTime" Version="12.22.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="DotNetEnv" Version="2.5.0" />

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -1062,15 +1062,14 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         [TestCategory(TestCategory.MSSQL)]
         [DataRow("/graphql/", HostMode.Development, HttpStatusCode.OK, "Banana Cake Pop",
             DisplayName = "GraphQL endpoint with no query in development mode.")]
-        [DataRow("/graphql", HostMode.Production, HttpStatusCode.BadRequest,
-            "Either the parameter query or the parameter id has to be set",
+        [DataRow("/graphql", HostMode.Production, HttpStatusCode.NotFound,
             DisplayName = "GraphQL endpoint with no query in production mode.")]
         [DataRow("/graphql/ui", HostMode.Development, HttpStatusCode.NotFound,
             DisplayName = "Default BananaCakePop in development mode.")]
         [DataRow("/graphql/ui", HostMode.Production, HttpStatusCode.NotFound,
             DisplayName = "Default BananaCakePop in production mode.")]
         [DataRow("/graphql?query={book_by_pk(id: 1){title}}",
-            HostMode.Development, HttpStatusCode.Moved,
+            HostMode.Development, HttpStatusCode.OK,
             DisplayName = "GraphQL endpoint with query in development mode.")]
         [DataRow("/graphql?query={book_by_pk(id: 1){title}}",
             HostMode.Production, HttpStatusCode.OK, "data",

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/GraphQLMutationTestBase.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/GraphQLMutationTestBase.cs
@@ -1188,7 +1188,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
         /// Test adding a website placement to a book which already has a website
         /// placement
         /// </summary>
-        public async Task TestViolatingOneToOneRelashionShip(string errorMessage)
+        public async Task TestViolatingOneToOneRelationship(string errorMessage)
         {
             string graphQLMutationName = "createBookWebsitePlacement";
             string graphQLMutation = @"

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/MsSqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/MsSqlGraphQLMutationTests.cs
@@ -841,10 +841,10 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
         /// placement
         /// </summary>
         [TestMethod]
-        public async Task TestViolatingOneToOneRelashionShip()
+        public async Task TestViolatingOneToOneRelationship()
         {
             string expectedErrorMessageSubString = "Violation of UNIQUE KEY constraint";
-            await TestViolatingOneToOneRelashionShip(expectedErrorMessageSubString);
+            await TestViolatingOneToOneRelationship(expectedErrorMessageSubString);
         }
         #endregion
     }

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
@@ -12,8 +12,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
     public class MySqlGraphQLMutationTests : GraphQLMutationTestBase
     {
         private static string _invalidForeignKeyError =
-            "Cannot add or update a child row: a foreign key constraint fails " +
-            "(`datagateway`.`books`";
+            "Cannot add or update a child row: a foreign key constraint fails";
 
         #region Test Fixture Setup
 

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
@@ -664,11 +664,11 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
         /// placement
         /// </summary>
         [TestMethod]
-        public async Task TestViolatingOneToOneRelashionShip()
+        public async Task TestViolatingOneToOneRelationship()
         {
-            string errorMessage = "Duplicate entry \\u00271\\u0027 for key " +
-                                  "\\u0027book_website_placements.book_id\\u0027\"";
-            await TestViolatingOneToOneRelashionShip(errorMessage);
+            string errorMessage = "Duplicate entry '1' for key " +
+                                  "'book_website_placements.book_id'";
+            await TestViolatingOneToOneRelationship(errorMessage);
         }
 
         [TestMethod]

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
@@ -13,7 +13,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
     {
         private static string _invalidForeignKeyError =
             "Cannot add or update a child row: a foreign key constraint fails " +
-            "(\\u0060datagateway\\u0060.\\u0060books\\u0060";
+            "(`datagateway`.`books`";
 
         #region Test Fixture Setup
 

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/PostgreSqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/PostgreSqlGraphQLMutationTests.cs
@@ -12,8 +12,8 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
     public class PostgreSqlGraphQLMutationTests : GraphQLMutationTestBase
     {
         private static string _invalidForeignKeyError =
-            "23503: insert or update on table \"books\" " +
-            "violates foreign key constraint \"book_publisher_fk\"";
+            "23503: insert or update on table \\\"books\\\" " +
+            "violates foreign key constraint \\\"book_publisher_fk\\\"";
 
         #region Test Fixture Setup
         /// <summary>
@@ -650,11 +650,11 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
         /// placement
         /// </summary>
         [TestMethod]
-        public async Task TestViolatingOneToOneRelashionShip()
+        public async Task TestViolatingOneToOneRelationship()
         {
             string errorMessage = "23505: duplicate key value violates unique constraint " +
-                                  "\"book_website_placements_book_id_key\"";
-            await TestViolatingOneToOneRelashionShip(errorMessage);
+                                  "\\\"book_website_placements_book_id_key\\\"";
+            await TestViolatingOneToOneRelationship(errorMessage);
         }
 
         [TestMethod]

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/PostgreSqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/PostgreSqlGraphQLMutationTests.cs
@@ -12,8 +12,8 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
     public class PostgreSqlGraphQLMutationTests : GraphQLMutationTestBase
     {
         private static string _invalidForeignKeyError =
-            "23503: insert or update on table \\u0022books\\u0022 " +
-            "violates foreign key constraint \\u0022book_publisher_fk\\u0022";
+            "23503: insert or update on table \"books\" " +
+            "violates foreign key constraint \"book_publisher_fk\"";
 
         #region Test Fixture Setup
         /// <summary>
@@ -653,7 +653,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
         public async Task TestViolatingOneToOneRelashionShip()
         {
             string errorMessage = "23505: duplicate key value violates unique constraint " +
-                                  "\\u0022book_website_placements_book_id_key\\u0022";
+                                  "\"book_website_placements_book_id_key\"";
             await TestViolatingOneToOneRelashionShip(errorMessage);
         }
 


### PR DESCRIPTION
## Why make this change?

- Pick up latest patch version for HotChocolate 12 for bug fixes.

## What is this change?

- Upgrade the patch version number in the global properties for all HotChocolate.* packages

## How was this tested?
- Verified BCP is launched for local dev and can query GraphQL.
- Existing integration tests -fix some to accommodate how upgraded hotchocolate behaves
