### PR TITLE
Addition of new database type DWSQL.

### DIFF
--- a/src/Config/ObjectModel/DatabaseType.cs
+++ b/src/Config/ObjectModel/DatabaseType.cs
@@ -9,5 +9,6 @@ public enum DatabaseType
     MySQL,
     MSSQL,
     PostgreSQL,
-    CosmosDB_PostgreSQL
+    CosmosDB_PostgreSQL,
+    DWSQL
 }


### PR DESCRIPTION
As part of ongoing effort to add support for Data warehouse to data-api-builder, this small pr adds the database type DWSQL to database type enum. 
