### PR TITLE
Add telemetry client only if it is enabled

### DIFF
--- a/src/Service.Tests/Configuration/TelemetryTests.cs
+++ b/src/Service.Tests/Configuration/TelemetryTests.cs
@@ -8,12 +8,16 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Configurations;
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Azure.DataApiBuilder.Service.Tests.Configuration.ConfigurationTests;
+using static HotChocolate.ErrorCodes;
 
 namespace Azure.DataApiBuilder.Service.Tests.Configuration;
 
@@ -89,6 +93,7 @@ public class TelemetryTests
         using (TestServer server = new(Program.CreateWebHostBuilder(args)))
         {
             await TestRestAndGraphQLRequestsOnServerInNonHostedScenario(server);
+            Assert.IsTrue(server.Services.GetService<TelemetryClient>() is not null);
         }
 
         List<ITelemetry> telemetryItems = ((CustomTelemetryChannel)telemetryChannel).GetTelemetryItems();
@@ -157,6 +162,9 @@ public class TelemetryTests
         using (TestServer server = new(Program.CreateWebHostBuilder(args)))
         {
             await TestRestAndGraphQLRequestsOnServerInNonHostedScenario(server);
+            // Telemetry client should be null if telemetry is disabled
+            // Using an EXOR here to assert this.
+            Assert.IsTrue(server.Services.GetService<TelemetryClient>() is null ^ isTelemetryEnabled);
         }
 
         List<ITelemetry> telemetryItems = ((CustomTelemetryChannel)telemetryChannel).GetTelemetryItems();

--- a/src/Service.Tests/Configuration/TelemetryTests.cs
+++ b/src/Service.Tests/Configuration/TelemetryTests.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.ObjectModel;
-using Azure.DataApiBuilder.Core.Configurations;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
@@ -17,7 +16,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static Azure.DataApiBuilder.Service.Tests.Configuration.ConfigurationTests;
-using static HotChocolate.ErrorCodes;
 
 namespace Azure.DataApiBuilder.Service.Tests.Configuration;
 

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -85,10 +85,15 @@ namespace Azure.DataApiBuilder.Service
             services.AddSingleton(configProvider);
             services.AddSingleton(configLoader);
 
-            // Add ApplicationTelemetry service and register custom ITelemetryInitializer implementation with the dependency injection
-            services.AddApplicationInsightsTelemetry();
-
-            services.AddSingleton<ITelemetryInitializer, AppInsightsTelemetryInitializer>();
+            if (configProvider.TryGetConfig(out RuntimeConfig? runtimeConfig)
+                && runtimeConfig.Runtime?.Telemetry?.ApplicationInsights is not null
+                && runtimeConfig.Runtime.Telemetry.ApplicationInsights.Enabled)
+            {
+                // Add ApplicationTelemetry service and register
+                // custom ITelemetryInitializer implementation with the dependency injection
+                services.AddApplicationInsightsTelemetry();
+                services.AddSingleton<ITelemetryInitializer, AppInsightsTelemetryInitializer>();
+            }
 
             services.AddSingleton(implementationFactory: (serviceProvider) =>
             {

--- a/src/Service/Telemetry/AppInsightsTelemetryInitializer.cs
+++ b/src/Service/Telemetry/AppInsightsTelemetryInitializer.cs
@@ -25,7 +25,7 @@ public class AppInsightsTelemetryInitializer : ITelemetryInitializer
 
         foreach (KeyValuePair<string, string> property in GlobalProperties)
         {
-            telemetry.Context.GlobalProperties.TryAdd(property.Key, property.Value);
+            telemetry.Context.GlobalProperties.Add(property.Key, property.Value);
         }
     }
 }

--- a/src/Service/Telemetry/AppInsightsTelemetryInitializer.cs
+++ b/src/Service/Telemetry/AppInsightsTelemetryInitializer.cs
@@ -25,7 +25,7 @@ public class AppInsightsTelemetryInitializer : ITelemetryInitializer
 
         foreach (KeyValuePair<string, string> property in GlobalProperties)
         {
-            telemetry.Context.GlobalProperties.Add(property.Key, property.Value);
+            telemetry.Context.GlobalProperties.TryAdd(property.Key, property.Value);
         }
     }
 }


### PR DESCRIPTION
## Why make this change?

- Saw this exception while running locally via VS:

![image](https://github.com/Azure/data-api-builder/assets/3513779/3d2b827d-de56-4cbb-9982-fcf8e9f339ce)

- it is triggered asynchronously when the grapqhql schema is being generated in the background
- Also, noticed telemetry client is being added irrespective of it is enabled or not.

## What is this change?
- Add AppInsights Telemetry only when it is enabled.
- Use `TryAdd` instead of simply doing an `Add` to the dictionary of global properties in the Initialize function that is used to initialize any telemetry object.
- Depending on if the telemetry object had already been initialized with the 2 global properties we intend to add, they may or may not be already present. Examples of such telemetry objects include `MetricsTelemetry`, `DependencyTelemetry` etc. 

## How was this tested?

- Reran the engine to verify the exception was gone upon starting.
- Added asserts in TelemetryTests to verify the client is created only when telemetry is enabled.
