### PR TITLE
Attempt to create OpenAPI document only if rest is enabled

### DIFF
--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -618,7 +618,7 @@ namespace Azure.DataApiBuilder.Service
                     }
                     catch (DataApiBuilderException dabException)
                     {
-                        _logger.LogError(exception: dabException, message: "OpenAPI Documentor initialization failed.");
+                        _logger.LogWarning(exception: dabException, message: "OpenAPI Documentor initialization failed.");
                     }
                 }
 

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -605,18 +605,21 @@ namespace Azure.DataApiBuilder.Service
 
                 runtimeConfigValidator.ValidateStoredProceduresInConfig(runtimeConfig, sqlMetadataProviderFactory!);
 
-                // Attempt to create OpenAPI document.
-                // Errors must not crash nor halt the intialization of the engine
-                // because OpenAPI document creation is not required for the engine to operate.
-                // Errors will be logged.
-                try
+                if (runtimeConfig.IsRestEnabled)
                 {
-                    IOpenApiDocumentor openApiDocumentor = app.ApplicationServices.GetRequiredService<IOpenApiDocumentor>();
-                    openApiDocumentor.CreateDocument();
-                }
-                catch (DataApiBuilderException dabException)
-                {
-                    _logger.LogError(exception: dabException, message: "OpenAPI Documentor initialization failed.");
+                    // Attempt to create OpenAPI document.
+                    // Errors must not crash nor halt the intialization of the engine
+                    // because OpenAPI document creation is not required for the engine to operate.
+                    // Errors will be logged.
+                    try
+                    {
+                        IOpenApiDocumentor openApiDocumentor = app.ApplicationServices.GetRequiredService<IOpenApiDocumentor>();
+                        openApiDocumentor.CreateDocument();
+                    }
+                    catch (DataApiBuilderException dabException)
+                    {
+                        _logger.LogError(exception: dabException, message: "OpenAPI Documentor initialization failed.");
+                    }
                 }
 
                 _logger.LogInformation("Successfully completed runtime initialization.");


### PR DESCRIPTION
## Why make this change?

- OpenAPI document is needed only when rest is enabled. For cosmosdb_nosql it is never enabled. So, any attempts to create the document will always fail. This shows up as a failure in the logs and has the potential to misguide the actual error that could cause a failure to start the engine. 
- E.g. see below logs from a
[question on stackoverflow](https://stackoverflow.com/questions/77432995/dataapibuilderexception-while-trying-to-run-swa-start)
> [dataApi] fail: Azure.DataApiBuilder.Service.Startup[0]
> [dataApi]       OpenAPI Documentor initialization failed.
> [dataApi]       Azure.DataApiBuilder.Service.Exceptions.DataApiBuilderException: OpenAPI description document can't be created when the REST endpoint is disabled globally.
> [dataApi]          at Azure.DataApiBuilder.Core.Services.OpenApiDocumentor.CreateDocument() in /_/src/Core/Services/OpenAPI/OpenApiDocumentor.cs:line 108
> [dataApi]          at Azure.DataApiBuilder.Service.Startup.PerformOnConfigChangeAsync(IApplicationBuilder app) in /_/src/Service/Startup.cs:line 687
> [dataApi] Unable to launch the runtime due to an error.
> [dataApi] Error: Failed to start the engine.
> [dataApi] cd "C:\Users\alexa\source\repos\az-lead\swa-db-connections" && "C:\Users\alexa\.swa\dataApiBuilder\0.9.6-rc\Microsoft.DataApiBuilder.exe" start -c staticwebapp.database.config.json --no-https-redirect exited with code 0

- On the surface the above error seems to be due to an OpenApi document creation failure, but it shouldn't be the case. We still need more customer logs to understand the issue. This PR is to fix the misguided logs.

## What is this change?

- Gaurd OpenAPI document creation call with a check for REST is enabled or not. 
- Change the log error to log warning - to avoid misguiding.

## How was this tested?

-  Started the engine locally to verify after the change the failure is gone for CosmosDb_NoSql.

## Sample Request(s)

Before when the engine has successfully started for CosmosDB_NoSql:
![image](https://github.com/Azure/data-api-builder/assets/3513779/9f0f7a59-3c07-4f9c-b002-900fcf6e8bc5)

After:
![image](https://github.com/Azure/data-api-builder/assets/3513779/b54dafca-f7aa-4bd4-a4f2-0a88321d0959)
