### PR TITLE
Configured CosmosDB Local Emulator for running integration tests on the Windows agent

### DIFF
--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -18,11 +18,8 @@ strategy:
     linux:
       imageName: "ubuntu-latest"
       ADDITIONAL_TEST_ARGS: '--collect "XPlat Code coverage"'
-    mac:
-      imageName: "macOS-latest"
-      ADDITIONAL_TEST_ARGS: ''
     windows:
-      imageName: "windows-2022"
+      imageName: "windows-latest"
       ADDITIONAL_TEST_ARGS: '--collect "XPlat Code coverage"'
   maxParallel: 3
 pool:
@@ -32,6 +29,15 @@ variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
 steps:
+- task: PowerShell@2
+  displayName: Start CosmosDB Emulator
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  inputs:
+    targetType: 'inline'
+    script: |
+      Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+      Start-CosmosDbEmulator
+
 - task: NuGetAuthenticate@0
   displayName: 'NuGet Authenticate'
 
@@ -57,7 +63,18 @@ steps:
     projects: '**/*.csproj'
     arguments: '-p:generateConfigFileForDbType=cosmosdb_nosql --configuration $(buildConfiguration)' # Update this to match your need
 
+- bash: |
+    echo "Waiting for CosmosDB Emulator to Start"
+    until [ "$(curl -k -s --connect-timeout 5 -o /dev/null -w "%{http_code}" https://localhost:8081/_explorer/index.html)" == "200" ]; do
+        sleep 5;
+        echo "Waiting for CosmosDB Emulator to Start"
+    done;
+    echo "CosmosDB Emulator is available"
+  condition: eq( variables['Agent.OS'], 'Windows_NT' )
+  displayName: Check CosmosDB Emulator is running
+
 - task: FileTransform@1.206.0
+  condition: eq( variables['Agent.OS'], 'Linux' )
   displayName: 'Generate dab-config.CosmosDb_NoSql.json'
   inputs:
     folderPath: '$(System.DefaultWorkingDirectory)'


### PR DESCRIPTION
## Why make this change?

Currently, we are running integration tests against a production CosmosDB account. Recently, we've encountered 429 errors during these tests because the same production account is used for each OS agent. To address this issue, we have started using the CosmosDB Local Emulator when running integration tests on the Windows agent.

## What is this change?
Changed the Windows agent to windows-latest. This agent has an emulator preinstalled.
Removed the FileTransform task for the Windows agent. Temporarily removed the Mac-os job to prevent 429 errors. 
Todo: Use an emulator in the Mac-os agent and Linux agent.

## How was this tested?

- [x] Integration Tests

