### PR TITLE
Fixing dw query builder to handle Unicode characters

### DIFF
--- a/config-generators/config-generator.sh
+++ b/config-generators/config-generator.sh
@@ -9,15 +9,19 @@ databaseTypes=();
 # The argument represents the database type. Valid arguments are MsSql, MySql, PostgreSql and Cosmos
 # When invoked with a database type, config file for that database type will be generated.
 # When invoked without any arguments, config files for all the database types will be generated.
+
+allowedDbTypes=("mssql" "mysql" "postgresql" "cosmosdb_nosql" "dwsql")
+databaseTypes=()
+
 if [[ $# -eq 0 ]]; then
-    databaseTypes=("mssql" "mysql" "postgresql" "cosmosdb_nosql")
+    databaseTypes=("${allowedDbTypes[@]}")
 elif [[ $# -eq 1 ]]; then
-    databaseType=$1;
-    if ! { [ $databaseType == "mssql" ] || [ $databaseType == "mysql" ] || [ $databaseType == "postgresql" ] || [ $databaseType == "cosmosdb_nosql" ]; }; then
-        echo "Valid arguments are mssql, mysql, postgresql or cosmosdb_nosql";
+    databaseType=$1
+    if [[ ! ${allowedDbTypes[@]} =~ ${databaseType} ]]; then
+        echo "Valid arguments are mssql, mysql, postgresql, cosmosdb_nosql, or dwsql";
         exit 1;
     fi
-    databaseTypes+=$databaseType;    
+    databaseTypes+=$databaseType;
 else
     echo "Please run with 0 or 1 arguments";
     exit 1;

--- a/src/Core/Resolvers/DWSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/DWSqlQueryBuilder.cs
@@ -109,12 +109,12 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 {
                     col_value = $"CAST([{col_value}] AS NVARCHAR(MAX))";
                     // Create json. Example: "book.id": 1 would be a sample output.
-                    stringAgg.Append($"\"{escapedLabel}\":\' + ISNULL(STRING_ESCAPE({col_value},'json'),'null') + \'");
+                    stringAgg.Append($"N\'\"{escapedLabel}\":\' + ISNULL(STRING_ESCAPE({col_value},'json'),'null')");
                 }
                 else
                 {
                     // Create json. Example: "book.title": "Title" would be a sample output.
-                    stringAgg.Append($"\"{escapedLabel}\":\' + ISNULL(\'\"\'+STRING_ESCAPE([{col_value}],'json')+\'\"\','null') + \'");
+                    stringAgg.Append($"N\'\"{escapedLabel}\":\' + ISNULL(\'\"\'+STRING_ESCAPE([{col_value}],'json')+\'\"\','null')");
                 }
 
                 i++;
@@ -123,11 +123,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 // the below ensures there is a comma after id but not after name.
                 if (i != structure.Columns.Count)
                 {
-                    stringAgg.Append(",");
+                    stringAgg.Append("+\',\'+");
                 }
             }
 
-            columns = $"STRING_AGG(\'{{{stringAgg}}}\',', ')";
+            columns = $"STRING_AGG(\'{{\'+{stringAgg}+\'}}\',', ')";
             if (structure.IsListQuery)
             {
                 // Array wrappers if we are trying to get a list of objects.


### PR DESCRIPTION
## Why make this change?

Dw pipeline test case was failing due to incorrect parsing for chinese characters. 
In addition, dw pipeline was not enabled for linux. 

## What is this change?

Use the N' prefix that handles unicode characters correctly when building the json in dw.
Added the db type in the config-generator.sh

## Tests
Unique characters test case passes along with other test cases.
