### PR TITLE
Eliminate generation of config files multiple times in the integration test pipelines

### DIFF
--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -60,7 +60,7 @@ steps:
   displayName: Build
   inputs:
     command: build
-    projects: projects: |
+    projects: |
         **/*.csproj
         !**/*Tests*.csproj
     arguments: '-p:generateConfigFileForDbType=cosmosdb_nosql --configuration $(buildConfiguration)' # Update this to match your need

--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -60,8 +60,17 @@ steps:
   displayName: Build
   inputs:
     command: build
-    projects: '**/*.csproj'
+    projects: projects: |
+        **/*.csproj
+        !**/*Tests*.csproj
     arguments: '-p:generateConfigFileForDbType=cosmosdb_nosql --configuration $(buildConfiguration)' # Update this to match your need
+
+- task: DotNetCoreCLI@2
+  displayName: Build Test Projects
+  inputs:
+    command: build
+    projects: '**/*Tests/*.csproj'
+    arguments: '--configuration $(buildConfiguration)'
 
 - bash: |
     echo "Waiting for CosmosDB Emulator to Start"

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -79,8 +79,17 @@ jobs:
     displayName: Build
     inputs:
       command: build
-      projects: '**/*.csproj'
+      projects: |
+        **/*.csproj
+        !**/*Tests*.csproj
       arguments: '-p:generateConfigFileForDbType=dwsql --configuration $(buildConfiguration)' # Update this to match your need
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Test Projects
+    inputs:
+      command: build
+      projects: '**/*Tests/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
 
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.DwSql.json'
@@ -194,9 +203,19 @@ jobs:
     displayName: Build
     inputs:
       command: build
-      projects: '**/*.csproj'
+      projects: build
+      projects: |
+        **/*.csproj
+        !**/*Tests*.csproj
       arguments: '-p:generateConfigFileForDbType=DwSql --configuration $(buildConfiguration)' # Update this to match your need
-    
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Test Projects
+    inputs:
+      command: build
+      projects: '**/*Tests/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.DwSql.json'
     inputs:

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -203,7 +203,6 @@ jobs:
     displayName: Build
     inputs:
       command: build
-      projects: build
       projects: |
         **/*.csproj
         !**/*Tests*.csproj

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -61,8 +61,17 @@ jobs:
     displayName: Build
     inputs:
       command: build
-      projects: '**/*.csproj'
+      projects: |
+        **/*.csproj
+        !**/*Tests*.csproj
       arguments: '-p:generateConfigFileForDbType=mssql --configuration $(buildConfiguration)' # Update this to match your need
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Test Projects
+    inputs:
+      command: build
+      projects: '**/*Tests/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
 
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.MsSql.json'
@@ -176,9 +185,18 @@ jobs:
     displayName: Build
     inputs:
       command: build
-      projects: '**/*.csproj'
+      projects: |
+        **/*.csproj
+        !**/*Tests*.csproj
       arguments: '-p:generateConfigFileForDbType=MsSql --configuration $(buildConfiguration)' # Update this to match your need
-    
+  
+  - task: DotNetCoreCLI@2
+    displayName: Build Test Projects
+    inputs:
+      command: build
+      projects: '**/*Tests/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
+
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.MsSql.json'
     inputs:

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       command: build
       projects: |
         **/*.csproj
-        !**/*Tests.csproj
+        !**/*Tests*.csproj
       arguments: '-p:generateConfigFileForDbType=mysql --configuration $(buildConfiguration)' # Update this to match your need
 
   - task: DotNetCoreCLI@2
@@ -70,7 +70,7 @@ jobs:
     inputs:
       command: build
       projects: '**/*Tests/*.csproj'
-      arguments: '--configuration $(buildConfiguration)' # Update this to match your need
+      arguments: '--configuration $(buildConfiguration)'
 
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.MySql.json'

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -61,8 +61,8 @@ jobs:
     inputs:
       command: build
       projects: |
-        '**/*.csproj'
-        '!**/*Tests.csproj'
+        **/*.csproj
+        !**/*Tests.csproj
       arguments: '-p:generateConfigFileForDbType=mysql --configuration $(buildConfiguration)' # Update this to match your need
 
   - task: DotNetCoreCLI@2

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -60,7 +60,9 @@ jobs:
     displayName: Build
     inputs:
       command: build
-      projects: '**/*.csproj;!**/*Tests/*.csproj'
+      projects: |
+        '**/*.csproj'
+        '!**/Tests/*.csproj'
       arguments: '-p:generateConfigFileForDbType=mysql --configuration $(buildConfiguration)' # Update this to match your need
 
   - task: DotNetCoreCLI@2

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -60,8 +60,15 @@ jobs:
     displayName: Build
     inputs:
       command: build
-      projects: '**/*.csproj'
+      projects: '**/*.csproj;!**/*Tests/*.csproj'
       arguments: '-p:generateConfigFileForDbType=mysql --configuration $(buildConfiguration)' # Update this to match your need
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Test Projects
+    inputs:
+      command: build
+      projects: '**/*Tests/*.csproj'
+      arguments: '--configuration $(buildConfiguration)' # Update this to match your need
 
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.MySql.json'

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       command: build
       projects: |
         '**/*.csproj'
-        '!**/*Tests/*.csproj'
+        '!**/*Tests.csproj'
       arguments: '-p:generateConfigFileForDbType=mysql --configuration $(buildConfiguration)' # Update this to match your need
 
   - task: DotNetCoreCLI@2

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
       command: build
       projects: |
         '**/*.csproj'
-        '!**/Tests/*.csproj'
+        '!**/*Tests/*.csproj'
       arguments: '-p:generateConfigFileForDbType=mysql --configuration $(buildConfiguration)' # Update this to match your need
 
   - task: DotNetCoreCLI@2

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -55,8 +55,17 @@ jobs:
     displayName: Build
     inputs:
       command: build
-      projects: '**/*.csproj'
+      projects: |
+        **/*.csproj
+        !**/*Tests*.csproj
       arguments: '-p:generateConfigFileForDbType=postgresql --configuration $(buildConfiguration)' # Update this to match your need
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Test Projects
+    inputs:
+      command: build
+      projects: '**/*Tests/*.csproj'
+      arguments: '--configuration $(buildConfiguration)'
 
   - task: FileTransform@1.206.0
     displayName: 'Generate dab-config.PostgreSql.json'


### PR DESCRIPTION
## Why make this change?

- Closes #1909 
  - To include CLI as part of the integration testing, config file used for all the integration tests are generated by CLI. The config file generation is added as a post build event (in the CLI module) to enable generation of config files in the a) integration testing pipelines b) local (if developer wishes to try out the config files we've used during development/testing.)
  - At the moment, the config file generation gets triggered twice. However, this is redundant. Ensuring that the config file generation is executed only once will improve the time taken in the integration testing pipelines.  

## What is this change?

- The config file generation gets triggered when building the 1) CLI 2) CLI.Tests modules.
- The build step in the pipeline is broken up as two

1. Build all the non-testing modules with `-p:generateConfigFileForDbType=<database_type>`
2. Build the test modules without any arguements. The presence of `-p:generateConfigFileForDbType` argument determines the execution of config generation script. So, when the test modules are built without this argument, the config file generation script does not execute.


## How was this tested?

- [ ]  Executing integration tests in the pipeline manually.

## Sample Request(s)

N/A