### PR TITLE
fixing datetime and bit issue in DW.

### DIFF
--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -3,7 +3,7 @@
 
 # MsSql Integration Testing Pipeline config is split into two jobs:
 # 1) LinuxTests -> Run SQL Server 2019 in Linux Docker Image
-# 2) WindowsTests -> Run LocalDB preinstalled on
+# 2) WindowsTests -> Run LocalDB preinstalled on machine
 
 trigger:
   batch: true
@@ -24,6 +24,8 @@ jobs:
       solution: '**/*.sln'
       buildPlatform: 'Any CPU'
       buildConfiguration: 'Release'
+      dbPassword: ''
+      data-source.connection-string: ''
 
   steps:
   - task: NuGetAuthenticate@0
@@ -51,11 +53,30 @@ jobs:
       releaseType: stable
 
   - task: Bash@3
+    displayName: 'Generate password'
+    inputs:
+      targetType: 'inline'
+      script: |
+        password=$(cat /dev/urandom | tr -dc 'A-Za-z0-9' | head -c24)
+        echo "##vso[task.setvariable variable=dbPassword;]$password"
+  
+  - task: PowerShell@2
+    displayName: 'Set Connection String'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $connectionString="Server=tcp:127.0.0.1,1433;Persist Security Info=False;User ID=SA;Password=$(dbPassword);MultipleActiveResultSets=False;Connection Timeout=5;TrustServerCertificate=True;Encrypt=False;"
+        Write-Host "##vso[task.setvariable variable=data-source.connection-string]$connectionString"
+
+  - task: Bash@3
     condition: eq( variables['Agent.OS'], 'Linux' )
     displayName: Get and Start Ubuntu SQL Server Image Docker with SSL enabled
     inputs:
-      filePath: scripts/start-mssql-server.bash
-      arguments: $(DockerSQLPass)
+      targetType: 'inline'
+      script: |
+        echo "Executing script with arguments."
+        chmod +x ./scripts/start-mssql-server.bash
+        ./scripts/start-mssql-server.bash $(dbPassword)
 
   - task: DotNetCoreCLI@2
     displayName: Build
@@ -129,7 +150,7 @@ jobs:
       # since windows needs a different string.
       # The variable setting on the pipeline UI sets the connection string
       # for the linux job above.
-      data-source.connection-string: $(ConnectionStringLocalDBVariable)
+      data-source.connection-string: Server=(localdb)\MSSQLLocalDB;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;TrustServerCertificate=True;
       InstallerUrl: https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SqlLocalDB.msi
       SqlVersionCode: '15.0'
 

--- a/config-generators/dwsql-commands.txt
+++ b/config-generators/dwsql-commands.txt
@@ -26,7 +26,6 @@ add Notebook --config "dab-config.DwSql.json" --source "notebooks" --permissions
 add Journal --config "dab-config.DwSql.json" --source "journals" --rest true --graphql true --permissions "policy_tester_noupdate:create,delete" --source.key-fields "id"
 add ArtOfWar --config "dab-config.DwSql.json" --source "aow" --rest true --graphql false --permissions "anonymous:*" --source.key-fields "NoteNum"
 add stocks_view_selected --config "dab-config.DwSql.json" --source stocks_view_selected --source.type "view" --source.key-fields "categoryid,pieceid" --permissions "anonymous:*" --rest true --graphql true
-add stocks_price --config "dab-config.DwSql.json" --source stocks_price --permissions "authenticated:create,read,update,delete"
 update stocks_price --config "dab-config.DwSql.json" --permissions "anonymous:read"
 update stocks_price --config "dab-config.DwSql.json" --permissions "TestNestedFilterFieldIsNull_ColumnForbidden:read" --fields.exclude "price"
 update stocks_price --config "dab-config.DwSql.json" --permissions "TestNestedFilterFieldIsNull_EntityReadForbidden:create"

--- a/config-generators/dwsql-commands.txt
+++ b/config-generators/dwsql-commands.txt
@@ -1,6 +1,7 @@
 init --config "dab-config.DwSql.json" --database-type dwsql --set-session-context true --connection-string "Server=tcp:127.0.0.1,1433;Persist Security Info=False;User ID=sa;Password=REPLACEME;MultipleActiveResultSets=False;Connection Timeout=5;" --host-mode Development --cors-origin "http://localhost:5000"
 add Publisher --config "dab-config.DwSql.json" --source publishers --permissions "anonymous:read" --source.key-fields "id"
 add Stock --config "dab-config.DwSql.json" --source stocks --permissions "anonymous:create,read,update,delete" --source.key-fields "categoryid,pieceid"
+add stocks_price --config "dab-config.DwSql.json" --source stocks_price --permissions "authenticated:create,read,update,delete" --source.key-fields "categoryid,pieceid,instant"
 add Book --config "dab-config.DwSql.json" --source books --permissions "anonymous:create,read,update,delete" --graphql "book:books" --source.key-fields "id"
 add BookWebsitePlacement --config "dab-config.DwSql.json" --source book_website_placements --permissions "anonymous:read" --source.key-fields "id"
 add Author --config "dab-config.DwSql.json" --source authors --permissions "anonymous:read" --source.key-fields "id"
@@ -25,6 +26,10 @@ add Notebook --config "dab-config.DwSql.json" --source "notebooks" --permissions
 add Journal --config "dab-config.DwSql.json" --source "journals" --rest true --graphql true --permissions "policy_tester_noupdate:create,delete" --source.key-fields "id"
 add ArtOfWar --config "dab-config.DwSql.json" --source "aow" --rest true --graphql false --permissions "anonymous:*" --source.key-fields "NoteNum"
 add stocks_view_selected --config "dab-config.DwSql.json" --source stocks_view_selected --source.type "view" --source.key-fields "categoryid,pieceid" --permissions "anonymous:*" --rest true --graphql true
+add stocks_price --config "dab-config.DwSql.json" --source stocks_price --permissions "authenticated:create,read,update,delete"
+update stocks_price --config "dab-config.DwSql.json" --permissions "anonymous:read"
+update stocks_price --config "dab-config.DwSql.json" --permissions "TestNestedFilterFieldIsNull_ColumnForbidden:read" --fields.exclude "price"
+update stocks_price --config "dab-config.DwSql.json" --permissions "TestNestedFilterFieldIsNull_EntityReadForbidden:create"
 update Publisher --config "dab-config.DwSql.json" --permissions "authenticated:create,read,update,delete" --rest true --graphql true --relationship books --target.entity Book --cardinality many --relationship.fields "id:publisher_id"
 update Publisher --config "dab-config.DwSql.json" --permissions "policy_tester_01:create,delete"
 update Publisher --config "dab-config.DwSql.json" --permissions "policy_tester_01:update" --fields.include "*"

--- a/src/Core/Resolvers/DWSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/DWSqlQueryBuilder.cs
@@ -116,7 +116,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                         // need to wrap datetime in quotes to ensure correct deserialization.
                         stringAgg.Append($"N\'\"{escapedLabel}\":\"\' + ISNULL(STRING_ESCAPE({col_value},'json'),'null') + \'\"\'+");
                     }
-                    else if(col_type == typeof(Boolean))
+                    else if (col_type == typeof(Boolean))
                     {
                         stringAgg.Append($"N\'\"{escapedLabel}\":\' + ISNULL(IIF({col_value} = 1, 'true', 'false'),'null')");
                     }

--- a/src/Core/Resolvers/DWSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/DWSqlQueryBuilder.cs
@@ -108,8 +108,23 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 if (!subQueryColumn && structure.GetColumnSystemType(column.ColumnName) != typeof(string))
                 {
                     col_value = $"CAST([{col_value}] AS NVARCHAR(MAX))";
-                    // Create json. Example: "book.id": 1 would be a sample output.
-                    stringAgg.Append($"N\'\"{escapedLabel}\":\' + ISNULL(STRING_ESCAPE({col_value},'json'),'null')");
+
+                    Type col_type = structure.GetColumnSystemType(column.ColumnName);
+
+                    if (col_type == typeof(DateTime))
+                    {
+                        // need to wrap datetime in quotes to ensure correct deserialization.
+                        stringAgg.Append($"N\'\"{escapedLabel}\":\"\' + ISNULL(STRING_ESCAPE({col_value},'json'),'null') + \'\"\'+");
+                    }
+                    else if(col_type == typeof(Boolean))
+                    {
+                        stringAgg.Append($"N\'\"{escapedLabel}\":\' + ISNULL(IIF({col_value} = 1, 'true', 'false'),'null')");
+                    }
+                    else
+                    {
+                        // Create json. Example: "book.id": 1 would be a sample output.
+                        stringAgg.Append($"N\'\"{escapedLabel}\":\' + ISNULL(STRING_ESCAPE({col_value},'json'),'null')");
+                    }
                 }
                 else
                 {

--- a/src/Service.Tests/DatabaseSchema-DwSql.sql
+++ b/src/Service.Tests/DatabaseSchema-DwSql.sql
@@ -13,6 +13,7 @@ DROP TABLE IF EXISTS book_website_placements;
 DROP TABLE IF EXISTS website_users;
 DROP TABLE IF EXISTS books;
 DROP TABLE IF EXISTS [foo].[magazines];
+DROP TABLE IF EXISTS stocks_price;
 DROP TABLE IF EXISTS stocks;
 DROP TABLE IF EXISTS comics;
 DROP TABLE IF EXISTS brokers;
@@ -125,6 +126,15 @@ CREATE TABLE stocks(
     piecesRequired int NOT NULL
 );
 
+
+CREATE TABLE stocks_price(
+    categoryid int NOT NULL,
+    pieceid int NOT NULL,
+    instant datetime NOT NULL,
+    price int,
+    is_wholesale_price bit
+);
+
 CREATE TABLE brokers(
     [ID Number] int NOT NULL,
     [First Name] varchar(2048) NOT NULL,
@@ -229,7 +239,7 @@ INSERT INTO brokers([ID Number], [First Name], [Last Name]) VALUES (1, 'Michael'
 INSERT INTO publishers(id, name) VALUES (1234, 'Big Company'), (2345, 'Small Town Publisher'), (2323, 'TBD Publishing One'), (2324, 'TBD Publishing Two Ltd'), (1940, 'Policy Publisher 01'), (1941, 'Policy Publisher 02'), (1156, 'The First Publisher');
 INSERT INTO book_author_link(book_id, author_id) VALUES (1, 123), (2, 124), (3, 123), (3, 124), (4, 123), (4, 124), (5, 126);
 INSERT INTO stocks(categoryid, pieceid, categoryName, piecesAvailable, piecesRequired) VALUES (1,1,'SciFi',0,0),(2,1,'Tales',0,0),(0,1,'',0,0),(100,99,'Historical',0,0);
-
+INSERT INTO stocks_price (categoryid, pieceid, instant, price, is_wholesale_price) VALUES (2, 1, '2023-08-21 15:11:04', 100, 1);
 INSERT INTO notebooks(id, notebookname, color, ownername) VALUES (1, 'Notebook1', 'red', 'Sean'), (2, 'Notebook2', 'green', 'Ani'), (3, 'Notebook3', 'blue', 'Jarupat'), (4, 'Notebook4', 'yellow', 'Aaron');
 INSERT INTO journals(id, journalname, color, ownername) VALUES (1, 'Journal1', 'red', 'Sean'), (2, 'Journal2', 'green', 'Ani'), (3, 'Journal3', 'blue', 'Jarupat'), (4, 'Journal4', 'yellow', 'Aaron');
 INSERT INTO aow(NoteNum, DetailAssessmentAndPlanning, WagingWar, StrategicAttack) VALUES (1, 'chapter one notes: ', 'chapter two notes: ', 'chapter three notes: ');

--- a/src/Service.Tests/SqlTests/RestApiTests/Find/DwSqlFindApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/DwSqlFindApiTests.cs
@@ -23,6 +23,11 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
                 $"WHERE id = 2 FOR JSON PATH, INCLUDE_NULL_VALUES, WITHOUT_ARRAY_WRAPPER"
             },
             {
+                "FindByDateTimePKTest",
+                $"SELECT categoryid, pieceid, FORMAT(instant, 'MMM dd yyyy  h:mmtt') as instant, price, is_wholesale_price FROM { _tableWithDateTimePK } " +
+                $"WHERE categoryid = 2 AND pieceid = 1 AND instant = '2023-08-21 15:11:04' FOR JSON PATH, INCLUDE_NULL_VALUES, WITHOUT_ARRAY_WRAPPER"
+            },
+            {
                 "FindEmptyTable",
                 $"SELECT * FROM { _emptyTableTableName } " +
                 $"FOR JSON PATH, INCLUDE_NULL_VALUES"
@@ -591,13 +596,6 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
         public override string GetQuery(string key)
         {
             return _queryMap[key];
-        }
-
-        [TestMethod]
-        [Ignore]
-        public override Task FindByDateTimePKTest()
-        {
-            throw new NotImplementedException();
         }
 
         // Pending Stored Procedure Support

--- a/src/Service.Tests/dab-config.DwSql.json
+++ b/src/Service.Tests/dab-config.DwSql.json
@@ -399,6 +399,75 @@
         }
       ]
     },
+    "stocks_price": {
+      "source": {
+        "object": "stocks_price",
+        "type": "table",
+        "key-fields": [
+          "categoryid",
+          "pieceid",
+          "instant"
+        ]
+      },
+      "graphql": {
+        "enabled": true,
+        "type": {
+          "singular": "stocks_price",
+          "plural": "stocks_prices"
+        }
+      },
+      "rest": {
+        "enabled": true
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "read"
+            }
+          ]
+        },
+        {
+          "role": "authenticated",
+          "actions": [
+            {
+              "action": "create"
+            },
+            {
+              "action": "read"
+            },
+            {
+              "action": "update"
+            },
+            {
+              "action": "delete"
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterFieldIsNull_ColumnForbidden",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [
+                  "price"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "role": "TestNestedFilterFieldIsNull_EntityReadForbidden",
+          "actions": [
+            {
+              "action": "create"
+            }
+          ]
+        }
+      ]
+    },
     "Book": {
       "source": {
         "object": "books",


### PR DESCRIPTION
## Why make this change?

Datawarehouse was having issues with datetime. This is because we are using string agg. if we dont add the "" to datetime, it is being deserialized as a number and we get a bug saying there is a - in the number. FOR JSON converts bit to true or false and hence we need to do same.

## What is this change?

Hence for datetime we need to add the wrapping "" to ensure correct deserialization. 
if datatype is bit set to true or false.


## How was this tested?

unit tests added. 
integration test done with dab running and dw datetime supported. image:
![Uploading image.png…]()

