### PR TITLE
Upgrade deprecated tasks in pipeline

### DIFF
--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -38,7 +38,7 @@ steps:
       Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
       Start-CosmosDbEmulator
 
-- task: NuGetAuthenticate@0
+- task: NuGetAuthenticate@1
   displayName: 'NuGet Authenticate'
 
 - task: UseDotNet@2

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       data-source.connection-string: ''
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2
@@ -158,7 +158,7 @@ jobs:
     inputs:
       script: 'echo ##vso[task.setvariable variable=publishverify]Yes'
 
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       data-source.connection-string: ''
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2
@@ -161,7 +161,7 @@ jobs:
     inputs:
       script: 'echo ##vso[task.setvariable variable=publishverify]Yes'
 
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
       buildConfiguration: 'Release'
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
       buildConfiguration: 'Release'
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2

--- a/.pipelines/templates/static-tools.yml
+++ b/.pipelines/templates/static-tools.yml
@@ -14,7 +14,7 @@ jobs:
     vmImage: '${{ parameters.VmImage }}'
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found


### PR DESCRIPTION
## Why make this change?

- To get rid of warning in pipelines due to use of deprecated tasks.
![image](https://github.com/Azure/data-api-builder/assets/102276754/ce5cfebd-d32f-46eb-a030-bf090f50b11f)


## What is this change?
 - Upgraded the deprecated (https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-authenticate-v0?view=azure-pipelines) Nuget Authenticate task in pipeline.

## How was this tested?
By running pipeline
