### PR TITLE
Update Dependencies and Suppress NU1603

### DIFF
--- a/src/Auth/Azure.DataApiBuilder.Auth.csproj
+++ b/src/Auth/Azure.DataApiBuilder.Auth.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Cli.Tests/Cli.Tests.csproj
+++ b/src/Cli.Tests/Cli.Tests.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <OutputPath>$(BaseOutputPath)\tests</OutputPath>
+        <NoWarn>NU1603</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -28,6 +28,7 @@
     </Dependencies>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Config/Azure.DataApiBuilder.Config.csproj
+++ b/src/Config/Azure.DataApiBuilder.Config.csproj
@@ -19,6 +19,8 @@
       <PackageReference Include="System.IO.Abstractions" />
       <PackageReference Include="System.Drawing.Common" />
       <PackageReference Include="Microsoft.Data.SqlClient" />
+      <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
       <PackageReference Include="StyleCop.Analyzers">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Config/Azure.DataApiBuilder.Config.csproj
+++ b/src/Config/Azure.DataApiBuilder.Config.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageVersion Include="Microsoft.OData.Edm" Version="7.12.5" />
     <PackageVersion Include="Microsoft.OData.Core" Version="7.12.5" />
@@ -45,6 +46,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <PackageVersion Include="System.IO.Abstractions" Version="19.2.29" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="19.2.29" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="6.0.14" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.26" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.14" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.14" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.20.0" />
     <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />

--- a/src/Product/Azure.DataApiBuilder.Product.csproj
+++ b/src/Product/Azure.DataApiBuilder.Product.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
+++ b/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
+++ b/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <OutputPath>$(BaseOutputPath)\tests</OutputPath>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -2862,7 +2862,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
         private static string GenerateMockJwtToken()
         {
-            string mySecret = "PlaceholderPlaceholder";
+            string mySecret = "PlaceholderPlaceholderPlaceholder";
             SymmetricSecurityKey mySecurityKey = new(Encoding.ASCII.GetBytes(mySecret));
 
             JwtSecurityTokenHandler tokenHandler = new();

--- a/src/Service/Azure.DataApiBuilder.Service.csproj
+++ b/src/Service/Azure.DataApiBuilder.Service.csproj
@@ -6,6 +6,7 @@
         <OutputPath>$(BaseOutputPath)\engine</OutputPath>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <NoWarn>NU1603</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
@@ -28,7 +29,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Docker|AnyCPU'">
-      <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Why make this change?
- Updates dependencies `SqlClient` and `Microsoft.AspNetCore.Authentication.JwtBearer`
- Explicitly set version of and include transitive dependencies: `System.IdentityModel.Tokens.Jwt` and `Microsoft.IdentityModel.JsonWebTokens`
- Suppress NU1603 when resolving dependencies from NuGet feed to prevent pipeline failures.
- Allows pipeline to pull compatible dependency version from private feed even when dependency is not the exact lower bounded version. DAB project treats warnings as errors and in this case, NU1603 is emitted and should be ignored.

- Background on issue: https://github.com/NuGet/Home/issues/5764

Even though our feed may have version `6.10.1` of the relevant package which meets the expectations of `>=6.10.0`, NuGet is expects and considers the "ideal" match to be `6.10.0` because that is what the package was built and tested against. Newer versions may or may not work and allows build systems to be consistent (per linked NuGet issue thread).

> ##[error]Core.csproj(0,0): Error NU1603: Microsoft.IdentityModel.Protocols 6.10.0 depends on Microsoft.IdentityModel.Tokens (>= 6.10.0) 
> but Microsoft.IdentityModel.Tokens 6.10.0 was not found. 
> An approximate best match of Microsoft.IdentityModel.Tokens 6.10.1 was resolved.

## What is this change?

- Suppress `NU1603` warning in all csproj files.
- Updates SqlClient dependency to version `5.1.4`.
- Updates Microsoft.AspNetCore.Authentication.JwtBearer to version `6.0.26`
- Updates System.IdentityModel.Tokens.Jwt and Microsoft.IdentityModel.JsonWebTokens to `6.35.0` explicitly even though transitive dependencies because latest SqlClient 5.1.4 references vulnerable 6.24.0 versions. Known issue in sqlclient https://github.com/dotnet/SqlClient/issues/2294 and workaround is to explicitly define the dependencies/needed version.

## How was this tested?

- [x] integration test: privately running the pipeline resolves expected dependencies without error.
