### PR TITLE
Refactor RuntimeConfig into Interface with Local and Hosted Providers

### DIFF
--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -1104,7 +1104,7 @@ namespace Cli
                 _logger.LogInformation("Loaded config file: {runtimeConfigFile}", runtimeConfigFile);
             }
 
-            RuntimeConfigProvider runtimeConfigProvider = new(loader);
+            LocalRuntimeConfigProvider runtimeConfigProvider = new(loader);
 
             ILogger<RuntimeConfigValidator> runtimeConfigValidatorLogger = LoggerFactoryForCli.CreateLogger<RuntimeConfigValidator>();
             RuntimeConfigValidator runtimeConfigValidator = new(runtimeConfigProvider, fileSystem, runtimeConfigValidatorLogger, true);

--- a/src/Config/ConfigFileWatcher.cs
+++ b/src/Config/ConfigFileWatcher.cs
@@ -1,8 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Azure.DataApiBuilder.Config.ObjectModel;
+
 namespace Azure.DataApiBuilder.Config;
 
+/// <summary>
+/// This class is responsible for monitoring the config file from the
+/// local file system, and if changes are detected, triggering the
+/// required logic to begin a hot reload scenario.
+/// </summary>
 public class ConfigFileWatcher
 {
     private FileSystemWatcher? _fileWatcher;
@@ -33,7 +40,7 @@ public class ConfigFileWatcher
         {
             if (_configLoader is null)
             {
-                throw new ArgumentNullException("_configProvider can not be null.");
+                throw new ArgumentNullException("ConfigLoader can not be null.");
             }
 
             if (_configLoader.RuntimeConfig is null)
@@ -43,7 +50,7 @@ public class ConfigFileWatcher
 
             if (_configLoader.RuntimeConfig.IsDevelopmentMode())
             {
-                _configLoader.HotReloadConfig();
+                _configLoader.HotReloadConfig(_configLoader.RuntimeConfig.DefaultDataSourceName);
             }
         }
         catch (Exception ex)

--- a/src/Config/ConfigFileWatcher.cs
+++ b/src/Config/ConfigFileWatcher.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Azure.DataApiBuilder.Core.Configurations;
+namespace Azure.DataApiBuilder.Config;
 
 public class ConfigFileWatcher
 {
     private FileSystemWatcher? _fileWatcher;
-    private readonly LocalRuntimeConfigProvider? _configProvider;
+    private FileSystemRuntimeConfigLoader _configLoader;
 
-    public ConfigFileWatcher(LocalRuntimeConfigProvider configProvider, string directoryName, string configFileName)
+    public ConfigFileWatcher(FileSystemRuntimeConfigLoader configLoader, string directoryName, string configFileName)
     {
         _fileWatcher = new FileSystemWatcher(directoryName)
         {
@@ -16,7 +16,7 @@ public class ConfigFileWatcher
             EnableRaisingEvents = true
         };
 
-        _configProvider = configProvider;
+        _configLoader = configLoader;
         _fileWatcher.Changed += OnConfigFileChange;
     }
 
@@ -31,14 +31,19 @@ public class ConfigFileWatcher
     {
         try
         {
-            if (_configProvider is null)
+            if (_configLoader is null)
             {
                 throw new ArgumentNullException("_configProvider can not be null.");
             }
 
-            if (!_configProvider.IsLateConfigured && _configProvider.GetConfig().IsDevelopmentMode())
+            if (_configLoader.RuntimeConfig is null)
             {
-                _configProvider.HotReloadConfig();
+                throw new ArgumentNullException("RuntimeConfig can not be null.");
+            }
+
+            if (_configLoader.RuntimeConfig.IsDevelopmentMode())
+            {
+                _configLoader.HotReloadConfig();
             }
         }
         catch (Exception ex)

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text.Json;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Service.Exceptions;
+using Microsoft.Extensions.Logging;
 
 namespace Azure.DataApiBuilder.Config;
 
@@ -91,11 +92,16 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
 
     /// <summary>
     /// Checks if we have already attempted to configure the file watcher, if not
-    /// instantiate the file watcher if we are in the correct mode.
-    /// Returns true if we instantiate a file watcher.
+    /// instantiate the file watcher if we are in the development mode.
+    /// Returns true if we instantiate a new file watcher.
     /// </summary>
     private bool TrySetupConfigFileWatcher()
     {
+        if (_configFileWatcher is not null)
+        {
+            return false;
+        }
+
         if (RuntimeConfig is not null && RuntimeConfig.IsDevelopmentMode())
         {
             try
@@ -122,28 +128,40 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     /// <param name="config">The loaded <c>RuntimeConfig</c>, or null if none was loaded.</param>
     /// <param name="replaceEnvVar">Whether to replace environment variable with its
     /// value or not while deserializing.</param>
+    /// <param name="logger">ILogger for logging errors.</param>
     /// <returns>True if the config was loaded, otherwise false.</returns>
     public bool TryLoadConfig(
         string path,
         [NotNullWhen(true)] out RuntimeConfig? config,
-        bool replaceEnvVar = false)
+        bool replaceEnvVar = false,
+        ILogger? logger = null,
+        string? defaultDataSourceName = null)
     {
         if (_fileSystem.File.Exists(path))
         {
             Console.WriteLine($"Loading config file from {path}.");
             string json = _fileSystem.File.ReadAllText(path);
-            bool res = TryParseConfig(json, out RuntimeConfig, connectionString: _connectionString, replaceEnvVar: replaceEnvVar);
+            bool configParsed = TryParseConfig(json, out RuntimeConfig, connectionString: _connectionString, replaceEnvVar: replaceEnvVar);
             TrySetupConfigFileWatcher();
             config = RuntimeConfig;
-            return res;
+            if (RuntimeConfig is not null && defaultDataSourceName is not null)
+            {
+                RuntimeConfig.DefaultDataSourceName = defaultDataSourceName;
+            }
+
+            return configParsed;
+        }
+
+        string errorMessage = $"Unable to find config file: {path} does not exist.";
+        if (logger is null)
+        {
+            Console.Error.WriteLine(errorMessage);
         }
         else
         {
-            // Unable to use ILogger because this code is invoked before LoggerFactory
-            // is instantiated.
-            Console.WriteLine($"Unable to find config file: {path} does not exist.");
+            logger.LogError(message: errorMessage);
         }
-
+        
         config = null;
         return false;
     }
@@ -155,7 +173,7 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     /// <param name="replaceEnvVar">Whether to replace environment variable with its
     /// value or not while deserializing.</param>
     /// <returns>True if the config was loaded, otherwise false.</returns>
-    public override bool TryLoadKnownConfig([NotNullWhen(true)] out RuntimeConfig? config, bool replaceEnvVar = false)
+    public override bool TryLoadKnownConfig([NotNullWhen(true)] out RuntimeConfig? config, bool replaceEnvVar = false, string? defaultDataSourceName = null)
     {
         return TryLoadConfig(ConfigFilePath, out config, replaceEnvVar);
     }
@@ -164,9 +182,9 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     /// Hot Reloads the runtime config when the file watcher
     /// is active and detects a change to the underlying config file.
     /// </summary>
-    public void HotReloadConfig()
+    public void HotReloadConfig(string defaultDataSourceName)
     {
-        TryLoadKnownConfig(out _, replaceEnvVar: true);
+        TryLoadKnownConfig(out _, replaceEnvVar: true, defaultDataSourceName);
     }
 
     /// <summary>

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -104,7 +104,9 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
         {
             Console.WriteLine($"Loading config file from {path}.");
             string json = _fileSystem.File.ReadAllText(path);
-            return TryParseConfig(json, out config, connectionString: _connectionString, replaceEnvVar: replaceEnvVar);
+            bool res = TryParseConfig(json, out RuntimeConfig, connectionString: _connectionString, replaceEnvVar: replaceEnvVar);
+            config = RuntimeConfig;
+            return res;
         }
         else
         {

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -169,7 +169,7 @@ public record RuntimeConfig
         this.DataSource = DataSource;
         this.Runtime = Runtime;
         this.Entities = Entities;
-        _defaultDataSourceName = Guid.NewGuid().ToString();
+        _defaultDataSourceName = DataSource.ConnectionString.GetHashCode().ToString();
 
         // we will set them up with default values
         _dataSourceNameToDataSource = new Dictionary<string, DataSource>

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -130,7 +130,7 @@ public record RuntimeConfig
         }
     }
 
-    private string _defaultDataSourceName;
+    public string DefaultDataSourceName;
 
     private Dictionary<string, DataSource> _dataSourceNameToDataSource;
 
@@ -169,18 +169,18 @@ public record RuntimeConfig
         this.DataSource = DataSource;
         this.Runtime = Runtime;
         this.Entities = Entities;
-        _defaultDataSourceName = DataSource.ConnectionString.GetHashCode().ToString();
+        DefaultDataSourceName = Guid.NewGuid().ToString(); //DataSource.ConnectionString.GetHashCode().ToString();
 
         // we will set them up with default values
         _dataSourceNameToDataSource = new Dictionary<string, DataSource>
         {
-            { _defaultDataSourceName, this.DataSource }
+            { DefaultDataSourceName, this.DataSource }
         };
 
         _entityNameToDataSourceName = new Dictionary<string, string>();
         foreach (KeyValuePair<string, Entity> entity in Entities)
         {
-            _entityNameToDataSourceName.TryAdd(entity.Key, _defaultDataSourceName);
+            _entityNameToDataSourceName.TryAdd(entity.Key, DefaultDataSourceName);
         }
 
         // Process data source and entities information for each database in multiple database scenario.
@@ -241,7 +241,7 @@ public record RuntimeConfig
         this.DataSource = DataSource;
         this.Runtime = Runtime;
         this.Entities = Entities;
-        _defaultDataSourceName = DefaultDataSourceName;
+        DefaultDataSourceName = DefaultDataSourceName;
         _dataSourceNameToDataSource = DataSourceNameToDataSource;
         _entityNameToDataSourceName = EntityNameToDataSourceName;
         this.DataSourceFiles = DataSourceFiles;
@@ -311,7 +311,7 @@ public record RuntimeConfig
     public string GetDefaultDataSourceName()
 #pragma warning restore CA1024 // Use properties where appropriate
     {
-        return _defaultDataSourceName;
+        return DefaultDataSourceName;
     }
 
     /// <summary>

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -22,6 +22,8 @@ public abstract class RuntimeConfigLoader
 {
     protected readonly string? _connectionString;
 
+    public RuntimeConfig? RuntimeConfig;
+
     public RuntimeConfigLoader(string? connectionString = null)
     {
         _connectionString = connectionString;

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -22,7 +22,7 @@ public abstract class RuntimeConfigLoader
 {
     protected readonly string? _connectionString;
 
-    public RuntimeConfig? RuntimeConfig;
+    public RuntimeConfig? RuntimeConfig { get; set; }
 
     public RuntimeConfigLoader(string? connectionString = null)
     {
@@ -36,7 +36,7 @@ public abstract class RuntimeConfigLoader
     /// <param name="replaceEnvVar">Whether to replace environment variable with its
     /// value or not while deserializing.</param>
     /// <returns>True if the config was loaded, otherwise false.</returns>
-    public abstract bool TryLoadKnownConfig([NotNullWhen(true)] out RuntimeConfig? config, bool replaceEnvVar = false);
+    public abstract bool TryLoadKnownConfig([NotNullWhen(true)] out RuntimeConfig? config, bool replaceEnvVar = false, string? defaultDataSourceName = null);
 
     /// <summary>
     /// Returns the link to the published draft schema.
@@ -56,6 +56,7 @@ public abstract class RuntimeConfigLoader
     /// value or not while deserializing. By default, no replacement happens.</param>
     /// <param name="dataSourceName"> datasource name for which to add connection string</param>
     /// <param name="datasourceNameToConnectionString"> dictionary of datasource name to connection string</param>
+    /// <param name="replacementFailureMode">Determines failure mode for env variable replacement.</param>
     public static bool TryParseConfig(string json,
         [NotNullWhen(true)] out RuntimeConfig? config,
         ILogger? logger = null,

--- a/src/Core/AuthenticationHelpers/AuthenticationSimulator/SimulatorAuthenticationHandler.cs
+++ b/src/Core/AuthenticationHelpers/AuthenticationSimulator/SimulatorAuthenticationHandler.cs
@@ -32,7 +32,7 @@ public class SimulatorAuthenticationHandler : AuthenticationHandler<Authenticati
     /// <param name="encoder">URL encoder.</param>
     /// <param name="clock">System clock.</param>
     public SimulatorAuthenticationHandler(
-        RuntimeConfigProvider runtimeConfigProvider,
+        IRuntimeConfigProvider runtimeConfigProvider,
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
         UrlEncoder encoder,

--- a/src/Core/AuthenticationHelpers/ClientRoleHeaderAuthenticationMiddleware.cs
+++ b/src/Core/AuthenticationHelpers/ClientRoleHeaderAuthenticationMiddleware.cs
@@ -34,7 +34,7 @@ public class ClientRoleHeaderAuthenticationMiddleware
 
     public ClientRoleHeaderAuthenticationMiddleware(RequestDelegate next,
         ILogger<ClientRoleHeaderAuthenticationMiddleware> logger,
-        RuntimeConfigProvider runtimeConfigProvider)
+        IRuntimeConfigProvider runtimeConfigProvider)
     {
         _nextMiddleware = next;
         _logger = logger;

--- a/src/Core/Authorization/AuthorizationResolver.cs
+++ b/src/Core/Authorization/AuthorizationResolver.cs
@@ -23,7 +23,7 @@ namespace Azure.DataApiBuilder.Core.Authorization;
 /// </summary>
 public class AuthorizationResolver : IAuthorizationResolver
 {
-    private readonly RuntimeConfigProvider _runtimeConfigProvider;
+    private readonly IRuntimeConfigProvider _runtimeConfigProvider;
     private readonly IMetadataProviderFactory _metadataProviderFactory;
     public const string WILDCARD = "*";
     public const string CLAIM_PREFIX = "@claims.";
@@ -36,7 +36,7 @@ public class AuthorizationResolver : IAuthorizationResolver
     public Dictionary<string, EntityMetadata> EntityPermissionsMap { get; private set; } = new();
 
     public AuthorizationResolver(
-        RuntimeConfigProvider runtimeConfigProvider,
+        IRuntimeConfigProvider runtimeConfigProvider,
         IMetadataProviderFactory metadataProviderFactory
         )
     {
@@ -48,7 +48,7 @@ public class AuthorizationResolver : IAuthorizationResolver
         }
         else
         {
-            runtimeConfigProvider.RuntimeConfigLoadedHandlers.Add((RuntimeConfigProvider sender, RuntimeConfig config) =>
+            runtimeConfigProvider.RuntimeConfigLoadedHandlers.Add((HostedRuntimeConfigProvider sender, RuntimeConfig config) =>
             {
                 SetEntityPermissionMap(config);
                 return Task.FromResult(true);

--- a/src/Core/Authorization/AuthorizationResolver.cs
+++ b/src/Core/Authorization/AuthorizationResolver.cs
@@ -48,7 +48,7 @@ public class AuthorizationResolver : IAuthorizationResolver
         }
         else
         {
-            runtimeConfigProvider.RuntimeConfigLoadedHandlers.Add((HostedRuntimeConfigProvider sender, RuntimeConfig config) =>
+            runtimeConfigProvider.RuntimeConfigLoadedHandlers.Add((IRuntimeConfigProvider sender, RuntimeConfig config) =>
             {
                 SetEntityPermissionMap(config);
                 return Task.FromResult(true);

--- a/src/Core/Configurations/ConfigFileWatcher.cs
+++ b/src/Core/Configurations/ConfigFileWatcher.cs
@@ -6,7 +6,7 @@ namespace Azure.DataApiBuilder.Core.Configurations;
 public class ConfigFileWatcher
 {
     private FileSystemWatcher? _fileWatcher;
-    private readonly IRuntimeConfigProvider? _configProvider;
+    private readonly LocalRuntimeConfigProvider? _configProvider;
 
     public ConfigFileWatcher(LocalRuntimeConfigProvider configProvider, string directoryName, string configFileName)
     {

--- a/src/Core/Configurations/ConfigFileWatcher.cs
+++ b/src/Core/Configurations/ConfigFileWatcher.cs
@@ -6,9 +6,9 @@ namespace Azure.DataApiBuilder.Core.Configurations;
 public class ConfigFileWatcher
 {
     private FileSystemWatcher? _fileWatcher;
-    private readonly RuntimeConfigProvider? _configProvider;
+    private readonly IRuntimeConfigProvider? _configProvider;
 
-    public ConfigFileWatcher(RuntimeConfigProvider configProvider, string directoryName, string configFileName)
+    public ConfigFileWatcher(LocalRuntimeConfigProvider configProvider, string directoryName, string configFileName)
     {
         _fileWatcher = new FileSystemWatcher(directoryName)
         {

--- a/src/Core/Configurations/HostedRuntimeConfigProvider.cs
+++ b/src/Core/Configurations/HostedRuntimeConfigProvider.cs
@@ -16,8 +16,9 @@ namespace Azure.DataApiBuilder.Core.Configurations;
 
 /// <summary>
 /// This class is responsible for exposing the runtime config to the rest of the service when in a hosted scenario.
-/// The <c>HostedRuntimeConfigProvider</c> won't directly load the config, but will instead rely on the <see cref="FileSystemRuntimeConfigLoader"/> to do so.
-/// </summary>
+/// The HostedRuntimeConfigProvider does not rely on the local file system and therefore has logic that handles
+/// the parsing and loading of the config from a string using <see cref="RuntimeConfigLoader"/>, as is required
+/// when we are in a hosted scenario.
 /// <remarks>
 /// The <c>HostedRuntimeConfigProvider</c> will maintain internal state of the config, and will only load it once.
 ///
@@ -64,11 +65,13 @@ public class HostedRuntimeConfigProvider : IRuntimeConfigProvider
         }
     }
 
+    // Not currently used in hosted scenario, but needed for interface
     public bool TryGetConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig)
     {
         throw new NotImplementedException();
     }
 
+    // Not currently used in hosted scenario, but needed for interface
     public bool TryGetLoadedConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig)
     {
         throw new NotImplementedException();
@@ -197,22 +200,22 @@ public class HostedRuntimeConfigProvider : IRuntimeConfigProvider
         return false;
     }
 
-    public async Task<bool> InvokeConfigLoadedHandlersAsync()
-    {
-        List<Task<bool>> configLoadedTasks = new();
-        if (_runtimeConfig is not null)
-        {
-            foreach (RuntimeConfigLoadedHandler configLoadedHandler in RuntimeConfigLoadedHandlers)
-            {
-                configLoadedTasks.Add(configLoadedHandler(this, _runtimeConfig));
-            }
-        }
+    //public async Task<bool> InvokeConfigLoadedHandlersAsync()
+    //{
+    //    List<Task<bool>> configLoadedTasks = new();
+    //    if (_runtimeConfig is not null)
+    //    {
+    //        foreach (RuntimeConfigLoadedHandler configLoadedHandler in RuntimeConfigLoadedHandlers)
+    //        {
+    //            configLoadedTasks.Add(configLoadedHandler(this, _runtimeConfig));
+    //        }
+    //    }
 
-        bool[] results = await Task.WhenAll(configLoadedTasks);
+    //    bool[] results = await Task.WhenAll(configLoadedTasks);
 
-        // Verify that all tasks succeeded.
-        return results.All(x => x);
-    }
+    //    // Verify that all tasks succeeded.
+    //    return results.All(x => x);
+    //}
 
     private static RuntimeConfig HandleCosmosNoSqlConfiguration(string? schema, RuntimeConfig runtimeConfig, string connectionString, string dataSourceName = "")
     {

--- a/src/Core/Configurations/IRuntimeConfigProvider.cs
+++ b/src/Core/Configurations/IRuntimeConfigProvider.cs
@@ -11,9 +11,11 @@ namespace Azure.DataApiBuilder.Core.Configurations
     public interface IRuntimeConfigProvider
     {
         public bool IsLateConfigured { get; set; }
+
         public RuntimeConfigLoader ConfigLoader { get; set; }
 
         public List<RuntimeConfigLoadedHandler> RuntimeConfigLoadedHandlers { get; }
+
         public Dictionary<string, string?> ManagedIdentityAccessToken { get; set; }
 
         public RuntimeConfig GetConfig();
@@ -21,6 +23,5 @@ namespace Azure.DataApiBuilder.Core.Configurations
         public bool TryGetConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig);
 
         public bool TryGetLoadedConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig);
-
     }
 }

--- a/src/Core/Configurations/IRuntimeConfigProvider.cs
+++ b/src/Core/Configurations/IRuntimeConfigProvider.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Azure.DataApiBuilder.Config;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using static Azure.DataApiBuilder.Core.Configurations.HostedRuntimeConfigProvider;
+
+namespace Azure.DataApiBuilder.Core.Configurations
+{
+    public interface IRuntimeConfigProvider
+    {
+        public bool IsLateConfigured { get; set; }
+        public RuntimeConfigLoader ConfigLoader { get; set; }
+
+        public List<RuntimeConfigLoadedHandler> RuntimeConfigLoadedHandlers { get; }
+        public Dictionary<string, string?> ManagedIdentityAccessToken { get; set; }
+
+        public RuntimeConfig GetConfig();
+
+        public bool TryGetConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig);
+
+        public bool TryGetLoadedConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig);
+
+    }
+}

--- a/src/Core/Configurations/IRuntimeConfigProvider.cs
+++ b/src/Core/Configurations/IRuntimeConfigProvider.cs
@@ -4,24 +4,59 @@
 using System.Diagnostics.CodeAnalysis;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
-using static Azure.DataApiBuilder.Core.Configurations.HostedRuntimeConfigProvider;
 
 namespace Azure.DataApiBuilder.Core.Configurations
 {
+    /// <summary>
+    /// Interface for interacting with the RuntimeConfig.
+    /// </summary>
     public interface IRuntimeConfigProvider
     {
+        /// <summary>
+        /// Indicates whether the config was loaded after the runtime was initialized.
+        /// </summary>
+        /// <remarks>This is most commonly used when DAB's config is provided via the <c>ConfigurationController</c>, such as with HostedRuntimeConfigProvider.</remarks>
         public bool IsLateConfigured { get; set; }
 
+        /// <summary>
+        /// Handles the loading and access to the RuntimeConfig.
+        /// </summary>
         public RuntimeConfigLoader ConfigLoader { get; set; }
+
+        public delegate Task<bool> RuntimeConfigLoadedHandler(IRuntimeConfigProvider sender, RuntimeConfig config);
 
         public List<RuntimeConfigLoadedHandler> RuntimeConfigLoadedHandlers { get; }
 
+        /// <summary>
+        /// The access tokens representing a Managed Identity to connect to the database.
+        /// The key is the unique datasource name and the value is the access token.
+        /// </summary>
         public Dictionary<string, string?> ManagedIdentityAccessToken { get; set; }
 
+        /// <summary>
+        /// Return the previous loaded config, or it will attempt to load the config that
+        /// is known by the loader.
+        /// </summary>
         public RuntimeConfig GetConfig();
 
+        /// <summary>
+        /// Attempt to acquire runtime configuration metadata.
+        /// </summary>
         public bool TryGetConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig);
 
+        /// <summary>
+        /// Attempt to acquire runtime configuration metadata from a previously loaded one.
+        /// This method will not load the config if it hasn't been loaded yet.
+        /// </summary>
         public bool TryGetLoadedConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig);
+
+        /// <summary>
+        /// Set the runtime configuration provider with the specified accessToken for the specified datasource.
+        /// This initialization method is used to set the access token for the current runtimeConfig.
+        /// As opposed to using a json input and regenerating the runtimconfig, it sets the access token for the current runtimeConfig on the provider.
+        /// </summary>
+        public bool TrySetAccesstoken(
+        string? accessToken,
+        string dataSourceName);
     }
 }

--- a/src/Core/Configurations/LocalRuntimeConfigProvider.cs
+++ b/src/Core/Configurations/LocalRuntimeConfigProvider.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using Azure.DataApiBuilder.Config;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Service.Exceptions;
+using static Azure.DataApiBuilder.Core.Configurations.HostedRuntimeConfigProvider;
+
+namespace Azure.DataApiBuilder.Core.Configurations;
+
+/// <summary>
+/// This class is responsible for exposing the runtime config to the rest of the service.
+/// The <c>RuntimeConfigProvider</c> won't directly load the config, but will instead rely on the <see cref="FileSystemRuntimeConfigLoader"/> to do so.
+/// </summary>
+/// <remarks>
+/// The <c>RuntimeConfigProvider</c> will maintain internal state of the config, and will only load it once.
+///
+/// This class should be treated as the owner of the config that is available within the service, and other classes
+/// should not load the config directly, or maintain a reference to it, so that we can do hot-reloading by replacing
+/// the config that is available from this type.
+/// </remarks>
+public class LocalRuntimeConfigProvider : IRuntimeConfigProvider
+{
+    /// <summary>
+    /// Indicates whether the config was loaded after the runtime was initialized.
+    /// </summary>
+    /// <remarks>This is most commonly used when DAB's config is provided via the <c>ConfigurationController</c>, such as when it's a hosted service.</remarks>
+    public bool IsLateConfigured { get; set; }
+
+    public List<RuntimeConfigLoadedHandler> RuntimeConfigLoadedHandlers { get; } = new List<RuntimeConfigLoadedHandler>();
+
+    public Dictionary<string, string?> ManagedIdentityAccessToken { get; set; } = new Dictionary<string, string?>();
+
+    public RuntimeConfigLoader ConfigLoader { get; set; }
+
+    private ConfigFileWatcher? _configFileWatcher;
+
+    public LocalRuntimeConfigProvider(RuntimeConfigLoader runtimeConfigLoader)
+    {
+        ConfigLoader = runtimeConfigLoader;
+    }
+
+    /// <summary>
+    /// Return the previous loaded config, or it will attempt to load the config that
+    /// is known by the loader.
+    /// </summary>
+    /// <returns>The RuntimeConfig instance.</returns>
+    /// <remark>Dont use this method if environment variable references need to be retained.</remark>
+    /// <exception cref="DataApiBuilderException">Thrown when the loader is unable to load an instance of the config from its known location.</exception>
+    public RuntimeConfig GetConfig()
+    {
+        if (ConfigLoader.RuntimeConfig is not null)
+        {
+            return ConfigLoader.RuntimeConfig;
+        }
+
+        // While loading the config file, replace all the environment variables with their values.
+        if (ConfigLoader.TryLoadKnownConfig(out _, replaceEnvVar: true))
+        {
+            TrySetupConfigFileWatcher();
+        }
+
+        if (ConfigLoader.RuntimeConfig is null)
+        {
+            throw new DataApiBuilderException(
+                message: "Runtime config isn't setup.",
+                statusCode: HttpStatusCode.ServiceUnavailable,
+                subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
+        }
+
+        return ConfigLoader.RuntimeConfig;
+    }
+
+    /// <summary>
+    /// Checks if we have already attempted to configure the file watcher, if not
+    /// instantiate the file watcher if we are in the correct scenario. If we
+    /// are not in the correct scenario, do not setup a file watcher but remember
+    /// that we have attempted to do so to avoid repeat checks in future calls.
+    /// Returns true if we instantiate a file watcher.
+    /// </summary>
+    private bool TrySetupConfigFileWatcher()
+    {
+        if (!IsLateConfigured && ConfigLoader.RuntimeConfig is not null && ConfigLoader.RuntimeConfig.IsDevelopmentMode())
+        {
+            try
+            {
+                FileSystemRuntimeConfigLoader loader = (FileSystemRuntimeConfigLoader)ConfigLoader;
+                _configFileWatcher = new(this, loader.GetConfigDirectoryName(), loader.GetConfigFileName());
+            }
+            catch (Exception ex)
+            {
+                // Need to remove the dependencies in startup on the RuntimeConfigProvider
+                // before we can have an ILogger here.
+                Console.WriteLine($"Attempt to configure config file watcher for hot reload failed due to: {ex.Message}.");
+            }
+
+            return _configFileWatcher is not null;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempt to acquire runtime configuration metadata.
+    /// </summary>
+    /// <param name="runtimeConfig">Populated runtime configuration, if present.</param>
+    /// <returns>True when runtime config is provided, otherwise false.</returns>
+    public bool TryGetConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig)
+    {
+        if (ConfigLoader.RuntimeConfig is null)
+        {
+            if (ConfigLoader.TryLoadKnownConfig(out RuntimeConfig? _, replaceEnvVar: true))
+            {
+                TrySetupConfigFileWatcher();
+            }
+        }
+
+        runtimeConfig = ConfigLoader.RuntimeConfig;
+        return ConfigLoader.RuntimeConfig is not null;
+    }
+
+    /// <summary>
+    /// Attempt to acquire runtime configuration metadata from a previously loaded one.
+    /// This method will not load the config if it hasn't been loaded yet.
+    /// </summary>
+    /// <param name="runtimeConfig">Populated runtime configuration, if present.</param>
+    /// <returns>True when runtime config is provided, otherwise false.</returns>
+    public bool TryGetLoadedConfig([NotNullWhen(true)] out RuntimeConfig? runtimeConfig)
+    {
+        runtimeConfig = ConfigLoader.RuntimeConfig;
+        return ConfigLoader.RuntimeConfig is not null;
+    }
+
+    /// <summary>
+    /// Hot Reloads the runtime config when the file watcher
+    /// is active and detects a change to the underlying config file.
+    /// </summary>
+    public void HotReloadConfig()
+    {
+        ConfigLoader.TryLoadKnownConfig(out _, replaceEnvVar: true);
+    }
+}

--- a/src/Core/Configurations/RuntimeConfigValidator.cs
+++ b/src/Core/Configurations/RuntimeConfigValidator.cs
@@ -24,7 +24,7 @@ namespace Azure.DataApiBuilder.Core.Configurations;
 /// </summary>
 public class RuntimeConfigValidator : IConfigValidator
 {
-    private readonly RuntimeConfigProvider _runtimeConfigProvider;
+    private readonly IRuntimeConfigProvider _runtimeConfigProvider;
     private readonly IFileSystem _fileSystem;
     private readonly ILogger<RuntimeConfigValidator> _logger;
 
@@ -55,7 +55,7 @@ public class RuntimeConfigValidator : IConfigValidator
     public const string URI_COMPONENT_WITH_RESERVED_CHARS_ERR_MSG = "contains one or more reserved characters.";
 
     public RuntimeConfigValidator(
-        RuntimeConfigProvider runtimeConfigProvider,
+        IRuntimeConfigProvider runtimeConfigProvider,
         IFileSystem fileSystem,
         ILogger<RuntimeConfigValidator> logger,
         bool isValidateOnly = false)

--- a/src/Core/Models/GraphQLFilterParsers.cs
+++ b/src/Core/Models/GraphQLFilterParsers.cs
@@ -25,7 +25,7 @@ public class GQLFilterParser
 {
     public static readonly string NullStringValue = "NULL";
 
-    private readonly RuntimeConfigProvider _configProvider;
+    private readonly IRuntimeConfigProvider _configProvider;
     private readonly IMetadataProviderFactory _metadataProviderFactory;
 
     /// <summary>
@@ -33,7 +33,7 @@ public class GQLFilterParser
     /// </summary>
     /// <param name="runtimeConfigProvider">runtimeConfig provider</param>
     /// <param name="metadataProviderFactory">metadataProvider factory.</param>
-    public GQLFilterParser(RuntimeConfigProvider runtimeConfigProvider, IMetadataProviderFactory metadataProviderFactory)
+    public GQLFilterParser(IRuntimeConfigProvider runtimeConfigProvider, IMetadataProviderFactory metadataProviderFactory)
     {
         _configProvider = runtimeConfigProvider;
         _metadataProviderFactory = metadataProviderFactory;

--- a/src/Core/Parsers/IntrospectionInterceptor.cs
+++ b/src/Core/Parsers/IntrospectionInterceptor.cs
@@ -14,15 +14,15 @@ namespace Azure.DataApiBuilder.Core.Parsers
     /// </summary>
     public class IntrospectionInterceptor : DefaultHttpRequestInterceptor
     {
-        private RuntimeConfigProvider _runtimeConfigProvider;
+        private IRuntimeConfigProvider _runtimeConfigProvider;
 
         /// <summary>
-        /// Constructor injects RuntimeConfigProvider to allow
+        /// Constructor injects IRuntimeConfigProvider to allow
         /// HotChocolate to attempt to retrieve the runtime config
         /// when evaluating GraphQL requests.
         /// </summary>
         /// <param name="runtimeConfigProvider"></param>
-        public IntrospectionInterceptor(RuntimeConfigProvider runtimeConfigProvider)
+        public IntrospectionInterceptor(IRuntimeConfigProvider runtimeConfigProvider)
         {
             _runtimeConfigProvider = runtimeConfigProvider;
         }

--- a/src/Core/Resolvers/CosmosClientProvider.cs
+++ b/src/Core/Resolvers/CosmosClientProvider.cs
@@ -19,9 +19,9 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
         public Dictionary<string, CosmosClient?> Clients { get; private set; }
 
-        public RuntimeConfigProvider RuntimeConfigProvider;
+        public IRuntimeConfigProvider RuntimeConfigProvider;
 
-        public CosmosClientProvider(RuntimeConfigProvider runtimeConfigProvider)
+        public CosmosClientProvider(IRuntimeConfigProvider runtimeConfigProvider)
         {
             // This access token is coming from ConfigurationController parameter, that's why it's not in RuntimeConfig file.
             // On engine first start-up, access token will be null since ConfigurationController hasn't been called at that time.

--- a/src/Core/Resolvers/DbExceptionParser.cs
+++ b/src/Core/Resolvers/DbExceptionParser.cs
@@ -25,7 +25,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         protected HashSet<string> TransientExceptionCodes;
         protected HashSet<string> ConflictExceptionCodes;
 
-        public DbExceptionParser(RuntimeConfigProvider configProvider)
+        public DbExceptionParser(IRuntimeConfigProvider configProvider)
         {
             _developerMode = configProvider.GetConfig().IsDevelopmentMode();
             BadRequestExceptionCodes = new();

--- a/src/Core/Resolvers/Factories/MutationEngineFactory.cs
+++ b/src/Core/Resolvers/Factories/MutationEngineFactory.cs
@@ -31,7 +31,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers.Factories
         /// <param name="httpContextAccessor">httpContextAccessor.</param>
         /// <param name="authorizationResolver">authorizationResolver.</param>
         /// <param name="gQLFilterParser">GqlFilterParser.</param>
-        public MutationEngineFactory(RuntimeConfigProvider runtimeConfigProvider,
+        public MutationEngineFactory(IRuntimeConfigProvider runtimeConfigProvider,
             IAbstractQueryManagerFactory queryManagerFactory,
             IMetadataProviderFactory metadataProviderFactory,
             CosmosClientProvider cosmosClientProvider,

--- a/src/Core/Resolvers/Factories/QueryEngineFactory.cs
+++ b/src/Core/Resolvers/Factories/QueryEngineFactory.cs
@@ -22,7 +22,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers.Factories
         private readonly Dictionary<DatabaseType, IQueryEngine> _queryEngines;
 
         /// <inheritdoc/>
-        public QueryEngineFactory(RuntimeConfigProvider runtimeConfigProvider,
+        public QueryEngineFactory(IRuntimeConfigProvider runtimeConfigProvider,
             IAbstractQueryManagerFactory queryManagerFactory,
             IMetadataProviderFactory metadataProviderFactory,
             CosmosClientProvider cosmosClientProvider,

--- a/src/Core/Resolvers/Factories/QueryManagerFactory.cs
+++ b/src/Core/Resolvers/Factories/QueryManagerFactory.cs
@@ -26,7 +26,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers.Factories
         /// <param name="runtimeConfigProvider">runtimeconfigprovider.</param>
         /// <param name="logger">logger.</param>
         /// <param name="contextAccessor">httpcontextaccessor.</param>
-        public QueryManagerFactory(RuntimeConfigProvider runtimeConfigProvider, ILogger<IQueryExecutor> logger, IHttpContextAccessor contextAccessor)
+        public QueryManagerFactory(IRuntimeConfigProvider runtimeConfigProvider, ILogger<IQueryExecutor> logger, IHttpContextAccessor contextAccessor)
         {
             _queryBuilders = new Dictionary<DatabaseType, IQueryBuilder>();
             _queryExecutors = new Dictionary<DatabaseType, IQueryExecutor>();

--- a/src/Core/Resolvers/MsSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MsSqlDbExceptionParser.cs
@@ -14,7 +14,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
     /// </summary>
     public class MsSqlDbExceptionParser : DbExceptionParser
     {
-        public MsSqlDbExceptionParser(RuntimeConfigProvider configProvider) : base(configProvider)
+        public MsSqlDbExceptionParser(IRuntimeConfigProvider configProvider) : base(configProvider)
         {
             // HashSet of Error codes ('Number') which are to be considered as bad requests.
             BadRequestExceptionCodes.UnionWith(new List<string>

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -63,7 +63,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         private Dictionary<string, bool> _dataSourceToSessionContextUsage;
 
         public MsSqlQueryExecutor(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             DbExceptionParser dbExceptionParser,
             ILogger<IQueryExecutor> logger,
             IHttpContextAccessor httpContextAccessor)

--- a/src/Core/Resolvers/MySqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MySqlDbExceptionParser.cs
@@ -14,7 +14,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
     /// </summary>
     public class MySqlDbExceptionParser : DbExceptionParser
     {
-        public MySqlDbExceptionParser(RuntimeConfigProvider configProvider) : base(configProvider)
+        public MySqlDbExceptionParser(IRuntimeConfigProvider configProvider) : base(configProvider)
         {
             // HashSet of 'SqlState'(s) which are to be considered as bad requests.
             BadRequestExceptionCodes.UnionWith(new List<string>

--- a/src/Core/Resolvers/MySqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MySqlQueryExecutor.cs
@@ -52,7 +52,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         private Dictionary<string, bool> _dataSourceAccessTokenUsage;
 
         public MySqlQueryExecutor(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             DbExceptionParser dbExceptionParser,
             ILogger<IQueryExecutor> logger,
             IHttpContextAccessor httpContextAccessor)

--- a/src/Core/Resolvers/PostgreSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/PostgreSqlDbExceptionParser.cs
@@ -13,7 +13,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
     /// </summary>
     public class PostgreSqlDbExceptionParser : DbExceptionParser
     {
-        public PostgreSqlDbExceptionParser(RuntimeConfigProvider configProvider) : base(configProvider)
+        public PostgreSqlDbExceptionParser(IRuntimeConfigProvider configProvider) : base(configProvider)
         {
             // HashSet of 'SqlState'(s) to be considered as bad requests.
             BadRequestExceptionCodes.UnionWith(new List<string>

--- a/src/Core/Resolvers/PostgreSqlExecutor.cs
+++ b/src/Core/Resolvers/PostgreSqlExecutor.cs
@@ -53,7 +53,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         private Dictionary<string, bool> _dataSourceAccessTokenUsage;
 
         public PostgreSqlQueryExecutor(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             DbExceptionParser dbExceptionParser,
             ILogger<IQueryExecutor> logger,
             IHttpContextAccessor httpContextAccessor)

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -25,7 +25,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
     {
         protected DbExceptionParser DbExceptionParser { get; }
         protected ILogger<IQueryExecutor> QueryExecutorLogger { get; }
-        protected RuntimeConfigProvider ConfigProvider { get; }
+        protected IRuntimeConfigProvider ConfigProvider { get; }
         protected IHttpContextAccessor HttpContextAccessor { get; }
 
         // The maximum number of attempts that can be made to execute the query successfully in addition to the first attempt.
@@ -41,7 +41,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
         public QueryExecutor(DbExceptionParser dbExceptionParser,
                              ILogger<IQueryExecutor> logger,
-                             RuntimeConfigProvider configProvider,
+                             IRuntimeConfigProvider configProvider,
                              IHttpContextAccessor httpContextAccessor)
         {
             DbExceptionParser = dbExceptionParser;

--- a/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -95,7 +95,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             IDictionary<string, object?> queryParams,
             ISqlMetadataProvider sqlMetadataProvider,
             IAuthorizationResolver authorizationResolver,
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             GQLFilterParser gQLFilterParser)
             // This constructor simply forwards to the more general constructor
             // that is used to create GraphQL queries. We give it some values
@@ -129,7 +129,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             RestRequestContext context,
             ISqlMetadataProvider sqlMetadataProvider,
             IAuthorizationResolver authorizationResolver,
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             GQLFilterParser gQLFilterParser,
             HttpContext httpContext)
             : this(sqlMetadataProvider,
@@ -252,7 +252,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 IObjectField schemaField,
                 FieldNode? queryField,
                 IncrementingInteger counter,
-                RuntimeConfigProvider runtimeConfigProvider,
+                IRuntimeConfigProvider runtimeConfigProvider,
                 GQLFilterParser gQLFilterParser,
                 string entityName = "")
             : this(sqlMetadataProvider,
@@ -560,7 +560,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// takes place which is required to fetch nested data.
         /// </summary>
         /// <param name="selections">Fields selection in the GraphQL Query.</param>
-        private void AddGraphQLFields(IReadOnlyList<ISelectionNode> selections, RuntimeConfigProvider runtimeConfigProvider)
+        private void AddGraphQLFields(IReadOnlyList<ISelectionNode> selections, IRuntimeConfigProvider runtimeConfigProvider)
         {
             foreach (ISelectionNode node in selections)
             {

--- a/src/Core/Resolvers/SqlMutationEngine.cs
+++ b/src/Core/Resolvers/SqlMutationEngine.cs
@@ -38,7 +38,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         private readonly IAuthorizationResolver _authorizationResolver;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly GQLFilterParser _gQLFilterParser;
-        private readonly RuntimeConfigProvider _runtimeConfigProvider;
+        private readonly IRuntimeConfigProvider _runtimeConfigProvider;
         public const string IS_UPDATE_RESULT_SET = "IsUpdateResultSet";
         private const string TRANSACTION_EXCEPTION_ERROR_MSG = "An unexpected error occurred during the transaction execution";
 
@@ -56,7 +56,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             IAuthorizationResolver authorizationResolver,
             GQLFilterParser gQLFilterParser,
             IHttpContextAccessor httpContextAccessor,
-            RuntimeConfigProvider runtimeConfigProvider)
+            IRuntimeConfigProvider runtimeConfigProvider)
         {
             _queryManagerFactory = queryManagerFactory;
             _sqlMetadataProviderFactory = sqlMetadataProviderFactory;

--- a/src/Core/Resolvers/SqlPaginationUtil.cs
+++ b/src/Core/Resolvers/SqlPaginationUtil.cs
@@ -247,7 +247,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             PaginationMetadata paginationMetadata,
             ISqlMetadataProvider sqlMetadataProvider,
             string EntityName,
-            RuntimeConfigProvider runtimeConfigProvider)
+            IRuntimeConfigProvider runtimeConfigProvider)
         {
             if (queryParams.TryGetValue(QueryBuilder.PAGINATION_TOKEN_ARGUMENT_NAME, out object? continuationObject))
             {
@@ -275,7 +275,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             PaginationMetadata paginationMetadata,
             ISqlMetadataProvider sqlMetadataProvider,
             string entityName,
-            RuntimeConfigProvider runtimeConfigProvider
+            IRuntimeConfigProvider runtimeConfigProvider
             )
         {
             List<PaginationColumn>? paginationCursorColumnsForQuery = new();

--- a/src/Core/Resolvers/SqlQueryEngine.cs
+++ b/src/Core/Resolvers/SqlQueryEngine.cs
@@ -28,7 +28,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IAuthorizationResolver _authorizationResolver;
         private readonly ILogger<IQueryEngine> _logger;
-        private readonly RuntimeConfigProvider _runtimeConfigProvider;
+        private readonly IRuntimeConfigProvider _runtimeConfigProvider;
         private readonly GQLFilterParser _gQLFilterParser;
 
         // <summary>
@@ -41,7 +41,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             IAuthorizationResolver authorizationResolver,
             GQLFilterParser gQLFilterParser,
             ILogger<IQueryEngine> logger,
-            RuntimeConfigProvider runtimeConfigProvider)
+            IRuntimeConfigProvider runtimeConfigProvider)
         {
             _queryFactory = queryFactory;
             _sqlMetadataProviderFactory = sqlMetadataProviderFactory;

--- a/src/Core/Services/GraphQLSchemaCreator.cs
+++ b/src/Core/Services/GraphQLSchemaCreator.cs
@@ -38,7 +38,7 @@ namespace Azure.DataApiBuilder.Core.Services
         private readonly IMetadataProviderFactory _metadataProviderFactory;
         private readonly RuntimeEntities _entities;
         private readonly IAuthorizationResolver _authorizationResolver;
-        private readonly RuntimeConfigProvider _runtimeConfigProvider;
+        private readonly IRuntimeConfigProvider _runtimeConfigProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphQLSchemaCreator"/> class.
@@ -49,7 +49,7 @@ namespace Azure.DataApiBuilder.Core.Services
         /// <param name="metadataProviderFactory">MetadataProviderFactory to get metadata provider used when generating the SQL-based GraphQL schema. Ignored if the runtime is Cosmos.</param>
         /// <param name="authorizationResolver">Authorization information for the runtime, to be applied to the GraphQL schema.</param>
         public GraphQLSchemaCreator(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             IQueryEngineFactory queryEngineFactory,
             IMutationEngineFactory mutationEngineFactory,
             IMetadataProviderFactory metadataProviderFactory,

--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -36,7 +36,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
 
         public List<Exception> SqlMetadataExceptions { get; private set; } = new();
 
-        public CosmosSqlMetadataProvider(RuntimeConfigProvider runtimeConfigProvider, IFileSystem fileSystem)
+        public CosmosSqlMetadataProvider(IRuntimeConfigProvider runtimeConfigProvider, IFileSystem fileSystem)
         {
             _fileSystem = fileSystem;
             _runtimeConfig = runtimeConfigProvider.GetConfig();

--- a/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
+++ b/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
@@ -17,7 +17,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
         private readonly IDictionary<string, ISqlMetadataProvider> _metadataProviders;
 
         public MetadataProviderFactory(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             IAbstractQueryManagerFactory queryManagerFactory,
             ILogger<ISqlMetadataProvider> logger,
             IFileSystem fileSystem,

--- a/src/Core/Services/MetadataProviders/MsSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/MsSqlMetadataProvider.cs
@@ -29,7 +29,7 @@ namespace Azure.DataApiBuilder.Core.Services
         SqlMetadataProvider<SqlConnection, SqlDataAdapter, SqlCommand>
     {
         public MsSqlMetadataProvider(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             IAbstractQueryManagerFactory queryManagerFactory,
             ILogger<ISqlMetadataProvider> logger,
             string dataSourceName,

--- a/src/Core/Services/MetadataProviders/MySqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/MySqlMetadataProvider.cs
@@ -22,7 +22,7 @@ namespace Azure.DataApiBuilder.Core.Services
         private readonly string _databaseName = "mysql";
 
         public MySqlMetadataProvider(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             IAbstractQueryManagerFactory queryManagerFactory,
             ILogger<ISqlMetadataProvider> logger,
             string dataSourceName,

--- a/src/Core/Services/MetadataProviders/PostgreSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/PostgreSqlMetadataProvider.cs
@@ -21,7 +21,7 @@ namespace Azure.DataApiBuilder.Core.Services
     {
 
         public PostgreSqlMetadataProvider(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             IAbstractQueryManagerFactory queryManagerFactory,
             ILogger<ISqlMetadataProvider> logger,
             string dataSourceName,

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -58,7 +58,7 @@ namespace Azure.DataApiBuilder.Core.Services
 
         protected DataSet EntitiesDataSet { get; init; }
 
-        private RuntimeConfigProvider _runtimeConfigProvider;
+        private IRuntimeConfigProvider _runtimeConfigProvider;
 
         private Dictionary<string, Dictionary<string, string>> EntityBackingColumnsToExposedNames { get; } = new();
 
@@ -92,7 +92,7 @@ namespace Azure.DataApiBuilder.Core.Services
         }
 
         public SqlMetadataProvider(
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             IAbstractQueryManagerFactory engineFactory,
             ILogger<ISqlMetadataProvider> logger,
             string dataSourceName,

--- a/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
+++ b/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
@@ -61,7 +61,7 @@ namespace Azure.DataApiBuilder.Core.Services
         /// </summary>
         /// <param name="sqlMetadataProvider">Provides database object metadata.</param>
         /// <param name="runtimeConfigProvider">Provides entity/REST path metadata.</param>
-        public OpenApiDocumentor(IMetadataProviderFactory metadataProviderFactory, RuntimeConfigProvider runtimeConfigProvider)
+        public OpenApiDocumentor(IMetadataProviderFactory metadataProviderFactory, IRuntimeConfigProvider runtimeConfigProvider)
         {
             _metadataProviderFactory = metadataProviderFactory;
             _runtimeConfig = runtimeConfigProvider.GetConfig();
@@ -137,7 +137,7 @@ namespace Azure.DataApiBuilder.Core.Services
                     },
                     Servers = new List<OpenApiServer>
                     {
-                        new OpenApiServer { Url = url }
+                        new() { Url = url }
                     },
                     Paths = BuildPaths(),
                     Components = components

--- a/src/Core/Services/OpenAPI/SwaggerEndpointMapper.cs
+++ b/src/Core/Services/OpenAPI/SwaggerEndpointMapper.cs
@@ -15,14 +15,14 @@ namespace Azure.DataApiBuilder.Core.Services.OpenAPI
     /// </summary>
     public class SwaggerEndpointMapper : IEnumerable<UrlDescriptor>
     {
-        private readonly RuntimeConfigProvider? _runtimeConfigProvider;
+        private readonly IRuntimeConfigProvider? _runtimeConfigProvider;
 
         /// <summary>
         /// Constructor to setup required services
         /// </summary>
         /// <param name="runtimeConfigProvider">RuntimeConfigProvider contains the reference to the
         /// configured REST path. Will be empty during late bound config, so returns default REST path for SwaggerUI.</param>
-        public SwaggerEndpointMapper(RuntimeConfigProvider? runtimeConfigProvider)
+        public SwaggerEndpointMapper(IRuntimeConfigProvider? runtimeConfigProvider)
         {
             _runtimeConfigProvider = runtimeConfigProvider;
         }

--- a/src/Core/Services/PathRewriteMiddleware.cs
+++ b/src/Core/Services/PathRewriteMiddleware.cs
@@ -25,7 +25,7 @@ namespace Azure.DataApiBuilder.Core.Services
     public class PathRewriteMiddleware
     {
         private readonly RequestDelegate _nextMiddleware;
-        private readonly RuntimeConfigProvider _runtimeConfigurationProvider;
+        private readonly IRuntimeConfigProvider _runtimeConfigurationProvider;
 
         // Default configured GraphQL endpoint path used when
         // not defined or customized in runtime configuration.
@@ -36,7 +36,7 @@ namespace Azure.DataApiBuilder.Core.Services
         /// </summary>
         /// <param name="next">Reference to next middleware in the request pipeline.</param>
         /// <param name="runtimeConfigurationProvider">Runtime configuration provider.</param>
-        public PathRewriteMiddleware(RequestDelegate next, RuntimeConfigProvider runtimeConfigurationProvider)
+        public PathRewriteMiddleware(RequestDelegate next, IRuntimeConfigProvider runtimeConfigurationProvider)
         {
             _nextMiddleware = next;
             _runtimeConfigurationProvider = runtimeConfigurationProvider;

--- a/src/Core/Services/RequestValidator.cs
+++ b/src/Core/Services/RequestValidator.cs
@@ -24,9 +24,9 @@ namespace Azure.DataApiBuilder.Core.Services
         public const string PRIMARY_KEY_NOT_PROVIDED_ERR_MESSAGE = "Primary Key for this HTTP request type is required.";
 
         private readonly IMetadataProviderFactory _sqlMetadataProviderFactory;
-        private readonly RuntimeConfigProvider _runtimeConfigProvider;
+        private readonly IRuntimeConfigProvider _runtimeConfigProvider;
 
-        public RequestValidator(IMetadataProviderFactory sqlMetadataProviderFactory, RuntimeConfigProvider runtimeConfigProvider)
+        public RequestValidator(IMetadataProviderFactory sqlMetadataProviderFactory, IRuntimeConfigProvider runtimeConfigProvider)
         {
             _sqlMetadataProviderFactory = sqlMetadataProviderFactory;
             _runtimeConfigProvider = runtimeConfigProvider;

--- a/src/Core/Services/ResolverMiddleware.cs
+++ b/src/Core/Services/ResolverMiddleware.cs
@@ -32,12 +32,12 @@ namespace Azure.DataApiBuilder.Core.Services
         internal readonly FieldDelegate _next;
         internal readonly IQueryEngineFactory _queryEngineFactory;
         internal readonly IMutationEngineFactory _mutationEngineFactory;
-        internal readonly RuntimeConfigProvider _runtimeConfigProvider;
+        internal readonly IRuntimeConfigProvider _runtimeConfigProvider;
 
         public ResolverMiddleware(FieldDelegate next,
             IQueryEngineFactory queryEngineFactory,
             IMutationEngineFactory mutationEngineFactory,
-            RuntimeConfigProvider runtimeConfigProvider)
+            IRuntimeConfigProvider runtimeConfigProvider)
         {
             _next = next;
             _queryEngineFactory = queryEngineFactory;

--- a/src/Core/Services/RestService.cs
+++ b/src/Core/Services/RestService.cs
@@ -31,7 +31,7 @@ namespace Azure.DataApiBuilder.Core.Services
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IAuthorizationService _authorizationService;
         private readonly IMetadataProviderFactory _sqlMetadataProviderFactory;
-        private readonly RuntimeConfigProvider _runtimeConfigProvider;
+        private readonly IRuntimeConfigProvider _runtimeConfigProvider;
         private readonly RequestValidator _requestValidator;
 
         public RestService(
@@ -40,7 +40,7 @@ namespace Azure.DataApiBuilder.Core.Services
             IMetadataProviderFactory sqlMetadataProviderFactory,
             IHttpContextAccessor httpContextAccessor,
             IAuthorizationService authorizationService,
-            RuntimeConfigProvider runtimeConfigProvider,
+            IRuntimeConfigProvider runtimeConfigProvider,
             RequestValidator requestValidator
             )
         {

--- a/src/Service.Tests/Authentication/Helpers/WebHostBuilderHelper.cs
+++ b/src/Service.Tests/Authentication/Helpers/WebHostBuilderHelper.cs
@@ -42,7 +42,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication.Helpers
             // Setup RuntimeConfigProvider object for the pipeline.
             MockFileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider runtimeConfigProvider = new(loader);
+            LocalRuntimeConfigProvider runtimeConfigProvider = new(loader);
 
             return await new HostBuilder()
                 .ConfigureWebHost(webBuilder =>

--- a/src/Service.Tests/Authentication/JwtTokenAuthenticationUnitTests.cs
+++ b/src/Service.Tests/Authentication/JwtTokenAuthenticationUnitTests.cs
@@ -285,7 +285,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
             // Setup RuntimeConfigProvider object for the pipeline.
             MockFileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider runtimeConfigProvider = new(loader);
+            LocalRuntimeConfigProvider runtimeConfigProvider = new(loader);
 
             return await new HostBuilder()
                 .ConfigureWebHost(webBuilder =>

--- a/src/Service.Tests/Authorization/AuthorizationHelpers.cs
+++ b/src/Service.Tests/Authorization/AuthorizationHelpers.cs
@@ -39,7 +39,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Authorization
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new(runtimeConfig.ToJson()));
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
 
-            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GetRuntimeConfigProvider(loader);
+            IRuntimeConfigProvider runtimeConfigProvider = TestHelper.GetRuntimeConfigProvider(loader);
             Mock<ISqlMetadataProvider> metadataProvider = new();
             Mock<ILogger<AuthorizationResolver>> logger = new();
             SourceDefinition sampleTable = CreateSampleTable();

--- a/src/Service.Tests/Authorization/GraphQL/GraphQLMutationAuthorizationTests.cs
+++ b/src/Service.Tests/Authorization/GraphQL/GraphQLMutationAuthorizationTests.cs
@@ -116,7 +116,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Authorization.GraphQL
             MockFileSystem fileSystem = new();
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(string.Empty));
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            LocalRuntimeConfigProvider provider = new(loader);
             DefaultHttpContext context = new();
             Mock<IMetadataProviderFactory> _metadataProviderFactory = new();
             Mock<GQLFilterParser> _gQLFilterParser = new(provider, _metadataProviderFactory.Object);

--- a/src/Service.Tests/Authorization/SimulatorIntegrationTests.cs
+++ b/src/Service.Tests/Authorization/SimulatorIntegrationTests.cs
@@ -82,7 +82,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Authorization
 
             JsonElement actual = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
                 _client,
-                configProvider: _server.Services.GetRequiredService<RuntimeConfigProvider>(),
+                configProvider: _server.Services.GetRequiredService<IRuntimeConfigProvider>(),
                 query: graphQLQuery,
                 queryName: graphQLQueryName,
                 variables: null,
@@ -111,7 +111,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Authorization
         private static void SetupCustomRuntimeConfiguration()
         {
             TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
-            RuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
+            LocalRuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
             RuntimeConfig config = configProvider.GetConfig();
 
             AuthenticationOptions AuthenticationOptions = new(Provider: AuthenticationOptions.SIMULATOR_AUTHENTICATION, null);

--- a/src/Service.Tests/Configuration/AuthenticationConfigValidatorUnitTests.cs
+++ b/src/Service.Tests/Configuration/AuthenticationConfigValidatorUnitTests.cs
@@ -21,7 +21,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
         private MockFileSystem _mockFileSystem;
         private FileSystemRuntimeConfigLoader _runtimeConfigLoader;
-        private RuntimeConfigProvider _runtimeConfigProvider;
+        private IRuntimeConfigProvider _runtimeConfigProvider;
         private RuntimeConfigValidator _runtimeConfigValidator;
 
         [TestInitialize]
@@ -29,7 +29,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         {
             _mockFileSystem = new MockFileSystem();
             _runtimeConfigLoader = new FileSystemRuntimeConfigLoader(_mockFileSystem);
-            _runtimeConfigProvider = new RuntimeConfigProvider(_runtimeConfigLoader);
+            _runtimeConfigProvider = new LocalRuntimeConfigProvider(_runtimeConfigLoader);
             Mock<ILogger<RuntimeConfigValidator>> logger = new();
             _runtimeConfigValidator = new RuntimeConfigValidator(_runtimeConfigProvider, _mockFileSystem, logger.Object);
         }

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -648,7 +648,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
             JsonContent content = GetJsonContentForCosmosConfigRequest(configurationEndpoint);
 
-            RuntimeConfigProvider runtimeConfigProvider = server.Services.GetService<RuntimeConfigProvider>();
+            IRuntimeConfigProvider runtimeConfigProvider = server.Services.GetService<IRuntimeConfigProvider>();
             runtimeConfigProvider.RuntimeConfigLoadedHandlers.Add((_, _) =>
             {
                 return Task.FromResult(false);
@@ -670,7 +670,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
             JsonContent content = GetJsonContentForCosmosConfigRequest(configurationEndpoint);
 
-            RuntimeConfigProvider runtimeConfigProvider = server.Services.GetService<RuntimeConfigProvider>();
+            IRuntimeConfigProvider runtimeConfigProvider = server.Services.GetService<IRuntimeConfigProvider>();
             bool taskHasCompleted = false;
             runtimeConfigProvider.RuntimeConfigLoadedHandlers.Add(async (_, _) =>
             {
@@ -790,7 +790,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             HttpResponseMessage postResult = await httpClient.PostAsync(configurationEndpoint, content);
             Assert.AreEqual(HttpStatusCode.OK, postResult.StatusCode);
 
-            RuntimeConfigProvider configProvider = server.Services.GetService<RuntimeConfigProvider>();
+            IRuntimeConfigProvider configProvider = server.Services.GetService<IRuntimeConfigProvider>();
 
             Assert.IsNotNull(configProvider, "Configuration Provider shouldn't be null after setting the configuration at runtime.");
             Assert.IsTrue(configProvider.TryGetConfig(out RuntimeConfig configuration), "TryGetConfig should return true when the config is set.");
@@ -917,7 +917,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             Assert.AreEqual(HttpStatusCode.OK, postResult.StatusCode);
 
             ValidateCosmosDbSetup(server);
-            RuntimeConfigProvider configProvider = server.Services.GetService<RuntimeConfigProvider>();
+            IRuntimeConfigProvider configProvider = server.Services.GetService<IRuntimeConfigProvider>();
 
             Assert.IsNotNull(configProvider, "Configuration Provider shouldn't be null after setting the configuration at runtime.");
             Assert.IsTrue(configProvider.TryGetConfig(out RuntimeConfig configuration), "TryGetConfig should return true when the config is set.");
@@ -1048,7 +1048,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         {
             TestHelper.SetupDatabaseEnvironment(MSSQL_ENVIRONMENT);
             FileSystemRuntimeConfigLoader configPath = TestHelper.GetRuntimeConfigLoader();
-            RuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(configPath);
+            IRuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(configPath);
 
             Mock<ILogger<RuntimeConfigValidator>> configValidatorLogger = new();
             RuntimeConfigValidator configValidator =
@@ -1069,7 +1069,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         {
             TestHelper.SetupDatabaseEnvironment(MSSQL_ENVIRONMENT);
             FileSystemRuntimeConfigLoader configPath = TestHelper.GetRuntimeConfigLoader();
-            RuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(configPath);
+            IRuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(configPath);
 
             Mock<ILogger<RuntimeConfigValidator>> configValidatorLogger = new();
             ILoggerFactory mockLoggerFactory = TestHelper.ProvisionLoggerFactory();
@@ -1135,7 +1135,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
             FileSystemRuntimeConfigLoader configLoader = TestHelper.GetRuntimeConfigLoader();
             configLoader.UpdateConfigFilePath(CUSTOM_CONFIG);
-            RuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(configLoader);
+            IRuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(configLoader);
 
             Mock<ILogger<RuntimeConfigValidator>> configValidatorLogger = new();
             RuntimeConfigValidator configValidator =
@@ -1789,7 +1789,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
                     JsonElement mutationResponse = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
                         client,
-                        server.Services.GetRequiredService<RuntimeConfigProvider>(),
+                        server.Services.GetRequiredService<IRuntimeConfigProvider>(),
                         query: graphQLMutation,
                         queryName: "createStock",
                         variables: null,
@@ -1827,7 +1827,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
                     _ = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
                         client,
-                        server.Services.GetRequiredService<RuntimeConfigProvider>(),
+                        server.Services.GetRequiredService<IRuntimeConfigProvider>(),
                         query: deleteMutation,
                         queryName: "deleteStock",
                         variables: null,
@@ -1914,7 +1914,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
                     JsonElement mutationResponse = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
                         client,
-                        server.Services.GetRequiredService<RuntimeConfigProvider>(),
+                        server.Services.GetRequiredService<IRuntimeConfigProvider>(),
                         query: graphQLMutation,
                         queryName: "createStock",
                         variables: null,
@@ -1939,7 +1939,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
                     _ = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
                         client,
-                        server.Services.GetRequiredService<RuntimeConfigProvider>(),
+                        server.Services.GetRequiredService<IRuntimeConfigProvider>(),
                         query: deleteMutation,
                         queryName: "deleteStock",
                         variables: null,
@@ -1960,7 +1960,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         {
             JsonElement queryResponse = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
                                                 client,
-                                                server.Services.GetRequiredService<RuntimeConfigProvider>(),
+                                                server.Services.GetRequiredService<IRuntimeConfigProvider>(),
                                                 query: query,
                                                 queryName: queryName,
                                                 variables: null,
@@ -2349,7 +2349,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             FileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
 
-            RuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(loader);
+            IRuntimeConfigProvider configProvider = TestHelper.GetRuntimeConfigProvider(loader);
             RuntimeConfig config = configProvider.GetConfig();
 
             // Setup configuration
@@ -2775,7 +2775,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
             try
             {
-                RuntimeConfigProvider configProvider = server.Services.GetRequiredService<RuntimeConfigProvider>();
+                IRuntimeConfigProvider configProvider = server.Services.GetRequiredService<IRuntimeConfigProvider>();
 
                 JsonElement actual = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
                     client,

--- a/src/Service.Tests/Configuration/LoadConfigViaEndpoint.cs
+++ b/src/Service.Tests/Configuration/LoadConfigViaEndpoint.cs
@@ -33,7 +33,7 @@ public class LoadConfigViaEndpointTests
             await httpClient.PostAsync(configurationEndpoint, content);
         Assert.AreEqual(HttpStatusCode.OK, postResult.StatusCode);
 
-        RuntimeConfigProvider configProvider = server.Services.GetService(typeof(RuntimeConfigProvider)) as RuntimeConfigProvider;
+        LocalRuntimeConfigProvider configProvider = server.Services.GetService(typeof(IRuntimeConfigProvider)) as LocalRuntimeConfigProvider;
         RuntimeConfig loadedConfig = configProvider.GetConfig();
 
         Assert.AreEqual(config.Schema, loadedConfig.Schema);
@@ -55,7 +55,7 @@ public class LoadConfigViaEndpointTests
             await httpClient.PostAsync(configurationEndpoint, content);
         Assert.AreEqual(HttpStatusCode.OK, postResult.StatusCode);
 
-        RuntimeConfigProvider configProvider = server.Services.GetService(typeof(RuntimeConfigProvider)) as RuntimeConfigProvider;
+        LocalRuntimeConfigProvider configProvider = server.Services.GetService(typeof(IRuntimeConfigProvider)) as LocalRuntimeConfigProvider;
         RuntimeConfig loadedConfig = configProvider.GetConfig();
 
         Assert.AreNotEqual(config.Schema, loadedConfig.Schema);

--- a/src/Service.Tests/CosmosTests/TestBase.cs
+++ b/src/Service.Tests/CosmosTests/TestBase.cs
@@ -123,7 +123,7 @@ type Sun @model(name:""Sun"") {
             { FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(updatedConfig.ToJson()) }
         });
         FileSystemRuntimeConfigLoader loader = new(fileSystem);
-        RuntimeConfigProvider provider = new(loader);
+        LocalRuntimeConfigProvider provider = new(loader);
 
         ISqlMetadataProvider cosmosSqlMetadataProvider = new CosmosSqlMetadataProvider(provider, fileSystem);
         Mock<IMetadataProviderFactory> metadataProviderFactory = new();
@@ -182,7 +182,7 @@ type Sun @model(name:""Sun"") {
     /// <returns></returns>
     internal Task<JsonElement> ExecuteGraphQLRequestAsync(string queryName, string query, Dictionary<string, object> variables = null, string authToken = null, string clientRoleHeader = null)
     {
-        RuntimeConfigProvider configProvider = _application.Services.GetService<RuntimeConfigProvider>();
+        IRuntimeConfigProvider configProvider = _application.Services.GetService<IRuntimeConfigProvider>();
         return GraphQLRequestExecutor.PostGraphQLRequestAsync(_client, configProvider, queryName, query, variables, authToken, clientRoleHeader);
     }
 

--- a/src/Service.Tests/GraphQLBuilder/MultiSourceBuilderTests.cs
+++ b/src/Service.Tests/GraphQLBuilder/MultiSourceBuilderTests.cs
@@ -44,7 +44,7 @@ namespace Azure.DataApiBuilder.Service.Tests.GraphQLBuilder
 
             FileSystemRuntimeConfigLoader loader = new(fs);
 
-            RuntimeConfigProvider provider = new(loader);
+            LocalRuntimeConfigProvider provider = new(loader);
 
             Mock<IAbstractQueryManagerFactory> queryManagerfactory = new();
             Mock<IQueryEngineFactory> queryEngineFactory = new();

--- a/src/Service.Tests/GraphQLRequestExecutor.cs
+++ b/src/Service.Tests/GraphQLRequestExecutor.cs
@@ -27,7 +27,7 @@ namespace Azure.DataApiBuilder.Service.Tests
         /// <returns>JsonResult</returns>
         public static async Task<JsonElement> PostGraphQLRequestAsync(
             HttpClient client,
-            RuntimeConfigProvider configProvider,
+            IRuntimeConfigProvider configProvider,
             string queryName,
             string query,
             Dictionary<string, object> variables = null,

--- a/src/Service.Tests/SqlTests/SqlTestBase.cs
+++ b/src/Service.Tests/SqlTests/SqlTestBase.cs
@@ -103,7 +103,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests
             runtimeConfig = AddCustomEntities(customEntities, runtimeConfig);
 
             // Generate in memory runtime config provider that uses the config that we have modified
-            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
+            LocalRuntimeConfigProvider runtimeConfigProvider = (LocalRuntimeConfigProvider)TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
 
             _queryEngineLogger = new Mock<ILogger<IQueryEngine>>().Object;
             _mutationEngineLogger = new Mock<ILogger<SqlMutationEngine>>().Object;
@@ -243,7 +243,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests
             }
         }
 
-        protected static void SetUpSQLMetadataProvider(RuntimeConfigProvider runtimeConfigProvider)
+        protected static void SetUpSQLMetadataProvider(IRuntimeConfigProvider runtimeConfigProvider)
         {
             _sqlMetadataLogger = new Mock<ILogger<ISqlMetadataProvider>>().Object;
             _queryManagerFactory = new Mock<IAbstractQueryManagerFactory>();
@@ -580,7 +580,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests
             string clientRoleHeader = null,
             bool expectsError = false)
         {
-            RuntimeConfigProvider configProvider = _application.Services.GetService<RuntimeConfigProvider>();
+            IRuntimeConfigProvider configProvider = _application.Services.GetService<IRuntimeConfigProvider>();
             return await GraphQLRequestExecutor.PostGraphQLRequestAsync(
                 HttpClient,
                 configProvider,

--- a/src/Service.Tests/SqlTests/SqlTestHelper.cs
+++ b/src/Service.Tests/SqlTests/SqlTestHelper.cs
@@ -266,7 +266,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests
         public static RuntimeConfig SetupRuntimeConfig()
         {
             FileSystemRuntimeConfigLoader configPath = TestHelper.GetRuntimeConfigLoader();
-            RuntimeConfigProvider provider = new(configPath);
+            LocalRuntimeConfigProvider provider = new(configPath);
 
             return provider.GetConfig();
         }

--- a/src/Service.Tests/TestHelper.cs
+++ b/src/Service.Tests/TestHelper.cs
@@ -53,9 +53,9 @@ namespace Azure.DataApiBuilder.Service.Tests
         /// </summary>
         /// <param name="loader"></param>
         /// <returns></returns>
-        public static RuntimeConfigProvider GetRuntimeConfigProvider(FileSystemRuntimeConfigLoader loader)
+        public static LocalRuntimeConfigProvider GetRuntimeConfigProvider(FileSystemRuntimeConfigLoader loader)
         {
-            RuntimeConfigProvider runtimeConfigProvider = new(loader);
+            LocalRuntimeConfigProvider runtimeConfigProvider = new(loader);
 
             // Only set IsLateConfigured for MsSQL for now to do certificate validation.
             // For Pg/MySQL databases, set this after SSL connections are enabled for testing.
@@ -194,12 +194,12 @@ namespace Azure.DataApiBuilder.Service.Tests
             ""entities"": {}" +
           "}";
 
-        public static RuntimeConfigProvider GenerateInMemoryRuntimeConfigProvider(RuntimeConfig runtimeConfig)
+        public static IRuntimeConfigProvider GenerateInMemoryRuntimeConfigProvider(RuntimeConfig runtimeConfig)
         {
             MockFileSystem fileSystem = new();
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, runtimeConfig.ToJson());
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider runtimeConfigProvider = new(loader);
+            IRuntimeConfigProvider runtimeConfigProvider = new LocalRuntimeConfigProvider(loader);
             return runtimeConfigProvider;
         }
 
@@ -214,7 +214,7 @@ namespace Azure.DataApiBuilder.Service.Tests
         public static void ConstructNewConfigWithSpecifiedHostMode(string configFileName, HostMode hostModeType, string databaseType, string runtimeBaseRoute = "/")
         {
             SetupDatabaseEnvironment(databaseType);
-            RuntimeConfigProvider configProvider = GetRuntimeConfigProvider(GetRuntimeConfigLoader());
+            LocalRuntimeConfigProvider configProvider = GetRuntimeConfigProvider(GetRuntimeConfigLoader());
             RuntimeConfig config = configProvider.GetConfig();
 
             RuntimeConfig configWithCustomHostMode =

--- a/src/Service.Tests/Unittests/ConfigFileWatcherUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigFileWatcherUnitTests.cs
@@ -117,7 +117,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
             FileSystem fileSystem = new();
             fileSystem.File.WriteAllText(configName, initialConfig);
             FileSystemRuntimeConfigLoader configLoader = new(fileSystem, configName, string.Empty);
-            RuntimeConfigProvider configProvider = new(configLoader);
+            LocalRuntimeConfigProvider configProvider = new(configLoader);
             // Must GetConfig() to start file watching
             RuntimeConfig runtimeConfig = configProvider.GetConfig();
             // assert we have a valid config

--- a/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
@@ -380,7 +380,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             // Mocking EntityToDatabaseObject
             MockFileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader) { IsLateConfigured = true };
+            LocalRuntimeConfigProvider provider = new(loader) { IsLateConfigured = true };
             RuntimeConfigValidator configValidator = new(provider, fileSystem, new Mock<ILogger<RuntimeConfigValidator>>().Object);
             Mock<ISqlMetadataProvider> _sqlMetadataProvider = new();
 
@@ -489,7 +489,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             // Mocking EntityToDatabaseObject
             MockFileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader) { IsLateConfigured = true };
+            LocalRuntimeConfigProvider provider = new(loader) { IsLateConfigured = true };
             RuntimeConfigValidator configValidator = new(provider, fileSystem, new Mock<ILogger<RuntimeConfigValidator>>().Object);
             Mock<ISqlMetadataProvider> _sqlMetadataProvider = new();
 
@@ -582,7 +582,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             MockFileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader) { IsLateConfigured = true };
+            LocalRuntimeConfigProvider provider = new(loader) { IsLateConfigured = true };
             RuntimeConfigValidator configValidator = new(provider, fileSystem, new Mock<ILogger<RuntimeConfigValidator>>().Object);
             Mock<ISqlMetadataProvider> _sqlMetadataProvider = new();
 
@@ -1767,7 +1767,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             RuntimeConfigLoader.TryParseConfig(runtimeConfigString, out RuntimeConfig runtimeConfig);
             MockFileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            LocalRuntimeConfigProvider provider = new(loader);
             RuntimeConfigValidator configValidator = new(provider, fileSystem, new Mock<ILogger<RuntimeConfigValidator>>().Object);
 
             // Perform validation on the permissions in the config and assert the expected results.
@@ -1826,7 +1826,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             MockFileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            LocalRuntimeConfigProvider provider = new(loader);
             Mock<ILogger<RuntimeConfigValidator>> loggerMock = new();
             RuntimeConfigValidator configValidator = new(provider, fileSystem, loggerMock.Object);
 
@@ -2183,7 +2183,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             MockFileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            LocalRuntimeConfigProvider provider = new(loader);
             return new(provider, fileSystem, new Mock<ILogger<RuntimeConfigValidator>>().Object);
         }
     }

--- a/src/Service.Tests/Unittests/DbExceptionParserUnitTests.cs
+++ b/src/Service.Tests/Unittests/DbExceptionParserUnitTests.cs
@@ -47,7 +47,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             MockFileSystem fileSystem = new();
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(mockConfig.ToJson()));
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            LocalRuntimeConfigProvider provider = new(loader);
 
             Mock<DbExceptionParser> parser = new(provider);
             DbException e = SqlTestHelper.CreateSqlException(connectionEstablishmentError, expected);
@@ -81,7 +81,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             MockFileSystem fileSystem = new();
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(mockConfig.ToJson()));
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            LocalRuntimeConfigProvider provider = new(loader);
             DbExceptionParser dbExceptionParser = new MsSqlDbExceptionParser(provider);
 
             Assert.AreEqual(expected, dbExceptionParser.IsTransientException(SqlTestHelper.CreateSqlException(number)));

--- a/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
+++ b/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
@@ -118,9 +118,9 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
             Mock<IMutationEngineFactory> mutationEngineFactory = new();
 
             Mock<RuntimeConfigLoader> mockLoader = new(null);
-            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig1, It.IsAny<bool>())).Returns(true);
+            mockLoader.Object.RuntimeConfig = mockConfig1;
 
-            RuntimeConfigProvider provider = new(mockLoader.Object);
+            LocalRuntimeConfigProvider provider = new(mockLoader.Object);
 
             // Using a sample schema file to test multi-source query.
             // Schema file contains some sample entities that we can test against.
@@ -193,9 +193,9 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
                );
 
             Mock<RuntimeConfigLoader> mockLoader = new(null);
-            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig, It.IsAny<bool>())).Returns(true);
+            mockLoader.Object.RuntimeConfig = mockConfig;
 
-            RuntimeConfigProvider provider = new(mockLoader.Object);
+            LocalRuntimeConfigProvider provider = new(mockLoader.Object);
             provider.TryGetConfig(out RuntimeConfig _);
             provider.TrySetAccesstoken(db1AccessToken, dataSourceName1);
             provider.TrySetAccesstoken(db2AccessToken, dataSourceName2);

--- a/src/Service.Tests/Unittests/MySqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/MySqlQueryExecutorUnitTests.cs
@@ -54,7 +54,10 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             MockFileSystem fileSystem = new();
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(mockConfig.ToJson()));
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            HostedRuntimeConfigProvider provider = new(loader)
+            {
+                _runtimeConfig = mockConfig
+            };
             Mock<DbExceptionParser> dbExceptionParser = new(provider);
             Mock<ILogger<MySqlQueryExecutor>> queryExecutorLogger = new();
             Mock<IHttpContextAccessor> httpContextAccessor = new();

--- a/src/Service.Tests/Unittests/ODataASTVisitorUnitTests.cs
+++ b/src/Service.Tests/Unittests/ODataASTVisitorUnitTests.cs
@@ -356,7 +356,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 Name = tableName
             };
             FindRequestContext context = new(entityName, dbo, isList);
-            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
+            LocalRuntimeConfigProvider runtimeConfigProvider = TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
             AuthorizationResolver authorizationResolver = new(
                 runtimeConfigProvider,
                 _metadataProviderFactory.Object);

--- a/src/Service.Tests/Unittests/PostgreSqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/PostgreSqlQueryExecutorUnitTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Resolvers;
@@ -62,7 +63,11 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                Entities: new(new Dictionary<string, Entity>())
             );
 
-            RuntimeConfigProvider provider = TestHelper.GenerateInMemoryRuntimeConfigProvider(mockConfig);
+            Mock<RuntimeConfigLoader> mockLoader = new(null);
+            HostedRuntimeConfigProvider provider = new(mockLoader.Object)
+            {
+                _runtimeConfig = mockConfig
+            };//(HostedRuntimeConfigProvider)TestHelper.GenerateInMemoryRuntimeConfigProvider(mockConfig);
             Mock<DbExceptionParser> dbExceptionParser = new(provider);
             Mock<ILogger<PostgreSqlQueryExecutor>> queryExecutorLogger = new();
             Mock<IHttpContextAccessor> httpContextAccessor = new();

--- a/src/Service.Tests/Unittests/RequestValidatorUnitTests.cs
+++ b/src/Service.Tests/Unittests/RequestValidatorUnitTests.cs
@@ -366,7 +366,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 MockFileSystem fileSystem = new();
                 fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(mockConfig.ToJson()));
                 FileSystemRuntimeConfigLoader loader = new(fileSystem);
-                RuntimeConfigProvider provider = new(loader);
+                LocalRuntimeConfigProvider provider = new(loader);
                 Mock<IMetadataProviderFactory> metadataProviderFactory = new();
                 metadataProviderFactory.Setup(x => x.GetMetadataProvider(It.IsAny<String>())).Returns(_mockMetadataStore.Object);
                 RequestValidator requestValidator = new(metadataProviderFactory.Object, provider);

--- a/src/Service.Tests/Unittests/RestServiceUnitTests.cs
+++ b/src/Service.Tests/Unittests/RestServiceUnitTests.cs
@@ -121,7 +121,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             MockFileSystem fileSystem = new();
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(mockConfig.ToJson()));
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            LocalRuntimeConfigProvider provider = new(loader);
             MsSqlQueryBuilder queryBuilder = new();
             Mock<DbExceptionParser> dbExceptionParser = new(provider);
             Mock<ILogger<QueryExecutor<SqlConnection>>> queryExecutorLogger = new();

--- a/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlMetadataProviderUnitTests.cs
@@ -63,7 +63,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             TestHelper.SetupDatabaseEnvironment(DatabaseEngine);
             RuntimeConfig runtimeConfig = SqlTestHelper.SetupRuntimeConfig();
             SqlTestHelper.RemoveAllRelationshipBetweenEntities(runtimeConfig);
-            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
+            LocalRuntimeConfigProvider runtimeConfigProvider = (LocalRuntimeConfigProvider)TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
             SetUpSQLMetadataProvider(runtimeConfigProvider);
             await ResetDbStateAsync();
             await _sqlMetadataProvider.InitializeAsync();
@@ -110,7 +110,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
             RuntimeConfig baseConfigFromDisk = SqlTestHelper.SetupRuntimeConfig();
-            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(baseConfigFromDisk);
+            LocalRuntimeConfigProvider runtimeConfigProvider = (LocalRuntimeConfigProvider)TestHelper.GenerateInMemoryRuntimeConfigProvider(baseConfigFromDisk);
 
             ILogger<ISqlMetadataProvider> sqlMetadataLogger = new Mock<ILogger<ISqlMetadataProvider>>().Object;
             Mock<IQueryExecutor> queryExecutor = new();
@@ -174,7 +174,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             RuntimeConfig baseConfigFromDisk = SqlTestHelper.SetupRuntimeConfig();
 
             RuntimeConfig runtimeConfig = baseConfigFromDisk with { DataSource = baseConfigFromDisk.DataSource with { ConnectionString = connectionString } };
-            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
+            LocalRuntimeConfigProvider runtimeConfigProvider = (LocalRuntimeConfigProvider)TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
             ILogger<ISqlMetadataProvider> sqlMetadataLogger = new Mock<ILogger<ISqlMetadataProvider>>().Object;
 
             try
@@ -222,7 +222,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             DatabaseEngine = TestCategory.MSSQL;
             TestHelper.SetupDatabaseEnvironment(DatabaseEngine);
             RuntimeConfig runtimeConfig = SqlTestHelper.SetupRuntimeConfig();
-            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
+            LocalRuntimeConfigProvider runtimeConfigProvider = (LocalRuntimeConfigProvider)TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
             SetUpSQLMetadataProvider(runtimeConfigProvider);
 
             await _sqlMetadataProvider.InitializeAsync();
@@ -252,7 +252,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 DatabaseEngine = TestCategory.MSSQL;
                 TestHelper.SetupDatabaseEnvironment(DatabaseEngine);
                 RuntimeConfig runtimeConfig = SqlTestHelper.SetupRuntimeConfig();
-                RuntimeConfigProvider runtimeConfigProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
+                LocalRuntimeConfigProvider runtimeConfigProvider = (LocalRuntimeConfigProvider)TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
                 SetUpSQLMetadataProvider(runtimeConfigProvider);
                 ((MsSqlMetadataProvider)_sqlMetadataProvider).ValidateEntityAndGraphQLPathUniqueness(path: entityPath, graphQLGlobalPath: graphQLConfigPath);
                 if (expectsError)

--- a/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
@@ -81,7 +81,10 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             MockFileSystem fileSystem = new();
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(mockConfig.ToJson()));
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader);
+            HostedRuntimeConfigProvider provider = new(loader)
+            {
+                _runtimeConfig = mockConfig
+            };
             Mock<DbExceptionParser> dbExceptionParser = new(provider);
             Mock<ILogger<MsSqlQueryExecutor>> queryExecutorLogger = new();
             Mock<IHttpContextAccessor> httpContextAccessor = new();
@@ -155,7 +158,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             MockFileSystem fileSystem = new();
             fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(mockConfig.ToJson()));
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader)
+            LocalRuntimeConfigProvider provider = new(loader)
             {
                 IsLateConfigured = true
             };
@@ -215,7 +218,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
             FileSystem fileSystem = new();
             FileSystemRuntimeConfigLoader loader = new(fileSystem);
-            RuntimeConfigProvider provider = new(loader) { IsLateConfigured = true };
+            LocalRuntimeConfigProvider provider = new(loader) { IsLateConfigured = true };
             Mock<ILogger<QueryExecutor<SqlConnection>>> queryExecutorLogger = new();
             Mock<IHttpContextAccessor> httpContextAccessor = new();
             DbExceptionParser dbExceptionParser = new MsSqlDbExceptionParser(provider);

--- a/src/Service/Controllers/ConfigurationController.cs
+++ b/src/Service/Controllers/ConfigurationController.cs
@@ -15,10 +15,10 @@ namespace Azure.DataApiBuilder.Service.Controllers
     [Route("[controller]")]
     public class ConfigurationController : Controller
     {
-        RuntimeConfigProvider _configurationProvider;
+        HostedRuntimeConfigProvider _configurationProvider;
         private readonly ILogger<ConfigurationController> _logger;
 
-        public ConfigurationController(RuntimeConfigProvider configurationProvider, ILogger<ConfigurationController> logger)
+        public ConfigurationController(HostedRuntimeConfigProvider configurationProvider, ILogger<ConfigurationController> logger)
         {
             _configurationProvider = configurationProvider;
             _logger = logger;

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -79,7 +79,7 @@ namespace Azure.DataApiBuilder.Service
                 null);
             IFileSystem fileSystem = new FileSystem();
             FileSystemRuntimeConfigLoader configLoader = new(fileSystem, configFileName, connectionString);
-            LocalRuntimeConfigProvider configProvider = new(configLoader);
+            IRuntimeConfigProvider configProvider = new LocalRuntimeConfigProvider(configLoader);
 
             services.AddSingleton(fileSystem);
             services.AddSingleton(configProvider);

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -79,7 +79,7 @@ namespace Azure.DataApiBuilder.Service
                 null);
             IFileSystem fileSystem = new FileSystem();
             FileSystemRuntimeConfigLoader configLoader = new(fileSystem, configFileName, connectionString);
-            RuntimeConfigProvider configProvider = new(configLoader);
+            LocalRuntimeConfigProvider configProvider = new(configLoader);
 
             services.AddSingleton(fileSystem);
             services.AddSingleton(configProvider);
@@ -234,7 +234,7 @@ namespace Azure.DataApiBuilder.Service
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, RuntimeConfigProvider runtimeConfigProvider, IHostApplicationLifetime hostLifetime)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IRuntimeConfigProvider runtimeConfigProvider, IHostApplicationLifetime hostLifetime)
         {
             bool isRuntimeReady = false;
             FileSystemRuntimeConfigLoader fileSystemRuntimeConfigLoader = (FileSystemRuntimeConfigLoader)runtimeConfigProvider.ConfigLoader;
@@ -292,7 +292,7 @@ namespace Azure.DataApiBuilder.Service
             {
                 app.UseSwaggerUI(c =>
                 {
-                    c.ConfigObject.Urls = new SwaggerEndpointMapper(app.ApplicationServices.GetService<RuntimeConfigProvider?>());
+                    c.ConfigObject.Urls = new SwaggerEndpointMapper(app.ApplicationServices.GetService<IRuntimeConfigProvider?>());
                 });
             }
 
@@ -403,7 +403,7 @@ namespace Azure.DataApiBuilder.Service
                 // attempt to get the runtime config to determine the loglevel based on host.mode.
                 // If runtime config is available, set the loglevel to Error if host.mode is Production,
                 // Debug if it is Development.
-                RuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<RuntimeConfigProvider>();
+                IRuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<IRuntimeConfigProvider>();
                 if (configProvider.TryGetConfig(out RuntimeConfig? runtimeConfig))
                 {
                     MinimumLogLevel = GetLogLevelBasedOnMode(runtimeConfig);
@@ -424,7 +424,7 @@ namespace Azure.DataApiBuilder.Service
         /// </summary>
         /// <param name="services">The service collection where authentication services are added.</param>
         /// <param name="runtimeConfigurationProvider">The provider used to load runtime configuration.</param>
-        private void ConfigureAuthentication(IServiceCollection services, RuntimeConfigProvider runtimeConfigurationProvider)
+        private void ConfigureAuthentication(IServiceCollection services, IRuntimeConfigProvider runtimeConfigurationProvider)
         {
             if (runtimeConfigurationProvider.TryGetConfig(out RuntimeConfig? runtimeConfig) &&
                 runtimeConfig.Runtime?.Host?.Authentication is not null)
@@ -562,7 +562,7 @@ namespace Azure.DataApiBuilder.Service
         {
             try
             {
-                RuntimeConfigProvider runtimeConfigProvider = app.ApplicationServices.GetService<RuntimeConfigProvider>()!;
+                IRuntimeConfigProvider runtimeConfigProvider = app.ApplicationServices.GetService<IRuntimeConfigProvider>()!;
                 RuntimeConfig runtimeConfig = runtimeConfigProvider.GetConfig();
 
                 RuntimeConfigValidator runtimeConfigValidator = app.ApplicationServices.GetService<RuntimeConfigValidator>()!;


### PR DESCRIPTION
## Why make this change?

-  Related to https://github.com/Azure/data-api-builder/issues/67
- Closes to https://github.com/Azure/data-api-builder/issues/1966
- Closes to https://github.com/Azure/data-api-builder/issues/1967

In order to better facilitate Hot Reload, we need to split the responsibility for loading and accessing the `RuntimeConfig` between the two different scenarios that our service can run within, local and hosted. We already have a `FileSystemRuntimeConfigLoader` which handles the loading of the config from a local file system. This refactor naturally extends that approach so that we can Hot Reload both in the local and eventually, the hosted scenario.

We also make some necessary changes for hot reloading to work within the service.

## What is this change?

As a part of the changes, we split the RuntimeConfigProvider into a `LocalRuntimeConfigProvider` and a `HostedRuntimeConfigProvider`. These classes then implement the `IRuntimeConfigProvider` interface in the way that makes sense for their scenario.

Rather than having these providers storing the internal copy of the `RuntimeConfig`, the natural approach is for the loaders to be responsible for maintaining this internal representation, and for the loaders to handle all of the loading, including any hot reloading that takes place for that `RuntimeConfig`.

This was previously not possible, because we could not store a copy of the `RuntimeConfig` with the loader due to circular dependency. This refactor removes that issue as part of its changes. We then move the internally stored `RuntimeConfig` to these loaders, as well as all of the logic for Hot Reloading. Since we are only handling Hot Reloading in the local scenario to being, we only have the loader for the local scenario currently setup to do this. When we extend Hot Reloading to the hosted scenario, that will mean adding a loader that can handle that specific logic in a hosted scenario.

We also change the way that the default data source names are generated so that this is deterministic. This is a requirement to pass validation during time of handling requests. In this case we are taking a hash of the connection string, though this means to hot reload the connection string we will need a new approach.


Within the tests, there was an attempt to use the `LocalRuntimeConfigProvider` when possible, since testing is naturally happening in a local scenario. However, some tests utilize functions that are only relevant for the `HostedRuntimeConfigProvider` and so in those cases, we used that class. This created some issues, and workarounds were found for these tests.

## How was this tested?

Current test suite.

## Sample Request(s)

Any valid request.
