### PR TITLE
[CherryPick] Upgrade dependencies, pipeline tasks, pipeline variables #1970 #1955 #1928 #1954

### DIFF
--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -38,7 +38,7 @@ steps:
       Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
       Start-CosmosDbEmulator
 
-- task: NuGetAuthenticate@0
+- task: NuGetAuthenticate@1
   displayName: 'NuGet Authenticate'
 
 - task: UseDotNet@2

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       data-source.connection-string: ''
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2
@@ -158,7 +158,7 @@ jobs:
     inputs:
       script: 'echo ##vso[task.setvariable variable=publishverify]Yes'
 
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -147,7 +147,7 @@ jobs:
       # since windows needs a different string.
       # The variable setting on the pipeline UI sets the connection string
       # for the linux job above.
-      data-source.connection-string: $(ConnectionStringLocalDBVariable)
+      data-source.connection-string: Server=(localdb)\MSSQLLocalDB;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;TrustServerCertificate=True;
       InstallerUrl: https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SqlLocalDB.msi
       SqlVersionCode: '15.0'
 

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       data-source.connection-string: ''
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2
@@ -161,7 +161,7 @@ jobs:
     inputs:
       script: 'echo ##vso[task.setvariable variable=publishverify]Yes'
 
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -3,7 +3,7 @@
 
 # MsSql Integration Testing Pipeline config is split into two jobs:
 # 1) LinuxTests -> Run SQL Server 2019 in Linux Docker Image
-# 2) WindowsTests -> Run LocalDB preinstalled on
+# 2) WindowsTests -> Run LocalDB preinstalled on machine
 
 trigger:
   batch: true
@@ -24,6 +24,8 @@ jobs:
       solution: '**/*.sln'
       buildPlatform: 'Any CPU'
       buildConfiguration: 'Release'
+      dbPassword: ''
+      data-source.connection-string: ''
 
   steps:
   - task: NuGetAuthenticate@0
@@ -51,11 +53,30 @@ jobs:
       releaseType: stable
 
   - task: Bash@3
+    displayName: 'Generate password'
+    inputs:
+      targetType: 'inline'
+      script: |
+        password=$(cat /dev/urandom | tr -dc 'A-Za-z0-9' | head -c24)
+        echo "##vso[task.setvariable variable=dbPassword;]$password"
+  
+  - task: PowerShell@2
+    displayName: 'Set Connection String'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $connectionString="Server=tcp:127.0.0.1,1433;Persist Security Info=False;User ID=SA;Password=$(dbPassword);MultipleActiveResultSets=False;Connection Timeout=5;TrustServerCertificate=True;Encrypt=False;"
+        Write-Host "##vso[task.setvariable variable=data-source.connection-string]$connectionString"
+
+  - task: Bash@3
     condition: eq( variables['Agent.OS'], 'Linux' )
     displayName: Get and Start Ubuntu SQL Server Image Docker with SSL enabled
     inputs:
-      filePath: scripts/start-mssql-server.bash
-      arguments: $(DockerSQLPass)
+      targetType: 'inline'
+      script: |
+        echo "Executing script with arguments."
+        chmod +x ./scripts/start-mssql-server.bash
+        ./scripts/start-mssql-server.bash $(dbPassword)
 
   - task: DotNetCoreCLI@2
     displayName: Build
@@ -129,7 +150,7 @@ jobs:
       # since windows needs a different string.
       # The variable setting on the pipeline UI sets the connection string
       # for the linux job above.
-      data-source.connection-string: $(ConnectionStringLocalDBVariable)
+      data-source.connection-string: Server=(localdb)\MSSQLLocalDB;Persist Security Info=False;Integrated Security=True;MultipleActiveResultSets=False;Connection Timeout=5;TrustServerCertificate=True;
       InstallerUrl: https://download.microsoft.com/download/7/c/1/7c14e92e-bdcb-4f89-b7cf-93543e7112d1/SqlLocalDB.msi
       SqlVersionCode: '15.0'
 

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
       buildConfiguration: 'Release'
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
       buildConfiguration: 'Release'
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - task: UseDotNet@2

--- a/.pipelines/templates/static-tools.yml
+++ b/.pipelines/templates/static-tools.yml
@@ -14,7 +14,7 @@ jobs:
     vmImage: '${{ parameters.VmImage }}'
 
   steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     displayName: 'NuGet Authenticate'
 
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found

--- a/src/Auth/Azure.DataApiBuilder.Auth.csproj
+++ b/src/Auth/Azure.DataApiBuilder.Auth.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Cli.Tests/Cli.Tests.csproj
+++ b/src/Cli.Tests/Cli.Tests.csproj
@@ -6,6 +6,7 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <OutputPath>$(BaseOutputPath)\tests</OutputPath>
+        <NoWarn>NU1603</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -28,6 +28,7 @@
     </Dependencies>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Config/Azure.DataApiBuilder.Config.csproj
+++ b/src/Config/Azure.DataApiBuilder.Config.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
@@ -18,6 +19,8 @@
       <PackageReference Include="System.IO.Abstractions" />
       <PackageReference Include="System.Drawing.Common" />
       <PackageReference Include="Microsoft.Data.SqlClient" />
+      <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
       <PackageReference Include="StyleCop.Analyzers">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,17 +17,18 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="6.0.14" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.26" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.14" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.14" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.20.0" />
     <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.35.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageVersion Include="Microsoft.OData.Edm" Version="7.12.5" />
     <PackageVersion Include="Microsoft.OData.Core" Version="7.12.5" />
@@ -45,6 +46,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <PackageVersion Include="System.IO.Abstractions" Version="19.2.29" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="19.2.29" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />

--- a/src/Product/Azure.DataApiBuilder.Product.csproj
+++ b/src/Product/Azure.DataApiBuilder.Product.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
+++ b/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
+++ b/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <OutputPath>$(BaseOutputPath)\tests</OutputPath>
+    <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -2862,7 +2862,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
         private static string GenerateMockJwtToken()
         {
-            string mySecret = "PlaceholderPlaceholder";
+            string mySecret = "PlaceholderPlaceholderPlaceholder";
             SymmetricSecurityKey mySecurityKey = new(Encoding.ASCII.GetBytes(mySecret));
 
             JwtSecurityTokenHandler tokenHandler = new();

--- a/src/Service/Azure.DataApiBuilder.Service.csproj
+++ b/src/Service/Azure.DataApiBuilder.Service.csproj
@@ -6,6 +6,7 @@
         <OutputPath>$(BaseOutputPath)\engine</OutputPath>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <NoWarn>NU1603</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
@@ -28,7 +29,7 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Docker|AnyCPU'">
-      <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
#1970 #1955 #1928 #1954

Updates dependencies:
- Microsoft.AspNetCore.Authentication.JwtBearer
- Microsoft.Data.SqlClient
- Microsoft.IdentityModel.JsonWebTokens
- System.IdentityModel.Tokens.Jwt

Update pipeline task:
- `NuGetAuthenticate@0` to `NuGetAuthenticate@1`
- LocalDB connection string default set instead of depending on private env_var.
- Auto generate db passwords and append to connection strings during each pipeline run

Other changes to support the changes above:
- Suppress NU1603 warning as error for all projects
- Update ConfigurationTests jwt token creation to handle breaking changes in newer versions of Jwt* dependencies.

All related to pipeline updates that are required for 0.10 stable.