### PR TITLE
Adding In-Memory cache support for CosmosDB

### DIFF
--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -374,7 +374,7 @@ public record RuntimeConfig
     public bool CanUseCache()
     {
         bool setSessionContextEnabled = DataSource.GetTypedOptions<MsSqlOptions>()?.SetSessionContext ?? true;
-        return IsCachingEnabled && (SqlDataSourceUsed || CosmosDataSourceUsed) && !setSessionContextEnabled;
+        return IsCachingEnabled && !setSessionContextEnabled;
     }
 
     /// <summary>

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -374,7 +374,7 @@ public record RuntimeConfig
     public bool CanUseCache()
     {
         bool setSessionContextEnabled = DataSource.GetTypedOptions<MsSqlOptions>()?.SetSessionContext ?? true;
-        return IsCachingEnabled && SqlDataSourceUsed && !setSessionContextEnabled;
+        return IsCachingEnabled && (SqlDataSourceUsed || CosmosDataSourceUsed) && !setSessionContextEnabled;
     }
 
     /// <summary>

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -121,12 +121,12 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <summary>
         /// ExecuteQueryAsync Performs single parition and cross partition queries. 
         /// </summary>
-        /// <param name="structure"></param>
-        /// <param name="querySpec"></param>
-        /// <param name="queryRequestOptions"></param>
-        /// <param name="container"></param>
-        /// <param name="idValue"></param>
-        /// <param name="partitionKeyValue"></param>
+        /// <param name="structure">CosmosQueryStructure</param>
+        /// <param name="querySpec">QueryDefinition Define a Cosmos SQL Query</param>
+        /// <param name="queryRequestOptions">The Cosmos query request options</param>
+        /// <param name="container">CosmosDB Container</param>
+        /// <param name="idValue">Id param</param>
+        /// <param name="partitionKeyValue">PartitionKey Value</param>
         /// <returns>JObject</returns>
         private static async Task<JObject> ExecuteQueryAsync(CosmosQueryStructure structure, QueryDefinition querySpec, QueryRequestOptions queryRequestOptions, Container container, string idValue, string partitionKeyValue)
         {

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -119,7 +119,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         }
 
         /// <summary>
-        /// ExecuteQueryAsync Performs single parition and cross partition queries. 
+        /// ExecuteQueryAsync Performs single partition and cross partition queries. 
         /// </summary>
         /// <param name="structure">CosmosQueryStructure</param>
         /// <param name="querySpec">QueryDefinition Define a Cosmos SQL Query</param>

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -1,7 +1,7 @@
-    // Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-# nullable disable
+#nullable disable
 using System.Text;
 using System.Text.Json;
 using Azure.DataApiBuilder.Auth;

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -107,7 +107,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
                 DatabaseQueryMetadata queryMetadata = new(queryText: queryString, dataSource: dataSourceKey.ToString(), queryParameters: structure.Parameters);
 
-                executeQueryResult = await _cache.GetOrSetAsync<JObject>(async () => await ExecuteQueryAsync(structure, querySpec, queryRequestOptions, container, idValue, partitionKeyValue), queryMetadata, 10);//runtimeConfig.GetEntityCacheEntryTtl(entityName: structure.EntityName));
+                executeQueryResult = await _cache.GetOrSetAsync<JObject>(async () => await ExecuteQueryAsync(structure, querySpec, queryRequestOptions, container, idValue, partitionKeyValue), queryMetadata, runtimeConfig.GetEntityCacheEntryTtl(entityName: structure.EntityName));
             }
             else
             {

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -63,7 +63,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             IDictionary<string, object> parameters,
             string dataSourceName)
         {
-            // TODO: fixme we have multiple rounds of serialization/deserialization JsomDocument/JObject
             // TODO: add support for join query against another container
             // TODO: add support for TOP and Order-by push-down
 
@@ -120,7 +119,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         }
 
         /// <summary>
-        /// ExecuteQueryAsync Perform single parition and cross partition query. 
+        /// ExecuteQueryAsync Performs single parition and cross partition queries. 
         /// </summary>
         /// <param name="structure"></param>
         /// <param name="querySpec"></param>
@@ -128,7 +127,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="container"></param>
         /// <param name="idValue"></param>
         /// <param name="partitionKeyValue"></param>
-        /// <returns>JsonDocument</returns>
+        /// <returns>JObject</returns>
         private static async Task<JObject> ExecuteQueryAsync(CosmosQueryStructure structure, QueryDefinition querySpec, QueryRequestOptions queryRequestOptions, Container container, string idValue, string partitionKeyValue)
         {
             string requestContinuation = null;

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -92,7 +92,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
             JObject executeQueryResult = null;
 
-            if (runtimeConfig.CanUseCache())
+            if (runtimeConfig.CanUseCache() && runtimeConfig.Entities[structure.EntityName].IsCachingEnabled)
             {
                 StringBuilder dataSourceKey = new(dataSourceName);
 

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -122,7 +122,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// ExecuteQueryAsync Performs single partition and cross partition queries. 
         /// </summary>
         /// <param name="structure">CosmosQueryStructure</param>
-        /// <param name="querySpec">QueryDefinition Define a Cosmos SQL Query</param>
+        /// <param name="querySpec">QueryDefinition defining a Cosmos SQL Query</param>
         /// <param name="queryRequestOptions">The Cosmos query request options</param>
         /// <param name="container">CosmosDB Container</param>
         /// <param name="idValue">Id param</param>

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -96,13 +96,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 StringBuilder dataSourceKey = new(dataSourceName);
 
                 // to support caching for paginated query adding continuation token in the datasource
-                if (structure.IsPaginated)
-                {
-                    dataSourceKey.Append(":");
-                    dataSourceKey.Append(structure.IsPaginated);
-                    dataSourceKey.Append(":");
-                    dataSourceKey.Append(structure.Continuation);
-                }
+                dataSourceKey.Append(":");
+                dataSourceKey.Append(structure.Continuation);
 
                 DatabaseQueryMetadata queryMetadata = new(queryText: queryString, dataSource: dataSourceKey.ToString(), queryParameters: structure.Parameters);
 

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -128,7 +128,13 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="idValue">Id param</param>
         /// <param name="partitionKeyValue">PartitionKey Value</param>
         /// <returns>JObject</returns>
-        private static async Task<JObject> ExecuteQueryAsync(CosmosQueryStructure structure, QueryDefinition querySpec, QueryRequestOptions queryRequestOptions, Container container, string idValue, string partitionKeyValue)
+        private static async Task<JObject> ExecuteQueryAsync(
+            CosmosQueryStructure structure,
+            QueryDefinition querySpec,
+            QueryRequestOptions queryRequestOptions,
+            Container container,
+            string idValue,
+            string partitionKeyValue)
         {
             string requestContinuation = null;
             if (structure.IsPaginated)

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+    // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 # nullable disable
@@ -173,7 +173,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             new JProperty(QueryBuilder.HAS_NEXT_PAGE_FIELD_NAME, responseContinuation != null),
                             new JProperty(QueryBuilder.PAGINATION_FIELD_NAME, jarray));
 
-                        // This extra deserialize/serialization will be removed after moving to Newtonsoft from System.Text.Json
                         return res;
                     }
 

--- a/src/Core/Resolvers/Factories/QueryEngineFactory.cs
+++ b/src/Core/Resolvers/Factories/QueryEngineFactory.cs
@@ -49,7 +49,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers.Factories
 
             if (config.CosmosDataSourceUsed)
             {
-                IQueryEngine queryEngine = new CosmosQueryEngine(cosmosClientProvider, metadataProviderFactory, authorizationResolver, gQLFilterParser);
+                IQueryEngine queryEngine = new CosmosQueryEngine(cosmosClientProvider, metadataProviderFactory, authorizationResolver, gQLFilterParser, runtimeConfigProvider, cache);
                 _queryEngines.Add(DatabaseType.CosmosDB_NoSQL, queryEngine);
             }
 

--- a/src/Core/Services/Cache/DabCacheService.cs
+++ b/src/Core/Services/Cache/DabCacheService.cs
@@ -79,7 +79,16 @@ public class DabCacheService
         return result;
     }
 
-    public async ValueTask<TResult?> GetOrSetAsync2<TResult>(Func<Task<TResult>> executeQueryAsync, DatabaseQueryMetadata queryMetadata, int cacheEntryTtl)
+    /// <summary>
+    /// Attempts to fetch response from cache. If there is a cache miss, invoke executeQueryAsync Func to get a response
+    /// </summary>
+    /// <typeparam name="TResult">Response payload Type</typeparam>
+    /// <param name="executeQueryAsync">Func with a result of type TResult. Only executed after a cache miss.</param>
+    /// <param name="queryMetadata">Metadata used to create a cache key or fetch a response from the database.</param>
+    /// <param name="cacheEntryTtl">Number of seconds the cache entry should be valid before eviction.</param>
+    /// <returns>JSON Response</returns>
+    /// <exception cref="Exception">Throws when the cache-miss factory method execution fails.</exception>
+    public async ValueTask<TResult?> GetOrSetAsync<TResult>(Func<Task<TResult>> executeQueryAsync, DatabaseQueryMetadata queryMetadata, int cacheEntryTtl)
     {
         string cacheKey = CreateCacheKey(queryMetadata);
         TResult? result = await _cache.GetOrSetAsync(
@@ -96,7 +105,6 @@ public class DabCacheService
                });
 
         return result;
-
     }
 
     /// <summary>

--- a/src/Core/Services/Cache/DabCacheService.cs
+++ b/src/Core/Services/Cache/DabCacheService.cs
@@ -7,7 +7,6 @@ using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Resolvers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using ZiggyCreatures.Caching.Fusion;
 
 namespace Azure.DataApiBuilder.Core.Services.Cache;
@@ -90,6 +89,7 @@ public class DabCacheService
     /// <exception cref="Exception">Throws when the cache-miss factory method execution fails.</exception>
     public async ValueTask<TResult?> GetOrSetAsync<TResult>(Func<Task<TResult>> executeQueryAsync, DatabaseQueryMetadata queryMetadata, int cacheEntryTtl)
     {
+
         string cacheKey = CreateCacheKey(queryMetadata);
         TResult? result = await _cache.GetOrSetAsync(
                key: cacheKey,
@@ -97,7 +97,7 @@ public class DabCacheService
                {
                    TResult result = await executeQueryAsync();
 
-                   ctx.Options.SetSize(EstimateCacheEntrySize(cacheKey: cacheKey, cacheValue: JsonSerializer.Serialize(result)));
+                   ctx.Options.SetSize(EstimateCacheEntrySize(cacheKey: cacheKey, cacheValue: JsonSerializer.Serialize(result?.ToString())));
                    ctx.Options.SetDuration(duration: TimeSpan.FromSeconds(cacheEntryTtl));
 
                    return result;

--- a/src/Core/Services/Cache/DabCacheService.cs
+++ b/src/Core/Services/Cache/DabCacheService.cs
@@ -111,6 +111,10 @@ public class DabCacheService
     /// Creates a cache key using the request metadata resolved from a built SqlQueryStructure
     /// Format: DataSourceName:QueryText:JSON_QueryParameters
     /// Example: 7a07f92a-1aa2-4e2a-81d6-b9af0a25bbb6:select * from MyTable where id = @param1 = :{"@param1":{"Value":"42","DbType":null}}
+    /// Format CosmosDB: DataSourceName:IsPaginated:ContinuationToken:QueryText:JSON_QueryParameters
+    /// IsPaginated and ContinuationToken are optional and will be present only for paginated queries
+    /// Example without Pagination : 11bbfedb-df1d-47ad-ac2c-8dfeecc5f1a1:SELECT c.id, c.name FROM c:{}
+    /// Example with Pagination: 11bbfedb-df1d-47ad-ac2c-8dfeecc5f1a1:True:W3sidG9rZW4iOiItUklEOn56dG9NQUxQaGhpWUZBQUFBQUFBQUFBPT0jUlQ6MSNUUkM6NSNJU1Y6MiNJRU86NjU1NjcjUUNGOjgiLCJyYW5nZSI6eyJtaW4iOiIiLCJtYXgiOiJGRiJ9fV0=:SELECT c.id, c.name FROM c:{}
     /// </summary>
     /// <returns>Cache key string</returns>
     private string CreateCacheKey(DatabaseQueryMetadata queryMetadata)

--- a/src/Core/Services/Cache/DabCacheService.cs
+++ b/src/Core/Services/Cache/DabCacheService.cs
@@ -111,10 +111,10 @@ public class DabCacheService
     /// Creates a cache key using the request metadata resolved from a built SqlQueryStructure
     /// Format: DataSourceName:QueryText:JSON_QueryParameters
     /// Example: 7a07f92a-1aa2-4e2a-81d6-b9af0a25bbb6:select * from MyTable where id = @param1 = :{"@param1":{"Value":"42","DbType":null}}
-    /// Format CosmosDB: DataSourceName:IsPaginated:ContinuationToken:QueryText:JSON_QueryParameters
+    /// Format CosmosDB: DataSourceName:ContinuationToken:QueryText:JSON_QueryParameters
     /// IsPaginated and ContinuationToken are optional and will be present only for paginated queries
     /// Example without Pagination : 11bbfedb-df1d-47ad-ac2c-8dfeecc5f1a1:SELECT c.id, c.name FROM c:{}
-    /// Example with Pagination: 11bbfedb-df1d-47ad-ac2c-8dfeecc5f1a1:True:W3sidG9rZW4iOiItUklEOn56dG9NQUxQaGhpWUZBQUFBQUFBQUFBPT0jUlQ6MSNUUkM6NSNJU1Y6MiNJRU86NjU1NjcjUUNGOjgiLCJyYW5nZSI6eyJtaW4iOiIiLCJtYXgiOiJGRiJ9fV0=:SELECT c.id, c.name FROM c:{}
+    /// Example with Pagination: 11bbfedb-df1d-47ad-ac2c-8dfeecc5f1a1:W3sidG9rZW4iOiItUklEOn56dG9NQUxQaGhpWUZBQUFBQUFBQUFBPT0jUlQ6MSNUUkM6NSNJU1Y6MiNJRU86NjU1NjcjUUNGOjgiLCJyYW5nZSI6eyJtaW4iOiIiLCJtYXgiOiJGRiJ9fV0=:SELECT c.id, c.name FROM c:{}
     /// </summary>
     /// <returns>Cache key string</returns>
     private string CreateCacheKey(DatabaseQueryMetadata queryMetadata)

--- a/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
+++ b/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
@@ -261,12 +261,11 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
         [TestMethod]
         public async Task FirstCacheServiceInvocationCallsFuncAndReturnResult()
         {
-            // Arrange
             using FusionCache cache = CreateFusionCache(sizeLimit: 1000, defaultEntryTtlSeconds: 1);
             JObject expectedDatabaseResponse = JObject.Parse(@"{""key"": ""value""}");
 
             Mock<Func<Task<JObject>>> mockExecuteQuery = new();
-            mockExecuteQuery.Setup(e => e.Invoke()).Returns( Task.FromResult(expectedDatabaseResponse));
+            mockExecuteQuery.Setup(e => e.Invoke()).Returns(Task.FromResult(expectedDatabaseResponse));
 
             Dictionary<string, DbConnectionParam> parameters = new()
             {
@@ -320,7 +319,6 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
             // Validates that the expected database response is returned by the cache service.
             Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
 
-          
             // Assert
             Assert.IsFalse(mockExecuteQuery.Invocations.Count is 2, message: "Expected a cache hit, but observed two cache misses.");
             Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);

--- a/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
+++ b/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
@@ -256,7 +256,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
         /// Validates that the first invocation of the cache service results in a cache miss because
         /// the cache is expected to be empty.
         /// After a cache miss, Func invocation is expected.
-        /// Func is references the method which will execute DB query
+        /// Func is referencing the method which will execute DB query
         /// </summary>
         [TestMethod]
         public async Task FirstCacheServiceInvocationCallsFuncAndReturnResult()

--- a/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
+++ b/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
@@ -349,7 +349,6 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
 
             int cacheEntryTtl = 1;
 
-            // Act
             // First call. Cache miss
             _ = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
             _ = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);

--- a/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
+++ b/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
@@ -261,6 +261,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
         [TestMethod]
         public async Task FirstCacheServiceInvocationCallsFuncAndReturnResult()
         {
+            // Arrange
             using FusionCache cache = CreateFusionCache(sizeLimit: 1000, defaultEntryTtlSeconds: 1);
             JObject expectedDatabaseResponse = JObject.Parse(@"{""key"": ""value""}");
 
@@ -293,6 +294,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
         [TestMethod]
         public async Task SecondCacheServiceInvocation_CacheHit_NoFuncInvocation()
         {
+            // Arrange
             using FusionCache cache = CreateFusionCache(sizeLimit: 1000, defaultEntryTtlSeconds: 1);
             JObject expectedDatabaseResponse = JObject.Parse(@"{""key"": ""value""}");
 
@@ -311,17 +313,16 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
             // First call. Cache miss
             _ = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
 
+            // Act
             JObject? result = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
 
             // Assert
             Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);
-
-            // Validates that the expected database response is returned by the cache service.
-            Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
-
-            // Assert
             Assert.IsFalse(mockExecuteQuery.Invocations.Count is 2, message: "Expected a cache hit, but observed two cache misses.");
             Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);
+            Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
+
+            // Validates that the expected database response is returned by the cache service.
             Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
         }
 
@@ -334,6 +335,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
         [TestMethod]
         public async Task ThirdCacheServiceInvocation_CacheHit_NoFuncInvocation()
         {
+            // Arrange
             using FusionCache cache = CreateFusionCache(sizeLimit: 1000, defaultEntryTtlSeconds: 1);
             JObject expectedDatabaseResponse = JObject.Parse(@"{""key"": ""value""}");
 
@@ -349,6 +351,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
             DabCacheService dabCache = CreateDabCacheService(cache);
 
             int cacheEntryTtl = 1;
+
+            // Act
             // First call. Cache miss
             _ = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
             _ = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
@@ -356,6 +360,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
             // Sleep for the amount of time the cache entry is valid to trigger eviction.
             Thread.Sleep(millisecondsTimeout: cacheEntryTtl * 1000);
 
+            // Act
             JObject? result = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
 
             // Assert

--- a/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
+++ b/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
@@ -318,7 +318,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
 
             // Assert
             Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);
-            Assert.IsFalse(mockExecuteQuery.Invocations.Count is 2, message: "Expected a cache hit, but observed two cache misses.");
+            Assert.IsFalse(mockExecuteQuery.Invocations.Count > 1, message: "Expected a cache hit, but observed cache misses.");
             Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);
             Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
         }

--- a/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
+++ b/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
@@ -321,9 +321,6 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
             Assert.IsFalse(mockExecuteQuery.Invocations.Count is 2, message: "Expected a cache hit, but observed two cache misses.");
             Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);
             Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
-
-            // Validates that the expected database response is returned by the cache service.
-            Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
         }
 
         // Validates that the provided cacheEntryOptions are honored by checking the number of Func Invocations within.
@@ -364,9 +361,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
             JObject? result = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
 
             // Assert
-            Assert.IsFalse(mockExecuteQuery.Invocations.Count is 1, message: "QueryExecutor invocation count too low. A cache hit shouldn't have occurred since the entry should have expired.");
-            Assert.IsFalse(mockExecuteQuery.Invocations.Count is 3, message: "Unexpected cache misses. The cache entry was never used as the factory method was called on every cache access attempt.");
-            Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 2, message: ERROR_UNEXPECTED_INVOCATIONS);
+            Assert.IsFalse(mockExecuteQuery.Invocations.Count < 2, message: "QueryExecutor invocation count too low. A cache hit shouldn't have occurred since the entry should have expired.");
+            Assert.IsFalse(mockExecuteQuery.Invocations.Count > 2, message: "Unexpected cache misses. The cache entry was never used as the factory method was called on every cache access attempt.");
             Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
         }
 

--- a/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
+++ b/src/Service.Tests/Caching/DabCacheServiceIntegrationTests.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json.Linq;
 using ZiggyCreatures.Caching.Fusion;
 
 namespace Azure.DataApiBuilder.Service.Tests.Caching
@@ -249,6 +250,121 @@ namespace Azure.DataApiBuilder.Service.Tests.Caching
             await Assert.ThrowsExceptionAsync<DataApiBuilderException>(
                 async () => await dabCache.GetOrSetAsync<JsonElement?>(queryExecutor: mockQueryExecutor.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl),
                 message: "Expected an exception to be thrown.");
+        }
+
+        /// <summary>
+        /// Validates that the first invocation of the cache service results in a cache miss because
+        /// the cache is expected to be empty.
+        /// After a cache miss, Func invocation is expected.
+        /// Func is references the method which will execute DB query
+        /// </summary>
+        [TestMethod]
+        public async Task FirstCacheServiceInvocationCallsFuncAndReturnResult()
+        {
+            // Arrange
+            using FusionCache cache = CreateFusionCache(sizeLimit: 1000, defaultEntryTtlSeconds: 1);
+            JObject expectedDatabaseResponse = JObject.Parse(@"{""key"": ""value""}");
+
+            Mock<Func<Task<JObject>>> mockExecuteQuery = new();
+            mockExecuteQuery.Setup(e => e.Invoke()).Returns( Task.FromResult(expectedDatabaseResponse));
+
+            Dictionary<string, DbConnectionParam> parameters = new()
+            {
+                {"param1", new DbConnectionParam(value: "param1Value") }
+            };
+
+            DatabaseQueryMetadata queryMetadata = new(queryText: "select c.name from c", dataSource: "dataSource1", queryParameters: parameters);
+            DabCacheService dabCache = CreateDabCacheService(cache);
+
+            // Act
+            int cacheEntryTtl = 1;
+            JObject? result = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
+
+            // Assert
+            Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);
+
+            // Validates that the expected database response is returned by the cache service.
+            Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
+        }
+
+        /// <summary>
+        /// Validates that a cache hit occurs when the same request is submitted before the cache entry expires.
+        /// Validates that DabCacheService.CreateCacheKey(..) outputs the same key given constant input.
+        /// </summary>
+        [TestMethod]
+        public async Task SecondCacheServiceInvocation_CacheHit_NoFuncInvocation()
+        {
+            using FusionCache cache = CreateFusionCache(sizeLimit: 1000, defaultEntryTtlSeconds: 1);
+            JObject expectedDatabaseResponse = JObject.Parse(@"{""key"": ""value""}");
+
+            Mock<Func<Task<JObject>>> mockExecuteQuery = new();
+            mockExecuteQuery.Setup(e => e.Invoke()).Returns(Task.FromResult(expectedDatabaseResponse));
+
+            Dictionary<string, DbConnectionParam> parameters = new()
+            {
+                {"param1", new DbConnectionParam(value: "param1Value") }
+            };
+
+            DatabaseQueryMetadata queryMetadata = new(queryText: "select c.name from c", dataSource: "dataSource1", queryParameters: parameters);
+            DabCacheService dabCache = CreateDabCacheService(cache);
+
+            int cacheEntryTtl = 1;
+            // First call. Cache miss
+            _ = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
+
+            JObject? result = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
+
+            // Assert
+            Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);
+
+            // Validates that the expected database response is returned by the cache service.
+            Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
+
+          
+            // Assert
+            Assert.IsFalse(mockExecuteQuery.Invocations.Count is 2, message: "Expected a cache hit, but observed two cache misses.");
+            Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 1, message: ERROR_UNEXPECTED_INVOCATIONS);
+            Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
+        }
+
+        // Validates that the provided cacheEntryOptions are honored by checking the number of Func Invocations within.
+        // CacheService.GetOrSetAsync(...)
+        // 1st Invocation: Invoke func and save result to cache
+        // 2nd Invocation: Return result from cache.
+        // (1 second pause)
+        // 3rd Invocation: Invoke func since cache entry evicted.
+        [TestMethod]
+        public async Task ThirdCacheServiceInvocation_CacheHit_NoFuncInvocation()
+        {
+            using FusionCache cache = CreateFusionCache(sizeLimit: 1000, defaultEntryTtlSeconds: 1);
+            JObject expectedDatabaseResponse = JObject.Parse(@"{""key"": ""value""}");
+
+            Mock<Func<Task<JObject>>> mockExecuteQuery = new();
+            mockExecuteQuery.Setup(e => e.Invoke()).Returns(Task.FromResult(expectedDatabaseResponse));
+
+            Dictionary<string, DbConnectionParam> parameters = new()
+            {
+                {"param1", new DbConnectionParam(value: "param1Value") }
+            };
+
+            DatabaseQueryMetadata queryMetadata = new(queryText: "select c.name from c", dataSource: "dataSource1", queryParameters: parameters);
+            DabCacheService dabCache = CreateDabCacheService(cache);
+
+            int cacheEntryTtl = 1;
+            // First call. Cache miss
+            _ = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
+            _ = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
+
+            // Sleep for the amount of time the cache entry is valid to trigger eviction.
+            Thread.Sleep(millisecondsTimeout: cacheEntryTtl * 1000);
+
+            JObject? result = await dabCache.GetOrSetAsync<JObject>(executeQueryAsync: mockExecuteQuery.Object, queryMetadata: queryMetadata, cacheEntryTtl: cacheEntryTtl);
+
+            // Assert
+            Assert.IsFalse(mockExecuteQuery.Invocations.Count is 1, message: "QueryExecutor invocation count too low. A cache hit shouldn't have occurred since the entry should have expired.");
+            Assert.IsFalse(mockExecuteQuery.Invocations.Count is 3, message: "Unexpected cache misses. The cache entry was never used as the factory method was called on every cache access attempt.");
+            Assert.AreEqual(expected: true, actual: mockExecuteQuery.Invocations.Count is 2, message: ERROR_UNEXPECTED_INVOCATIONS);
+            Assert.AreEqual(expected: expectedDatabaseResponse, actual: result, message: ERROR_UNEXPECTED_RESULT);
         }
 
         /// <summary>

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -36,6 +36,7 @@ using Azure.DataApiBuilder.Service.Tests.Authorization;
 using Azure.DataApiBuilder.Service.Tests.OpenApiIntegration;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
 using HotChocolate;
+using HotChocolate.Utilities;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -3184,7 +3185,9 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             GraphQLRuntimeOptions graphqlOptions,
             RestRuntimeOptions restOptions,
             Entity entity = null,
-            string entityName = null)
+            string entityName = null,
+            EntityCacheOptions cacheOptions =null
+            )
         {
             entity ??= new(
                 Source: new("books", EntitySourceType.Table, null, null),
@@ -3217,7 +3220,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 Schema: "IntegrationTestMinimalSchema",
                 DataSource: dataSource,
                 Runtime: new(restOptions, graphqlOptions,
-                    Host: new(Cors: null, Authentication: null, Mode: HostMode.Development)),
+                    Host: new(Cors: null, Authentication: null, Mode: HostMode.Development), Cache: cacheOptions),
                 Entities: new(entityMap)
             );
         }

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -36,7 +36,6 @@ using Azure.DataApiBuilder.Service.Tests.Authorization;
 using Azure.DataApiBuilder.Service.Tests.OpenApiIntegration;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
 using HotChocolate;
-using HotChocolate.Utilities;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -3186,7 +3185,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             RestRuntimeOptions restOptions,
             Entity entity = null,
             string entityName = null,
-            EntityCacheOptions cacheOptions =null
+            EntityCacheOptions cacheOptions = null
             )
         {
             entity ??= new(

--- a/src/Service.Tests/CosmosTests/QueryTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryTests.cs
@@ -532,7 +532,7 @@ type Planet @model(name:""Planet"") {
             string entityName = "Planet";
 
             // cache configuration
-            RuntimeConfig configuration = ConfigurationTests.InitMinimalRuntimeConfig(dataSource, graphqlOptions, restRuntimeOptions, entity, entityName, new EntityCacheOptions() { Enabled = true, TtlSeconds = 5 }); 
+            RuntimeConfig configuration = ConfigurationTests.InitMinimalRuntimeConfig(dataSource, graphqlOptions, restRuntimeOptions, entity, entityName, new EntityCacheOptions() { Enabled = true, TtlSeconds = 5 } ); 
 
             const string CUSTOM_CONFIG = "custom-config.json";
             const string CUSTOM_SCHEMA = "custom-schema.gql";

--- a/src/Service.Tests/CosmosTests/QueryTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryTests.cs
@@ -479,6 +479,12 @@ fragment p on Planet { id }
             Assert.AreEqual(id, response.GetProperty("id").GetString());
         }
 
+        /// <summary>
+        /// Validates that cached data is returned for the query.
+        /// First step - Query data for an ID.
+        /// Second step - Modify the name field for the document queried in the first step.
+        /// Third step - Query the document again to verify that cached data is returned and not modified one.
+        /// </summary>
         [TestMethod]
         public async Task QueryWithCacheEnabledShouldReturnCachedResponse()
         {

--- a/src/Service.Tests/CosmosTests/QueryTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryTests.cs
@@ -732,7 +732,6 @@ type Planet @model(name:""Planet"") {
             File.WriteAllText(CUSTOM_CONFIG, configuration.ToJson());
             File.WriteAllText(CUSTOM_SCHEMA, SCHEMA);
 
-
             return new[]
             {
                 $"--ConfigFileName={CUSTOM_CONFIG}"

--- a/src/Service.Tests/CosmosTests/QueryTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryTests.cs
@@ -538,7 +538,7 @@ type Planet @model(name:""Planet"") {
             string entityName = "Planet";
 
             // cache configuration
-            RuntimeConfig configuration = ConfigurationTests.InitMinimalRuntimeConfig(dataSource, graphqlOptions, restRuntimeOptions, entity, entityName, new EntityCacheOptions() { Enabled = true, TtlSeconds = 5 } ); 
+            RuntimeConfig configuration = ConfigurationTests.InitMinimalRuntimeConfig(dataSource, graphqlOptions, restRuntimeOptions, entity, entityName, new EntityCacheOptions() { Enabled = true, TtlSeconds = 5 });
 
             const string CUSTOM_CONFIG = "custom-config.json";
             const string CUSTOM_SCHEMA = "custom-schema.gql";

--- a/src/Service.Tests/CosmosTests/QueryTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryTests.cs
@@ -611,23 +611,6 @@ query {{
 
                 // Asserting cached data is returned
                 Assert.IsFalse(queryResponse.GetProperty("name").GetString() != name, "Query didn't return cached value");
-
-                update = new
-                {
-                    id = id,
-                    name = name,
-                };
-
-                // Clean up setting document name back to original value
-                _ = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
-                                client,
-                                server.Services.GetRequiredService<RuntimeConfigProvider>(),
-                                query: mutation,
-                                queryName: "updatePlanet",
-                                variables: new() { { "id", id }, { "partitionKeyValue", id }, { "item", update } },
-                                authToken: AuthTestHelper.CreateStaticWebAppsEasyAuthToken(),
-                                clientRoleHeader: AuthorizationResolver.ROLE_AUTHENTICATED
-                                );
             }
         }
 


### PR DESCRIPTION
## Why make this change?
Adding In-Memory cache support for CosmosDB. Closes #1884 

## What is this change?
Introduced a new generic method GetOrSetAsync  for getting and setting cached item.
Using GetOrSetAsync for caching Cosmosdb query result.

## How was this tested?

- [x] Integration Tests
Added integration tests using Mock Func execution by DabCacheService.GetOrSetAsync. 
Performed manual testing of caching behavior. Had to manually override enablecaching and TTL since config changes were throwing an error. Will perform another round of tests by enabling caching from configuration before merging the PR.

