### PR TITLE
Fixing nit comments from previous DW mutation support prs.

### DIFF
--- a/src/Core/Services/GraphQLSchemaCreator.cs
+++ b/src/Core/Services/GraphQLSchemaCreator.cs
@@ -234,10 +234,12 @@ namespace Azure.DataApiBuilder.Core.Services
             }
 
             Dictionary<string, FieldDefinitionNode> fields = new();
+
+            // Add the DBOperationResult type to the schema
             NameNode nameNode = new(value: GraphQLUtils.DB_OPERATION_RESULT_TYPE);
             FieldDefinitionNode field = GetDbOperationResultField();
 
-            fields.TryAdd("result", field);
+            fields.TryAdd(GraphQLUtils.DB_OPERATION_RESULT_FIELD_NAME, field);
 
             objectTypes.Add(GraphQLUtils.DB_OPERATION_RESULT_TYPE, new ObjectTypeDefinitionNode(
                 location: null,
@@ -290,7 +292,7 @@ namespace Azure.DataApiBuilder.Core.Services
         {
             return new(
                 location: null,
-                name: new("result"),
+                name: new(GraphQLUtils.DB_OPERATION_RESULT_FIELD_NAME),
                 description: new StringValueNode("Contains result for mutation execution"),
                 arguments: new List<InputValueDefinitionNode>(),
                 type: new StringType().ToTypeNode(),

--- a/src/Service.GraphQLBuilder/GraphQLUtils.cs
+++ b/src/Service.GraphQLBuilder/GraphQLUtils.cs
@@ -30,6 +30,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
         public const string OBJECT_TYPE_QUERY = "query";
         public const string SYSTEM_ROLE_ANONYMOUS = "anonymous";
         public const string DB_OPERATION_RESULT_TYPE = "DbOperationResult";
+        public const string DB_OPERATION_RESULT_FIELD_NAME = "result";
 
         public static bool IsModelType(ObjectTypeDefinitionNode objectTypeDefinitionNode)
         {
@@ -319,9 +320,11 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
         /// </summary>
         public static string GetEntityNameFromContext(IMiddlewareContext context)
         {
-            string entityName = context.Selection.Field.Type.TypeName();
+            IOutputType type = context.Selection.Field.Type;
+            string graphQLTypeName = type.TypeName();
+            string entityName = graphQLTypeName;
 
-            if (entityName is DB_OPERATION_RESULT_TYPE)
+            if (graphQLTypeName is DB_OPERATION_RESULT_TYPE)
             {
                 // CUD for a mutation whose result set we do not have. Get Entity name mutation field directive.
                 if (GraphQLUtils.TryExtractGraphQLFieldModelName(context.Selection.Field.Directives, out string? modelName))
@@ -333,7 +336,6 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
             {
                 // for rest of scenarios get entity name from output object type.
                 ObjectType underlyingFieldType;
-                IOutputType type = context.Selection.Field.Type;
                 underlyingFieldType = GraphQLUtils.UnderlyingGraphQLEntityType(type);
                 // Example: CustomersConnectionObject - for get all scenarios.
                 if (QueryBuilder.IsPaginationType(underlyingFieldType))

--- a/src/Service.GraphQLBuilder/Mutations/CreateMutationBuilder.cs
+++ b/src/Service.GraphQLBuilder/Mutations/CreateMutationBuilder.cs
@@ -253,9 +253,9 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations
                 databaseType,
                 entities);
 
-            // Create authorize directive denoting allowed roles
-            List<DirectiveNode> fieldDefinitionNodeDirectives = new() { new(ModelDirectiveType.DirectiveName, new ArgumentNode("name", dbEntityName)) };
+            List<DirectiveNode> fieldDefinitionNodeDirectives = new() { new(ModelDirectiveType.DirectiveName, new ArgumentNode(ModelDirectiveType.ModelNameArgument, dbEntityName)) };
 
+            // Create authorize directive denoting allowed roles
             if (CreateAuthorizationDirectiveIfNecessary(
                     rolesAllowedForMutation,
                     out DirectiveNode? authorizeDirective))

--- a/src/Service.GraphQLBuilder/Mutations/DeleteMutationBuilder.cs
+++ b/src/Service.GraphQLBuilder/Mutations/DeleteMutationBuilder.cs
@@ -58,7 +58,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations
             }
 
             // Create authorize directive denoting allowed roles
-            List<DirectiveNode> fieldDefinitionNodeDirectives = new() { new(ModelDirectiveType.DirectiveName, new ArgumentNode("name", dbEntityName)) };
+            List<DirectiveNode> fieldDefinitionNodeDirectives = new() { new(ModelDirectiveType.DirectiveName, new ArgumentNode(ModelDirectiveType.ModelNameArgument, dbEntityName)) };
 
             if (CreateAuthorizationDirectiveIfNecessary(
                     rolesAllowedForMutation,

--- a/src/Service.GraphQLBuilder/Mutations/UpdateMutationBuilder.cs
+++ b/src/Service.GraphQLBuilder/Mutations/UpdateMutationBuilder.cs
@@ -239,7 +239,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations
                     new List<DirectiveNode>()));
 
             // Create authorize directive denoting allowed roles
-            List<DirectiveNode> fieldDefinitionNodeDirectives = new() { new(ModelDirectiveType.DirectiveName, new ArgumentNode("name", dbEntityName)) };
+            List<DirectiveNode> fieldDefinitionNodeDirectives = new() { new(ModelDirectiveType.DirectiveName, new ArgumentNode(ModelDirectiveType.ModelNameArgument, dbEntityName)) };
 
             if (CreateAuthorizationDirectiveIfNecessary(
                     rolesAllowedForMutation,

--- a/src/Service.Tests/GraphQLBuilder/MutationBuilderTests.cs
+++ b/src/Service.Tests/GraphQLBuilder/MutationBuilderTests.cs
@@ -9,6 +9,7 @@ using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config.DatabasePrimitives;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Service.Exceptions;
+using Azure.DataApiBuilder.Service.GraphQLBuilder;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations;
 using Azure.DataApiBuilder.Service.Tests.GraphQLBuilder.Helpers;
 using HotChocolate.Language;
@@ -94,7 +95,7 @@ type Foo @model(name:""Foo"") {
             FieldDefinitionNode createField =
                 query.Fields.Where(f => f.Name.Value == $"createFoo").First();
             Assert.AreEqual(expected: isAuthorizeDirectiveExpected ? 1 : 0,
-                actual: createField.Directives.Where(x => x.Name.Value is "authorize").Count());
+                actual: createField.Directives.Where(x => x.Name.Value is GraphQLUtils.AUTHORIZE_DIRECTIVE).Count());
         }
 
         [TestMethod]


### PR DESCRIPTION
## Why make this change?

Fixing nit comments from earlier pr: https://github.com/Azure/data-api-builder/pull/1978

## What is this change?

There were some nit comments to fix while adding implementation for mutation support for DW.

## How was this tested?

Existing tests should cover as this pr only handles nit fixes.
