### PR TITLE
[CherryPick] Create a unittest pipeline, moving common steps into templates, disab…

### DIFF
--- a/.pipelines/build-pipelines.yml
+++ b/.pipelines/build-pipelines.yml
@@ -18,325 +18,221 @@ pool:
   vmImage: 'ubuntu-latest' # examples of other options: 'macOS-10.15', 'windows-2019'
 
 variables:
-  solution: '**/*.sln'
-  buildPlatform: 'Any CPU'
-  buildConfiguration: 'Release'
-  major: 0
-  minor: 11
-  # Maintain a separate patch value between CI and PR runs.
-  # The counter is reset when the minor version is updated.
-  patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 0)]
-  isReleaseBuild: $(isNugetRelease)
-  $id: 'https://github.com/Azure/data-api-builder/releases/download/v$(major).$(minor).$(patch)/dab.draft.schema.json'
-  SNAPSHOOTER_STRICT_MODE: true
+- template: templates/variables.yml
 
-steps:
-- task: NuGetAuthenticate@1
-  displayName: 'NuGet Authenticate'
+jobs:
+- job:
+  steps:
+  - template:  templates/build-pipelines.yml
 
-# If this is a release, do not append the build number at the end as it will 
-# generate the prerelease nuget version.
-# We cannot set this in variables section above because $(isNugetRelease) 
-# is not available at pipeline compilation time.
-- bash: |
-    echo IsNugetRelease = $ISNUGETRELEASE
-    echo IsReleaseCandidate = $ISRELEASECANDIDATE
-    dabVersion=$(major).$(minor).$(patch)
-    if [ "$ISNUGETRELEASE" = "true" ]
-    then
-      if [ "$ISRELEASECANDIDATE" = "true" ]
-      then
-        dabVersion=$dabVersion-rc
-      fi
-    else
-      dabVersion=$dabVersion-$(Build.BuildId)
-    fi
-    echo dabVersion = $dabVersion
-    echo "##vso[task.setvariable variable=dabVersion]$dabVersion"
-    schemaId="https://github.com/Azure/data-api-builder/releases/download/v$dabVersion/dab.draft.schema.json"
-    echo schemaId = $schemaId
-    echo "##vso[task.setvariable variable=\$id]$schemaId"
-  displayName: Set dab version
+  - task: FileTransform@1.206.0
+    displayName: 'Version stamp dab.draft.schema.json'
+    inputs:
+      folderPath: '$(System.DefaultWorkingDirectory)'
+      fileType: 'json'
+      targetFiles: 'schemas/dab.draft.schema.json'
+  
+  - task: CopyFiles@2
+    displayName: 'Copy dab.draft.schema.json'
+    inputs:
+      sourceFolder: '$(Build.SourcesDirectory)/schemas'
+      contents: 'dab.draft.schema.json'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
 
-- task: UseDotNet@2
-  displayName: Setup .NET SDK v6.0.x
-  inputs:
-    packageType: sdk
-    version: 6.0.x
-    installationPath: $(Agent.ToolsDirectory)/dotnet
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Governance Detection'
+    inputs:
+      alertWarningLevel: Medium
+      failOnAlert: true
 
-- task: NuGetToolInstaller@1
+  - task: notice@0
+    # This will generate the NOTICE.txt for distribution
+    displayName: Generate NOTICE file
+    condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
+    inputs:
+      outputfile: $(Build.SourcesDirectory)/NOTICE.txt
+      outputformat: text
 
-- task: NuGetCommand@2
-  inputs:
-    restoreSolution: '$(solution)'
-    feedsToUse: config
-    nugetConfigPath: Nuget.config
+  - task: PowerShell@2
+    displayName: "Add Additional Licenses to NOTICE file"
+    condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/notice-generation.ps1
+      # Artifact Staging Directory used to temporarily store downloaded ChilliCream license.
+      arguments: $(Build.ArtifactStagingDirectory) $(Build.SourcesDirectory)
 
-- task: DotNetCoreCLI@2
-  displayName: Check formatting
-  inputs:
-    command: custom
-    custom: format
-    projects: '$(solution)'
-    arguments: '--verify-no-changes'
+  - template: templates/code-signing.yml
+    parameters:
+      # This is the path that will be used for packing nuget package.
+      # We will need to sign the binaries in this location.
+      path: '$(Build.SourcesDirectory)/src/out/cli/net6.0/publish' 
 
-# Use dotnet pack command to build the project because we want to generate build output
-# in the correct location that pack command will be using. This build output location
-# will be used to do code signing so we need to do this first.
-- task: DotNetCoreCLI@2
-  displayName: Build
-  inputs:
-    command: custom
-    custom: pack
-    projects: '**/*.sln'
-    arguments: '--configuration $(buildConfiguration) -p:Version=$(dabVersion)' 
+  # Create nuget package after the binaries are signed. So that the binaries inside nuget package are signed.
+  - task: DotNetCoreCLI@2
+    displayName: 'Creating Nuget Package'
+    inputs:
+      command: custom
+      custom: pack
+      projects: '**/Cli.csproj'
+      arguments: '--configuration $(buildConfiguration) --no-build -p:Version=$(dabVersion) -o $(Build.ArtifactStagingDirectory)/nupkg'
 
-- task: DotNetCoreCLI@2
-  displayName: "Run Unit Tests"
-  inputs:
-    command: test
-    projects: '**/*Tests*.csproj'
-    arguments: '--filter "TestCategory!=CosmosDb_NoSql&TestCategory!=MsSql&TestCategory!=PostgreSql&TestCategory!=MySql&TestCategory!=DwSql" --configuration $(buildConfiguration) --collect "XPlat Code coverage"'
+  # Now sign the nuget package itself.
+  - template: templates/code-signing.yml
+    parameters:
+      path: '$(Build.ArtifactStagingDirectory)/nupkg'
+      signNuget: true
 
-- task: CmdLine@2
-  displayName: 'Set flag to publish Verify *.received files when tests fail'
-  condition: failed()
-  inputs:
-    script: 'echo ##vso[task.setvariable variable=publishverify]Yes'
+  - task: PowerShell@2
+    displayName: "Package DAB to multiple platforms"
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/publish.ps1
+      arguments: $(buildConfiguration) $(Build.ArtifactStagingDirectory) $(dabVersion) -Package
 
-- task: CopyFiles@2
-  condition: eq(variables['publishverify'], 'Yes')
-  displayName: 'Copy received files to Artifact Staging'
-  inputs:
-    contents: '**\*.received.*' 
-    targetFolder: '$(Build.ArtifactStagingDirectory)\Verify'
-    cleanTargetFolder: true
-    overWrite: true
+  - task: PowerShell@2
+    displayName: "Smoke Test for DAB CLI"
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/dab-smoke-test-script.ps1
+      arguments: $(buildConfiguration) $(Build.ArtifactStagingDirectory) $(Agent.OS)  $(dabVersion)
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish received files as Artifacts'
-  name: 'verifypublish'
-  condition: eq(variables['publishverify'], 'Yes')
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\Verify'
-    ArtifactName: 'Verify'
-    publishLocation: 'Container'
+  # Sign the binaries that were generated per platform
+  - template: templates/code-signing.yml
+    parameters:
+      path: '$(Build.ArtifactStagingDirectory)/publish'
 
-- task: FileTransform@1.206.0
-  displayName: 'Version stamp dab.draft.schema.json'
-  inputs:
-    folderPath: '$(System.DefaultWorkingDirectory)'
-    fileType: 'json'
-    targetFiles: 'schemas/dab.draft.schema.json'
- 
-- task: CopyFiles@2
-  displayName: 'Copy dab.draft.schema.json'
-  inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/schemas'
-    contents: 'dab.draft.schema.json'
-    targetFolder: '$(Build.ArtifactStagingDirectory)'
+  # Zip the binaries after signing process.
+  - task: PowerShell@2
+    displayName: "Zip the binaries after signing"
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/publish.ps1
+      arguments: $(buildConfiguration) $(Build.ArtifactStagingDirectory) $(dabVersion) -CreateZip
 
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: 'Component Governance Detection'
-  inputs:
-    alertWarningLevel: Medium
-    failOnAlert: true
+  # Generating SBOM manifest for Dab files
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'SBOM Generation Task'
+    inputs:
+        BuildDropPath: '$(Build.ArtifactStagingDirectory)'
 
-- task: notice@0
-  # This will generate the NOTICE.txt for distribution
-  displayName: Generate NOTICE file
-  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
-  inputs:
-    outputfile: $(Build.SourcesDirectory)/NOTICE.txt
-    outputformat: text
+  # Downloads the manifest file from the latest GitHub Release.
+  - task: DownloadGitHubRelease@0
+    inputs:
+      connection: 'DataApiBuilder'
+      userRepository: '$(Build.Repository.Name)'
+      defaultVersionType: 'latest'
+      itemPattern: 'dab-manifest.json'
+      downloadPath: '$(Build.ArtifactStagingDirectory)'
 
-- task: PowerShell@2
-  displayName: "Add Additional Licenses to NOTICE file"
-  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
-  inputs:
-    targetType: 'filePath'
-    filePath: $(System.DefaultWorkingDirectory)/scripts/notice-generation.ps1
-    # Artifact Staging Directory used to temporarily store downloaded ChilliCream license.
-    arguments: $(Build.ArtifactStagingDirectory) $(Build.SourcesDirectory)
+  # Generating Manifest File for generated Zip package
+  - task: PowerShell@2
+    displayName: "Generate Manifest File"
+    inputs:
+      targetType: 'filePath'
+      filePath: $(System.DefaultWorkingDirectory)/scripts/create-manifest-file.ps1
+      arguments: $(buildConfiguration) $(Build.ArtifactStagingDirectory) $(dabVersion) $(isReleaseBuild)
 
-- template: templates/code-signing.yml
-  parameters:
-    # This is the path that will be used for packing nuget package.
-    # We will need to sign the binaries in this location.
-    path: '$(Build.SourcesDirectory)/src/out/cli/net6.0/publish' 
+  # This code takes all the files in $(Build.ArtifactStagingDirectory) and uploads them as an artifact of your build.
+  - task: PublishPipelineArtifact@1
+    displayName: "Upload build artifacts"
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)' 
+      publishLocation: 'pipeline'
 
-# Create nuget package after the binaries are signed. So that the binaries inside nuget package are signed.
-- task: DotNetCoreCLI@2
-  displayName: 'Creating Nuget Package'
-  inputs:
-    command: custom
-    custom: pack
-    projects: '**/Cli.csproj'
-    arguments: '--configuration $(buildConfiguration) --no-build -p:Version=$(dabVersion) -o $(Build.ArtifactStagingDirectory)/nupkg'
+  - task: NuGetCommand@2
+    displayName: 'Publish Nuget to Internal Feed'
+    condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
+    inputs:
+      command: 'push'
+      feedsToUse: 'select'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+      nuGetFeedType: 'internal'
+      publishVstsFeed: CosmosDB/DataApiBuilder
+      versioningScheme: 'off'
+      allowPackageConflicts: false
 
-# Now sign the nuget package itself.
-- template: templates/code-signing.yml
-  parameters:
-    path: '$(Build.ArtifactStagingDirectory)/nupkg'
-    signNuget: true
+  - task: NuGetCommand@2
+    displayName: 'Publish Nuget to Nuget.org'
+    condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
+    inputs:
+      command: push
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
+      nuGetFeedType: external
+      publishFeedCredentials: Microsoft.DataApiBuilder
 
-- task: PowerShell@2
-  displayName: "Package DAB to multiple platforms"
-  inputs:
-    targetType: 'filePath'
-    filePath: $(System.DefaultWorkingDirectory)/scripts/publish.ps1
-    arguments: $(buildConfiguration) $(Build.ArtifactStagingDirectory) $(dabVersion) -Package
+  # Create a draft release with Assets
+  - task: GitHubRelease@1
+    displayName: "Draft Github Release"
+    condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
+    inputs:
+      gitHubConnection: 'DataApiBuilder'
+      repositoryName: '$(Build.Repository.Name)'
+      action: 'create'
+      target: '$(Build.SourceVersion)'
+      tagSource: 'userSpecifiedTag'
+      tag: 'v$(dabVersion)'
+      title: 'New Release: Data API Builder for Azure Databases'
+      assets: |
+        $(Build.ArtifactStagingDirectory)/**/*.nupkg
+        $(Build.ArtifactStagingDirectory)/**/*.zip
+        $(Build.ArtifactStagingDirectory)/**/dab-manifest.json
+        $(Build.ArtifactStagingDirectory)/**/dab.draft.schema.json
+      isDraft: true
+      isPreRelease: $(isReleaseCandidate)
+      addChangeLog: true
 
-- task: PowerShell@2
-  displayName: "Smoke Test for DAB CLI"
-  inputs:
-    targetType: 'filePath'
-    filePath: $(System.DefaultWorkingDirectory)/scripts/dab-smoke-test-script.ps1
-    arguments: $(buildConfiguration) $(Build.ArtifactStagingDirectory) $(Agent.OS)  $(dabVersion)
+  # This task gets the current date and saves it to a variable so the docker task can use the build's
+  # date and time as a tag.
+  - task: PowerShell@2
+    displayName: "Get date for Docker image Tag"
+    inputs:
+      targetType: 'inline'
+      script: |
+        Write-Host "Setting up the date and time as a build variable for the Docker tag"
+        $date=$(Get-Date -format yyyyMMdd-HHmmss)
+        Write-Host "##vso[task.setvariable variable=BuildDate]$date"
 
-# Sign the binaries that were generated per platform
-- template: templates/code-signing.yml
-  parameters:
-    path: '$(Build.ArtifactStagingDirectory)/publish'
+  # Build a docker image and push it to the container registry.
+  - task: Docker@2
+    displayName: "Build and push docker image to Azure Container Registry"
+    condition: and(succeeded(), eq(variables.isReleaseBuild, 'false'))
+    inputs:
+      containerRegistry: 'Data API builder Container Registry Connection'
+      repository: 'dab/$(Build.SourceBranch)'
+      command: 'buildAndPush'
+      Dockerfile: '**/Dockerfile'
+      tags: |
+        $(BuildDate)-$(Build.SourceVersion)
+        latest
 
-# Zip the binaries after signing process.
-- task: PowerShell@2
-  displayName: "Zip the binaries after signing"
-  inputs:
-    targetType: 'filePath'
-    filePath: $(System.DefaultWorkingDirectory)/scripts/publish.ps1
-    arguments: $(buildConfiguration) $(Build.ArtifactStagingDirectory) $(dabVersion) -CreateZip
+  # Build a docker image and push it to the container registry.
+  # Tag the image with the value of the releaseName variable and nuget release version.
+  - task: Docker@2
+    displayName: "Build and push docker image to Azure Container Registry tagged with releaseName and nuget release version"
+    condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
+    inputs:
+      containerRegistry: 'Data API builder Container Registry Connection'
+      repository: 'dab'
+      command: 'buildAndPush'
+      Dockerfile: '**/Dockerfile'
+      tags: |
+        $(BuildDate)-$(Build.SourceVersion)
+        $(releaseName)
+        $(dabVersion)
 
-# Generating SBOM manifest for Dab files
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'SBOM Generation Task'
-  inputs:
-      BuildDropPath: '$(Build.ArtifactStagingDirectory)'
-
-# Downloads the manifest file from the latest GitHub Release.
-- task: DownloadGitHubRelease@0
-  inputs:
-    connection: 'DataApiBuilder'
-    userRepository: '$(Build.Repository.Name)'
-    defaultVersionType: 'latest'
-    itemPattern: 'dab-manifest.json'
-    downloadPath: '$(Build.ArtifactStagingDirectory)'
-
-# Generating Manifest File for generated Zip package
-- task: PowerShell@2
-  displayName: "Generate Manifest File"
-  inputs:
-    targetType: 'filePath'
-    filePath: $(System.DefaultWorkingDirectory)/scripts/create-manifest-file.ps1
-    arguments: $(buildConfiguration) $(Build.ArtifactStagingDirectory) $(dabVersion) $(isReleaseBuild)
-
-# This code takes all the files in $(Build.ArtifactStagingDirectory) and uploads them as an artifact of your build.
-- task: PublishPipelineArtifact@1
-  displayName: "Upload build artifacts"
-  inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)' 
-    publishLocation: 'pipeline'
-
-- task: NuGetCommand@2
-  displayName: 'Publish Nuget to Internal Feed'
-  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
-  inputs:
-    command: 'push'
-    feedsToUse: 'select'
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
-    nuGetFeedType: 'internal'
-    publishVstsFeed: CosmosDB/DataApiBuilder
-    versioningScheme: 'off'
-    allowPackageConflicts: false
-
-- task: NuGetCommand@2
-  displayName: 'Publish Nuget to Nuget.org'
-  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
-  inputs:
-    command: push
-    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg'
-    nuGetFeedType: external
-    publishFeedCredentials: Microsoft.DataApiBuilder
-
-- task: PublishCodeCoverageResults@1
-  displayName: 'Publish code coverage'
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(Agent.TempDirectory)/**/*cobertura.xml'
-
-# Create a draft release with Assets
-- task: GitHubRelease@1
-  displayName: "Draft Github Release"
-  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
-  inputs:
-    gitHubConnection: 'DataApiBuilder'
-    repositoryName: '$(Build.Repository.Name)'
-    action: 'create'
-    target: '$(Build.SourceVersion)'
-    tagSource: 'userSpecifiedTag'
-    tag: 'v$(dabVersion)'
-    title: 'New Release: Data API Builder for Azure Databases'
-    assets: |
-      $(Build.ArtifactStagingDirectory)/**/*.nupkg
-      $(Build.ArtifactStagingDirectory)/**/*.zip
-      $(Build.ArtifactStagingDirectory)/**/dab-manifest.json
-      $(Build.ArtifactStagingDirectory)/**/dab.draft.schema.json
-    isDraft: true
-    isPreRelease: $(isReleaseCandidate)
-    addChangeLog: true
-
-# This task gets the current date and saves it to a variable so the docker task can use the build's
-# date and time as a tag.
-- task: PowerShell@2
-  displayName: "Get date for Docker image Tag"
-  inputs:
-    targetType: 'inline'
-    script: |
-      Write-Host "Setting up the date and time as a build variable for the Docker tag"
-      $date=$(Get-Date -format yyyyMMdd-HHmmss)
-      Write-Host "##vso[task.setvariable variable=BuildDate]$date"
-
-# Build a docker image and push it to the container registry.
-- task: Docker@2
-  displayName: "Build and push docker image to Azure Container Registry"
-  condition: and(succeeded(), eq(variables.isReleaseBuild, 'false'))
-  inputs:
-    containerRegistry: 'Data API builder Container Registry Connection'
-    repository: 'dab/$(Build.SourceBranch)'
-    command: 'buildAndPush'
-    Dockerfile: '**/Dockerfile'
-    tags: |
-      $(BuildDate)-$(Build.SourceVersion)
-      latest
-
-# Build a docker image and push it to the container registry.
-# Tag the image with the value of the releaseName variable and nuget release version.
-- task: Docker@2
-  displayName: "Build and push docker image to Azure Container Registry tagged with releaseName and nuget release version"
-  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
-  inputs:
-    containerRegistry: 'Data API builder Container Registry Connection'
-    repository: 'dab'
-    command: 'buildAndPush'
-    Dockerfile: '**/Dockerfile'
-    tags: |
-      $(BuildDate)-$(Build.SourceVersion)
-      $(releaseName)
-      $(dabVersion)
-
-# Build a docker image and push it to ACR for publishing to MCR.
-# This step will pick the image with name `public/azure-databases/data-api-builder` and push to MCR.
-# This image will also be available in DockerHub.
-# Tag the image with dab version and latest.
-- task: Docker@2
-  displayName: "Build and push docker image to ACR for publishing to MCR"
-  condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
-  inputs:
-    containerRegistry: 'Data API builder Container Registry Connection'
-    repository: 'public/azure-databases/data-api-builder'
-    command: 'buildAndPush'
-    Dockerfile: '**/Dockerfile'
-    tags: |
-      $(dabVersion)
-      latest
+  # Build a docker image and push it to ACR for publishing to MCR.
+  # This step will pick the image with name `public/azure-databases/data-api-builder` and push to MCR.
+  # This image will also be available in DockerHub.
+  # Tag the image with dab version and latest.
+  - task: Docker@2
+    displayName: "Build and push docker image to ACR for publishing to MCR"
+    condition: and(succeeded(), eq(variables.isReleaseBuild, 'true'))
+    inputs:
+      containerRegistry: 'Data API builder Container Registry Connection'
+      repository: 'public/azure-databases/data-api-builder'
+      command: 'buildAndPush'
+      Dockerfile: '**/Dockerfile'
+      tags: |
+        $(dabVersion)
+        latest

--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -15,9 +15,6 @@ trigger:
 
 strategy:
   matrix:
-    linux:
-      imageName: "ubuntu-latest"
-      ADDITIONAL_TEST_ARGS: '--collect "XPlat Code coverage"'
     windows:
       imageName: "windows-latest"
       ADDITIONAL_TEST_ARGS: '--collect "XPlat Code coverage"'

--- a/.pipelines/templates/build-pipelines.yml
+++ b/.pipelines/templates/build-pipelines.yml
@@ -1,0 +1,106 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# ASP.NET Core (.NET Framework)
+# Build and test ASP.NET Core projects targeting the full .NET Framework.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://learn.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+steps:
+- task: NuGetAuthenticate@1
+  displayName: 'NuGet Authenticate'
+
+# If this is a release, do not append the build number at the end as it will 
+# generate the prerelease nuget version.
+# We cannot set this in variables section above because $(isNugetRelease) 
+# is not available at pipeline compilation time.
+- bash: |
+    echo IsNugetRelease = $ISNUGETRELEASE
+    echo IsReleaseCandidate = $ISRELEASECANDIDATE
+    dabVersion=$(major).$(minor).$(patch)
+    if [ "$ISNUGETRELEASE" = "true" ]
+    then
+      if [ "$ISRELEASECANDIDATE" = "true" ]
+      then
+        dabVersion=$dabVersion-rc
+      fi
+    else
+      dabVersion=$dabVersion-$(Build.BuildId)
+    fi
+    echo dabVersion = $dabVersion
+    echo "##vso[task.setvariable variable=dabVersion]$dabVersion"
+    schemaId="https://github.com/Azure/data-api-builder/releases/download/v$dabVersion/dab.draft.schema.json"
+    echo schemaId = $schemaId
+    echo "##vso[task.setvariable variable=\$id]$schemaId"
+  displayName: Set dab version
+
+- task: UseDotNet@2
+  displayName: Setup .NET SDK v6.0.x
+  inputs:
+    packageType: sdk
+    version: 6.0.x
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
+- task: NuGetToolInstaller@1
+
+- task: NuGetCommand@2
+  inputs:
+    restoreSolution: '$(solution)'
+    feedsToUse: config
+    nugetConfigPath: Nuget.config
+
+- task: DotNetCoreCLI@2
+  displayName: Check formatting
+  inputs:
+    command: custom
+    custom: format
+    projects: '$(solution)'
+    arguments: '--verify-no-changes'
+
+# Use dotnet pack command to build the project because we want to generate build output
+# in the correct location that pack command will be using. This build output location
+# will be used to do code signing so we need to do this first.
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:
+    command: custom
+    custom: pack
+    projects: '**/*.sln'
+    arguments: '--configuration $(buildConfiguration) -p:Version=$(dabVersion)' 
+
+- task: DotNetCoreCLI@2
+  displayName: "Run Unit Tests"
+  inputs:
+    command: test
+    projects: '**/*Tests*.csproj'
+    arguments: '--filter "TestCategory!=CosmosDb_NoSql&TestCategory!=MsSql&TestCategory!=PostgreSql&TestCategory!=MySql&TestCategory!=DwSql" --configuration $(buildConfiguration) --collect "XPlat Code coverage"'
+
+- task: CmdLine@2
+  displayName: 'Set flag to publish Verify *.received files when tests fail'
+  condition: failed()
+  inputs:
+    script: 'echo ##vso[task.setvariable variable=publishverify]Yes'
+
+- task: CopyFiles@2
+  condition: eq(variables['publishverify'], 'Yes')
+  displayName: 'Copy received files to Artifact Staging'
+  inputs:
+    contents: '**\*.received.*' 
+    targetFolder: '$(Build.ArtifactStagingDirectory)\Verify'
+    cleanTargetFolder: true
+    overWrite: true
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish received files as Artifacts'
+  name: 'verifypublish'
+  condition: eq(variables['publishverify'], 'Yes')
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\Verify'
+    ArtifactName: 'Verify'
+    publishLocation: 'Container'
+
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish code coverage'
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Agent.TempDirectory)/**/*cobertura.xml'

--- a/.pipelines/templates/variables.yml
+++ b/.pipelines/templates/variables.yml
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+variables:
+  solution: '**/*.sln'
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+  major: 0
+  minor: 11
+  # Maintain a separate patch value between CI and PR runs.
+  # The counter is reset when the minor version is updated.
+  patch: $[counter(format('{0}_{1}', variables['build.reason'], variables['minor']), 0)]
+  isReleaseBuild: $(isNugetRelease)
+  $id: 'https://github.com/Azure/data-api-builder/releases/download/v$(major).$(minor).$(patch)/dab.draft.schema.json'
+  SNAPSHOOTER_STRICT_MODE: true

--- a/.pipelines/unittest-pipelines.yml
+++ b/.pipelines/unittest-pipelines.yml
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+pool:
+  vmImage: 'ubuntu-latest' # examples of other options: 'macOS-10.15', 'windows-2019'
+
+variables:
+- template: templates/variables.yml
+
+steps:
+- template: templates/build-pipelines.yml


### PR DESCRIPTION
…le CosmosDB testing on linux (#2049)

## Why make this change?

- Trying to improve the pipeline triggering experience by moving all PR validation pipelines to public project.
- Desired goal is to have all pipelines automatically trigger upon commenting `/azp run` on an approved PR by a team member

## What is this change?

- Create a unittest pipeline to run unittests
- Move common steps and variables from original build pipeline to templates
- Remove testing on the linux platform for CosmosDB in preparation to run this pipeline in the public project too. Its been difficult to start a CosmosDB emulator on linux, preventing us to test on this platform in the public project where pipeline secrets aren't allowed for PRs from forked repositories. (they are allowed in private projects, hence we had been able to test on linux when the pipeline was in the private project)

## How was this tested?

- Temporarily renamed the unittest-pipelines.yml as build-pipelines.yml and ran the `Build` pipeline on this branch to verify a successful build


![image](https://github.com/Azure/data-api-builder/assets/3513779/12c250a0-5cbc-4687-b918-984e8f6e63f0)
