### PR TITLE
Cosmos DB: Upgrade cosmos DB SDK to latest version i.e. 3.38.1

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.14" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.14" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.20.0" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
     <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />


### PR DESCRIPTION
## Why make this change?

We want to use SDK latest features like:
1. Patch API
2. Ability to disable certificate check by including a flag in connection string.
3. Hierarchal Partition Key

etc.

## What is this change?
Upgrade Cosmos to the latest version`3.38.1`. It's a non-breaking change

## How was this tested?

NA

## Sample Request(s)

NA
