### PR TITLE
Disable mssql linux test pipeline

### DIFF
--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -18,6 +18,7 @@ trigger:
 
 jobs:
 - job: linux
+  condition: false # Disable until we resolve flakey pipeline issue. https://github.com/Azure/data-api-builder/issues/2010
   pool:
     vmImage: 'ubuntu-latest'
   variables:


### PR DESCRIPTION
## Why make this change?

- Closes #2077  While we investigate #2010 , disabling MSSQL linux tests to allow us to be productive while solution is found.

## What is this change?

- Sets Linux MSSQL test job condition to false to disable job. The intent is to keep the pipeline config without deleting and have a simple re-enable task when appropriate.
  - Solution credit: https://developercommunity.visualstudio.com/t/add-support-to-temporarily-disableskip-a-job-in-mu/393253

## How was this tested?

- [x] Integration Tests
Shows as skipped as intended:
![image](https://github.com/Azure/data-api-builder/assets/6414189/13dd6325-d120-4d9f-bdb5-8cc12dbed4b0)
