### PR TITLE
Update `dab start --help` loglevel link

### DIFF
--- a/src/Cli/Commands/StartOptions.cs
+++ b/src/Cli/Commands/StartOptions.cs
@@ -16,6 +16,8 @@ namespace Cli.Commands
     [Verb("start", isDefault: false, HelpText = "Start Data Api Builder Engine", Hidden = false)]
     public class StartOptions : Options
     {
+        private const string LOGLEVEL_HELPTEXT = "Specifies logging level as provided value. For possible values, see: https://go.microsoft.com/fwlink/?linkid=2263106";
+
         public StartOptions(bool verbose, LogLevel? logLevel, bool isHttpsRedirectionDisabled, string config)
             : base(config)
         {
@@ -26,10 +28,10 @@ namespace Cli.Commands
 
         // SetName defines mutually exclusive sets, ie: can not have
         // both verbose and LogLevel.
-        [Option("verbose", SetName = "verbose", Required = false, HelpText = "Specify logging level as informational.")]
+        [Option("verbose", SetName = "verbose", Required = false, HelpText = "Specifies logging level as informational.")]
         public bool Verbose { get; }
-        [Option("LogLevel", SetName = "LogLevel", Required = false, HelpText = "Specify logging level as provided value, " +
-            "see: https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel?view=dotnet-plat-ext-7.0")]
+
+        [Option("LogLevel", SetName = "LogLevel", Required = false, HelpText = LOGLEVEL_HELPTEXT)]
         public LogLevel? LogLevel { get; }
 
         [Option("no-https-redirect", Required = false, HelpText = "Disables automatic https redirects.")]


### PR DESCRIPTION
## Why make this change?

- closes #1819 
- CLI has unusable (truncated) link as seen here:
![image](https://github.com/Azure/data-api-builder/assets/6414189/73421bb8-cfbf-4192-a99a-d21338699aa8)
- This pr fixes that.

## What is this change?

- Updating to the link: https://go.microsoft.com/fwlink/?linkid=2263106 -> https://learn.microsoft.com/dotnet/api/microsoft.extensions.logging.loglevel

Looks like:
![image](https://github.com/Azure/data-api-builder/assets/6414189/95ca056c-eb6a-47bf-b083-98d725c8666b)


## How was this tested?

Tested in cli with cmd `dab start --help`, screenshot with change shown above.
