### PR TITLE
executionHelper public so consumers of nuget, can call logic

### DIFF
--- a/src/Core/Services/ExecutionHelper.cs
+++ b/src/Core/Services/ExecutionHelper.cs
@@ -24,7 +24,7 @@ namespace Azure.DataApiBuilder.Service.Services
     /// This helper class provides the various resolvers and middlewares used
     /// during query execution.
     /// </summary>
-    internal sealed class ExecutionHelper
+    public sealed class ExecutionHelper
     {
         internal readonly IQueryEngineFactory _queryEngineFactory;
         internal readonly IMutationEngineFactory _mutationEngineFactory;


### PR DESCRIPTION

## Why make this change?
Consumers of the nuget, would need to be able to leverage common dab logic  for query/mutation resolvers. 

## What is this change?
Exposing executionHelper as a public method

## How was this tested?
No existing logic change, just made method public from internal. existing tests should cover all flows.
