### PR TITLE
Enable filtering with custom roles

### DIFF
--- a/src/Core/Authorization/AuthorizationResolver.cs
+++ b/src/Core/Authorization/AuthorizationResolver.cs
@@ -136,7 +136,17 @@ public class AuthorizationResolver : IAuthorizationResolver
 
         if (!EntityPermissionsMap[entityName].RoleToOperationMap.TryGetValue(roleName, out RoleMetadata? roleMetadata) && roleMetadata is null)
         {
-            return false;
+            if (ROLE_ANONYMOUS.Equals(roleName, StringComparison.OrdinalIgnoreCase) ||
+                ROLE_AUTHENTICATED.Equals(roleName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // roleName is a custom role and derives from authenticated role. Let's try with authenticated role.
+            if (!EntityPermissionsMap[entityName].RoleToOperationMap.TryGetValue(ROLE_AUTHENTICATED, out roleMetadata) && roleMetadata is null)
+            {
+                return false;
+            }
         }
 
         // Short circuit when OperationMetadata lookup fails. When lookup succeeds, operationToColumnMap will be populated


### PR DESCRIPTION
## Why make this change?
This pull request is related to issue 2115 (https://github.com/Azure/data-api-builder/issues/2115) that reports that it's not
possible to filter entities anonymously accessible when the caller is using a custom role.

## What is this change?
When filtering is disallowed for a custom role because the role is not defined for that entity, it is then checked for the authenticated role the custom role inherits from. Please note that when no authenticated role is defined for an entity, it is automatically defined using the definition of the anonymous role.

## How was this tested?
I've tested in our live environment.