### PR TITLE
Remove myself from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # review when someone opens a pull request.
-*       @mbhaskar @Aniruddh25 @JelteF @seantleonard @mathos1432 @gledis69 @aaronburtle @tarazou9 @ayush3797 @abhishekkumams @aaronpowell @severussundar @ravishetye @rohkhann @neeraj-sharma2592 @sourabh1007 
+*       @mbhaskar @Aniruddh25 @seantleonard @mathos1432 @gledis69 @aaronburtle @tarazou9 @ayush3797 @abhishekkumams @aaronpowell @severussundar @ravishetye @rohkhann @neeraj-sharma2592 @sourabh1007 


### PR DESCRIPTION
I haven't worked on this project in quite a while and I don't expect to be doing that in the near future either. This removes me from CODEOWNERS so I don't get notifications for this anymore (and so I cannot approve PRs anymore).