### PR TITLE
Add new Dockerfile for pipeline container usage

### DIFF
--- a/.pipelines/onebranch/Dockerfile
+++ b/.pipelines/onebranch/Dockerfile
@@ -1,0 +1,23 @@
+#
+# Build Data API builder Docker container in OneBranch
+#
+# Version values referenced from https://hub.docker.com/_/microsoft-dotnet-aspnet
+# dotnet/sdk and dotnet/aspnet required to build working container.
+FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0. AS build
+WORKDIR /src
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0 AS runtime
+
+# The ./src/out path below points to the finalized build bits created by the pipeline.
+# The path is relative to the "Docker build context" specified by the parameter dockerFileContextPath
+# in task: onebranch.pipeline.imagebuildinfo@1
+# The "Docker build context" contains all the files that will be used by the command "docker build"
+# OneBranch uses the injected task Copy Artifacts to
+# copy artifacts from pipeline artifacts: "/mnt/{...}/out" 
+# to the container running the docker tasks: /mnt/{...}/docker/artifacts/
+COPY ./src/out/engine/net6.0 /App
+
+# Change working directory to the /App folder within the Docker image and configure
+# how Data Api buider is started when the container runs.
+WORKDIR /App
+ENV ASPNETCORE_URLS=http://+:5000
+ENTRYPOINT ["dotnet", "Azure.DataApiBuilder.Service.dll"]


### PR DESCRIPTION
## Why make this change?

- Part of #2095

## What is this change?

- Used by pipelines to build Docker container.
- This Dockerfile assumes that pre-built DAB bits are provided to the Docker context. 
- The provided built binaries are in path `/src/out/engine/net6.0`

## How was this tested?
- [x] Pipeline
- [x] Local run of docker build -> docker compose ->  

- In the docker build step, `C:\<repo_root_with_project_built>` just means: clone repo and build dab with dotnet build. pass the path pointing to the root of the repo.
- the arg `-f "C:\dockertest-ob\Dockerfile"` should point to the Dockerfile e.g. the file this pr adds.
```sh
docker build -t local-dab-container:sean -f "C:\dockertest-ob\Dockerfile" C:\<repo_root_with_project_built>

docker compose -f "C:\dockertest-ob\docker-compose-mssql.yml" --verbose up
```

Sample docker compose file:

```yml
version: "3.9"
services:
  hawaii:
    image: "local-dab-container:sean"
    ports:
      - "5000:5000"
    volumes:
      - "C:/dockertest-ob/dab-config.MsSql.json:/App/dab-config.json"
```