### PR TITLE
Cherry pick #2134 and #2135 (CosmosDB: Query Filter by Id Variable support and String Array search)

### DIFF
--- a/src/Core/Models/SqlQueryStructures.cs
+++ b/src/Core/Models/SqlQueryStructures.cs
@@ -143,7 +143,7 @@ public enum PredicateOperation
     None,
     Equal, GreaterThan, LessThan, GreaterThanOrEqual, LessThanOrEqual, NotEqual,
     AND, OR, LIKE, NOT_LIKE,
-    IS, IS_NOT, EXISTS
+    IS, IS_NOT, EXISTS, ARRAY_CONTAINS, NOT_ARRAY_CONTAINS
 }
 
 /// <summary>

--- a/src/Core/Resolvers/CosmosQueryBuilder.cs
+++ b/src/Core/Resolvers/CosmosQueryBuilder.cs
@@ -108,6 +108,10 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     return "";
                 case PredicateOperation.IS_NOT:
                     return "NOT";
+                case PredicateOperation.ARRAY_CONTAINS:
+                    return "ARRAY_CONTAINS";
+                case PredicateOperation.NOT_ARRAY_CONTAINS:
+                    return "NOT ARRAY_CONTAINS";
                 default:
                     throw new ArgumentException($"Cannot build unknown predicate operation {op}.");
             }
@@ -125,7 +129,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             }
 
             string predicateString;
-            if (ResolveOperand(predicate.Right).Equals(GQLFilterParser.NullStringValue))
+            if (predicate.Op == PredicateOperation.ARRAY_CONTAINS || predicate.Op == PredicateOperation.NOT_ARRAY_CONTAINS)
+            {
+                predicateString = $" {Build(predicate.Op)} ( {ResolveOperand(predicate.Left)}, {ResolveOperand(predicate.Right)})";
+            }
+            else if (ResolveOperand(predicate.Right).Equals(GQLFilterParser.NullStringValue))
             {
                 predicateString = $" {Build(predicate.Op)} IS_NULL({ResolveOperand(predicate.Left)})";
             }

--- a/src/Core/Resolvers/CosmosQueryEngine.cs
+++ b/src/Core/Resolvers/CosmosQueryEngine.cs
@@ -9,6 +9,7 @@ using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Core.Services.MetadataProviders;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Queries;
+using Azure.DataApiBuilder.Service.Services;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using Microsoft.AspNetCore.Mvc;
@@ -68,7 +69,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
             CosmosClient client = _clientProvider.Clients[dataSourceName];
             Container container = client.GetDatabase(structure.Database).GetContainer(structure.Container);
-            (string idValue, string partitionKeyValue) = await GetIdAndPartitionKey(parameters, container, structure, metadataStoreProvider);
+            (string idValue, string partitionKeyValue) = await GetIdAndPartitionKey(context, parameters, container, structure, metadataStoreProvider);
 
             foreach (KeyValuePair<string, DbConnectionParam> parameterEntry in structure.Parameters)
             {
@@ -271,7 +272,22 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         }
 
 #nullable enable
-        private static async Task<(string? idValue, string? partitionKeyValue)> GetIdAndPartitionKey(IDictionary<string, object?> parameters, Container container, CosmosQueryStructure structure, ISqlMetadataProvider metadataStoreProvider)
+
+        /// <summary>
+        /// Resolve partition key and id value from input parameters.
+        /// </summary>
+        /// <param name="context">Provide the information about variables and filters</param>
+        /// <param name="parameters">Contains argument information such as id, filter</param>
+        /// <param name="container">Container instance to get the container properties such as partition path</param>
+        /// <param name="structure">Fallback to get partition path information</param>
+        /// <param name="metadataStoreProvider">Set partition key path, fetched from container properties</param>
+        /// <returns></returns>
+        private static async Task<(string? idValue, string? partitionKeyValue)> GetIdAndPartitionKey(
+            IMiddlewareContext context,
+            IDictionary<string, object?> parameters,
+            Container container,
+            CosmosQueryStructure structure,
+            ISqlMetadataProvider metadataStoreProvider)
         {
             string? partitionKeyValue = null, idValue = null;
             string partitionKeyPath = await GetPartitionKeyPath(container, metadataStoreProvider);
@@ -287,8 +303,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 else if (parameterEntry.Key == QueryBuilder.FILTER_FIELD_NAME)
                 {
                     // Mapping partitionKey and id value from filter object if filter keyword exists in args
-                    partitionKeyValue = GetPartitionKeyValue(partitionKeyPath, parameterEntry.Value);
-                    idValue = GetIdValue(parameterEntry.Value);
+                    partitionKeyValue = GetPartitionKeyValue(context, partitionKeyPath, parameterEntry.Value);
+                    idValue = GetIdValue(context, parameterEntry.Value);
                 }
             }
 
@@ -310,7 +326,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="parameter"></param>
         /// <returns></returns>
 #nullable enable
-        private static string? GetPartitionKeyValue(string? partitionKeyPath, object? parameter)
+        private static string? GetPartitionKeyValue(IMiddlewareContext context, string? partitionKeyPath, object? parameter)
         {
             if (parameter is null || partitionKeyPath is null)
             {
@@ -324,7 +340,10 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 if (partitionKeyPath == string.Empty
                     && string.Equals(item.Name.Value, "eq", StringComparison.OrdinalIgnoreCase))
                 {
-                    return item.Value.Value?.ToString();
+                    return ExecutionHelper.ExtractValueFromIValueNode(
+                        item.Value,
+                        context.Selection.Field.Arguments[QueryBuilder.FILTER_FIELD_NAME],
+                        context.Variables)?.ToString();
                 }
 
                 if (partitionKeyPath != string.Empty
@@ -333,7 +352,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     // Recursion to mapping next inner object
                     int index = partitionKeyPath.IndexOf(currentEntity);
                     string newPartitionKeyPath = partitionKeyPath[(index + currentEntity.Length)..partitionKeyPath.Length];
-                    return GetPartitionKeyValue(newPartitionKeyPath, item.Value.Value);
+                    return GetPartitionKeyValue(context, newPartitionKeyPath, item.Value.Value);
                 }
             }
 
@@ -345,7 +364,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         /// <param name="parameter"></param>
         /// <returns></returns>
-        private static string? GetIdValue(object? parameter)
+        private static string? GetIdValue(IMiddlewareContext context, object? parameter)
         {
             if (parameter != null)
             {
@@ -354,7 +373,18 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     if (string.Equals(item.Name.Value, "id", StringComparison.OrdinalIgnoreCase))
                     {
                         IList<ObjectFieldNode>? idValueObj = (IList<ObjectFieldNode>?)item.Value.Value;
-                        return idValueObj?.FirstOrDefault(x => x.Name.Value == "eq")?.Value?.Value?.ToString();
+
+                        ObjectFieldNode? itemToResolve = idValueObj?.FirstOrDefault(x => x.Name.Value == "eq");
+                        if (itemToResolve is null)
+                        {
+                            return null;
+                        }
+
+                        return ExecutionHelper.ExtractValueFromIValueNode(
+                            itemToResolve.Value,
+                            context.Selection.Field.Arguments[QueryBuilder.FILTER_FIELD_NAME],
+                            context.Variables)?
+                            .ToString();
                     }
                 }
             }

--- a/src/Service.Tests/CosmosTests/QueryFilterTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryFilterTests.cs
@@ -1093,7 +1093,47 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
         }
 
         /// <summary>
-        /// Tests that the pk level query filter is working variables
+        /// Tests that the field level query filter work with list type for 'contains' operator
+        /// </summary>
+        [TestMethod]
+        public async Task TestQueryFilterContains_WithStringArray()
+        {
+            string gqlQuery = @"{
+                planets(" + QueryBuilder.FILTER_FIELD_NAME + @" : {tags: { contains : ""tag1""}})
+                {
+                    items {
+                        id
+                        name
+                    }
+                }
+            }";
+
+            string dbQuery = $"SELECT c.id, c.name FROM c where ARRAY_CONTAINS(c.tags, 'tag1')";
+            await ExecuteAndValidateResult(_graphQLQueryName, gqlQuery, dbQuery);
+        }
+
+        /// <summary>
+        /// Tests that the field level query filter work with list type for 'notcontains' operator.
+        /// </summary>
+        [TestMethod]
+        public async Task TestQueryFilterNotContains_WithStringArray()
+        {
+            string gqlQuery = @"{
+                planets(" + QueryBuilder.FILTER_FIELD_NAME + @" : {tags: { notContains : ""tag3""}})
+                {
+                    items {
+                        id
+                        name
+                    }
+                }
+            }";
+
+            string dbQuery = $"SELECT c.id, c.name FROM c where NOT ARRAY_CONTAINS(c.tags, 'tag3')";
+            await ExecuteAndValidateResult(_graphQLQueryName, gqlQuery, dbQuery);
+        }
+
+        /// <summary>
+        /// Tests that the pk level query filter is working with variables.
         /// </summary>
         [TestMethod]
         public async Task TestQueryIdFilterField_WithVariables()

--- a/src/Service.Tests/CosmosTests/QueryFilterTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryFilterTests.cs
@@ -262,7 +262,7 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
             await ExecuteAndValidateResult(_graphQLQueryName, gqlQuery, dbQueryWithJoin);
         }
 
-        private async Task ExecuteAndValidateResult(string graphQLQueryName, string gqlQuery, string dbQuery, bool ignoreBlankResults = false, Dictionary<string, object> variables = null)
+        private async Task ExecuteAndValidateResult(string graphQLQueryName, string gqlQuery, string dbQuery, Dictionary<string, object> variables = null)
         {
             string authToken = AuthTestHelper.CreateStaticWebAppsEasyAuthToken(specificRole: AuthorizationType.Authenticated.ToString());
             JsonElement actual = await ExecuteGraphQLRequestAsync(graphQLQueryName, query: gqlQuery, authToken: authToken, variables: variables);

--- a/src/Service.Tests/CosmosTests/QueryFilterTests.cs
+++ b/src/Service.Tests/CosmosTests/QueryFilterTests.cs
@@ -262,9 +262,10 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
             await ExecuteAndValidateResult(_graphQLQueryName, gqlQuery, dbQueryWithJoin);
         }
 
-        private async Task ExecuteAndValidateResult(string graphQLQueryName, string gqlQuery, string dbQuery)
+        private async Task ExecuteAndValidateResult(string graphQLQueryName, string gqlQuery, string dbQuery, bool ignoreBlankResults = false, Dictionary<string, object> variables = null)
         {
-            JsonElement actual = await ExecuteGraphQLRequestAsync(graphQLQueryName, query: gqlQuery);
+            string authToken = AuthTestHelper.CreateStaticWebAppsEasyAuthToken(specificRole: AuthorizationType.Authenticated.ToString());
+            JsonElement actual = await ExecuteGraphQLRequestAsync(graphQLQueryName, query: gqlQuery, authToken: authToken, variables: variables);
             JsonDocument expected = await ExecuteCosmosRequestAsync(dbQuery, _pageSize, null, _containerName);
             ValidateResults(actual.GetProperty("items"), expected.RootElement);
         }
@@ -1089,6 +1090,28 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
             string errorMessage = response.ToString();
             Assert.IsTrue(errorMessage.Contains(DataApiBuilderException.GRAPHQL_FILTER_FIELD_AUTHZ_FAILURE));
 
+        }
+
+        /// <summary>
+        /// Tests that the pk level query filter is working variables
+        /// </summary>
+        [TestMethod]
+        public async Task TestQueryIdFilterField_WithVariables()
+        {
+            string gqlQuery = @"
+            query ($id: ID) {
+                    planets(" + QueryBuilder.FILTER_FIELD_NAME + @" : {id: {eq : $id}})
+                    {
+                        items {
+                            id
+                            name
+                        }
+                    }
+                }
+            ";
+
+            string dbQuery = $"SELECT c.id, c.name FROM c where c.id = \"{_idList[0]}\"";
+            await ExecuteAndValidateResult(_graphQLQueryName, gqlQuery, dbQuery, variables: new() { { "id", _idList[0] } });
         }
         #endregion
 


### PR DESCRIPTION
Note: these two PRs are ported together as #2135 depends on changes from #2134. So if we ever need to revert, this joint commit will mean that we can't put release branch in broken state.


# #2134 
## Why make this change?

ref. https://github.com/Azure/data-api-builder/issues/1953

## What is this change?

Added variable support if query filter has ID

- Example REST and/or GraphQL request to demonstrate modifications
- Example of CLI usage to demonstrate modifications
# #2135 

## Why make this change?

ref. https://github.com/Azure/data-api-builder/discussions/1897#discussioncomment-8761872

## What is this change?
Added `contains` and `notContains` support for string Array Type.

1. Data schema:
``` gql
type Planet @model {
    id : ID!,
    name : String,
    tags: [String!]
}
```

2. GraphQl :
```graphql
{
      planets(" + QueryBuilder.FILTER_FIELD_NAME + @" : {tags: { contains : ""tag1""}})
      {
          items {
              id
              name
          }
      }
}
```

4. Cosmos DB Query:
```sql
SELECT c.id, c.name FROM c where ARRAY_CONTAINS(c.tags, 'tag1')
```

5. GraphQl :
```graphql
{
    planets(" + QueryBuilder.FILTER_FIELD_NAME + @" : {tags: { notContains : ""tag3""}})
    {
        items {
            id
            name
        }
    }
}
```

7. Cosmos DB Query:
```sql
SELECT c.id, c.name FROM c where NOT ARRAY_CONTAINS(c.tags, 'tag3')
```

## How was this tested?

- [x] Integration Tests
- [ ] Unit Tests


