### PR TITLE
Update notice-generation.ps1 to fix pipeline Issue

### DIFF
--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -9,14 +9,14 @@ param (
 # Download and save the ChilliCream License 1.0 from ChilliCream/graphql-platform GitHub repo
 $chiliCreamLicenseSavePath = "$BuildArtifactStagingDir/chillicreamlicense.txt"
 $chiliCreamLicenseMetadataURL = "https://raw.githubusercontent.com/ChilliCream/graphql-platform/main/website/src/basic/licensing/chillicream-license.md"
-Invoke-WebRequest $chiliCreamLicenseMetadataURL `
-| Select-Object -ExpandProperty Content `
-| Out-File $chiliCreamLicenseSavePath
+Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
+ Select-Object -ExpandProperty Content |
+ Out-File $chiliCreamLicenseSavePath
 
 # Download and save the Microsoft.Data.SqlClient.SNI.runtime license
 $sqlClientSNILicenseSavePath = "$BuildArtifactStagingDir/sqlclient_sni_runtime.txt"
 $sqlClientSNILicenseMetadataURL = "https://www.nuget.org/packages/Microsoft.Data.SqlClient.SNI.runtime/5.0.1/License"
-$pageContent = Invoke-WebRequest $sqlClientSNILicenseMetadataURL
+$pageContent = Invoke-WebRequest $sqlClientSNILicenseMetadataURL -UseBasicParsing
 
 # Regular expression with three capture groups.
 # Capture Group 1: HTML tag which indicates start of license text


### PR DESCRIPTION
## Why make this change?

![image](https://github.com/Azure/data-api-builder/assets/102276754/f6c53cc9-4b6e-407b-a6c6-7a1f0bb98cf6)


## What is this change?
- using the `-UseBasicParsing` parameter with the `Invoke-WebRequest` cmdlet. This parameter tells PowerShell to use a simple internal HTML parser to parse the HTML content and strips the Document Object Model (DOM) parsing engine from Internet Explorer.

## How was this tested?
- pipeline ran correctly

