### PR TITLE
Change TypeName in DatabaseObject Serialization to exclude unwanted parts

### DIFF
--- a/src/Core/Services/MetadataProviders/Converters/DatabaseObjectConverter.cs
+++ b/src/Core/Services/MetadataProviders/Converters/DatabaseObjectConverter.cs
@@ -45,8 +45,8 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders.Converters
             // Add TypeName property in DatabaseObject object that we are serializing based on its type. (DatabaseTable, DatabaseView)
             // We add this property to differentiate between them in the dictionary. This extra property gets used in deserialization above.
             // for example if object is DatabaseTable then we need to add
-            // "TypeName": "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
-            writer.WriteString(TYPE_NAME, value.GetType().AssemblyQualifiedName);
+            // "TypeName": "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config",
+            writer.WriteString(TYPE_NAME, GetTypeNameFromType(value.GetType()));
 
             // Add other properties of DatabaseObject
             foreach (PropertyInfo prop in value.GetType().GetProperties())
@@ -74,6 +74,24 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders.Converters
             }
 
             return type;
+        }
+
+        /// <summary>
+        /// Changes the AssemblyQualified to deseried format
+        /// we cannot use the FullName as during deserialization it throws exception as object not found.
+        /// </summary>
+        private static string GetTypeNameFromType(Type type)
+        {
+            // AssemblyQualifiedName for the type looks like :
+            // "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+            // we donot need version or culture or publickeytoken for serialization or deserialization, we need the first two parts.
+
+            string assemblyQualifiedName  = type.AssemblyQualifiedName!;
+            string[] parts = assemblyQualifiedName.Split(',');
+
+            // typename would be : "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config"
+            string typeName = $"{parts[0]},{parts[1]}";
+            return typeName;
         }
     }
 }

--- a/src/Core/Services/MetadataProviders/Converters/DatabaseObjectConverter.cs
+++ b/src/Core/Services/MetadataProviders/Converters/DatabaseObjectConverter.cs
@@ -77,7 +77,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders.Converters
         }
 
         /// <summary>
-        /// Changes the AssemblyQualified to deseried format
+        /// Changes the Type.AssemblyQualifiedName to desired format
         /// we cannot use the FullName as during deserialization it throws exception as object not found.
         /// </summary>
         private static string GetTypeNameFromType(Type type)

--- a/src/Core/Services/MetadataProviders/Converters/DatabaseObjectConverter.cs
+++ b/src/Core/Services/MetadataProviders/Converters/DatabaseObjectConverter.cs
@@ -86,7 +86,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders.Converters
             // "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
             // we donot need version or culture or publickeytoken for serialization or deserialization, we need the first two parts.
 
-            string assemblyQualifiedName  = type.AssemblyQualifiedName!;
+            string assemblyQualifiedName = type.AssemblyQualifiedName!;
             string[] parts = assemblyQualifiedName.Split(',');
 
             // typename would be : "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config"

--- a/src/Service.Tests/Unittests/SerializationDeserializationTests.cs
+++ b/src/Service.Tests/Unittests/SerializationDeserializationTests.cs
@@ -336,7 +336,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
 
         /// <summary>
         /// During serialization we add TypeName to the DatabaseObject based on its type. TypeName is the AssemblyQualifiedName for the type.
-        /// Example : "TypeName": "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+        /// Example : "TypeName": "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config",
         /// If there is a code refactor which changes the path of this object, the deserialization with old value will fail, as it wont be able to find the object in the location
         /// previously defined.
         /// Note : Currently this is being used by GraphQL workload, failure of this test case needs to be
@@ -367,7 +367,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
 
                     // Split TypeName into different parts
                     // following splits different sections of :
-                    // "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+                    // "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config"
                     string[] typeNameSplitParts = typeName.Split(',');
 
                     string namespaceString = typeNameSplitParts[0].Trim();
@@ -376,6 +376,8 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
 
                     string projectNameString = typeNameSplitParts[1].Trim();
                     Assert.AreEqual(projectNameString, "Azure.DataApiBuilder.Config");
+
+                    Assert.AreEqual(typeNameSplitParts.Length, 2);
                 }
                 else
                 {


### PR DESCRIPTION
## What is this change?
Change TypeName in DatabaseObjectConverter during DatabaseObject Serialization to exclude the unwanted parts.

Currently TypeName field added during DatabaseObject serialization is set to Type.AssemblyQualifiedName, which looks like : "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null"

1.0.0.0 was the default value set, hence when the version changes, deserialization will fail if the initial serialization had version as 1.0.0.0. 

Updating this TypeName to only include the necessary parts : "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable, Azure.DataApiBuilder.Config"

Tested again by using Type.FullName which is "Azure.DataApiBuilder.Config.DatabasePrimitives.DatabaseTable", but serialization fails saying DatabaseTable not found. 

## Why make this change?
Due to recent changes to update the version number based of release, deserialization on graphql workload failed, it is looking for version 1.0.0.0 which doesnot exists. Hence removing the dependency on version number. 

## How was this tested?
- Unit Tests


