### PR TITLE
Update onebranch Dockerfile for windows agent

### DIFF
--- a/onebranch/Dockerfile
+++ b/onebranch/Dockerfile
@@ -3,9 +3,9 @@
 #
 # Version values referenced from https://hub.docker.com/_/microsoft-dotnet-aspnet
 # dotnet/sdk and dotnet/aspnet required to build working container.
-FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0. AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 
 # The ./src/out path below points to the finalized build bits created by the pipeline.
 # The path is relative to the "Docker build context" specified by the parameter dockerFileContextPath


### PR DESCRIPTION
## Why make this change?

- We were getting the error message "no matching manifest for windows/amd64 10.0.20348 in the manifest list entries".
- the problem is that the Docker image we're trying to pull (mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0) does not support the architecture of our Docker host (Windows/amd64).
- The 6.0-cbl-mariner2.0 tag of the dotnet/aspnet image is designed for the CBL-Mariner (Common Base Linux) operating system, which is a Linux distribution developed by Microsoft. This image will not work on a Windows host of our onebranch pipeline.

## What is this change?
-  changed the base images from Linux-based images to Windows-based images.
- `mcr.microsoft.com/dotnet/aspnet:6.0`

## How was this tested?

- [X] pipeline passing