### PR TITLE
[Cherrypick] Update onebranch Dockerfile for windows agent #2159 to `release/0.11`

### DIFF
--- a/onebranch/Dockerfile
+++ b/onebranch/Dockerfile
@@ -1,0 +1,23 @@
+#
+# Build Data API builder Docker container in OneBranch
+#
+# Version values referenced from https://hub.docker.com/_/microsoft-dotnet-aspnet
+# dotnet/sdk and dotnet/aspnet required to build working container.
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+
+# The ./src/out path below points to the finalized build bits created by the pipeline.
+# The path is relative to the "Docker build context" specified by the parameter dockerFileContextPath
+# in task: onebranch.pipeline.imagebuildinfo@1
+# The "Docker build context" contains all the files that will be used by the command "docker build"
+# OneBranch uses the injected task Copy Artifacts to
+# copy artifacts from pipeline artifacts: "/mnt/{...}/out" 
+# to the container running the docker tasks: /mnt/{...}/docker/artifacts/
+COPY ./src/out/engine/net6.0 /App
+
+# Change working directory to the /App folder within the Docker image and configure
+# how Data Api buider is started when the container runs.
+WORKDIR /App
+ENV ASPNETCORE_URLS=http://+:5000
+ENTRYPOINT ["dotnet", "Azure.DataApiBuilder.Service.dll"]


### PR DESCRIPTION
Cherrypick #2159 to `release/0.11`

## Why make this change?

- We were getting the error message "no matching manifest for windows/amd64 10.0.20348 in the manifest list entries".
- the problem is that the Docker image we're trying to pull (mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0) does not support the architecture of our Docker host (Windows/amd64).
- The 6.0-cbl-mariner2.0 tag of the dotnet/aspnet image is designed for the CBL-Mariner (Common Base Linux) operating system, which is a Linux distribution developed by Microsoft. This image will not work on a Windows host of our onebranch pipeline.

## What is this change?
-  changed the base images from Linux-based images to Windows-based images.
- `mcr.microsoft.com/dotnet/aspnet:6.0`

## How was this tested?

- [X] pipeline passing