### PR TITLE
using linux image for building docker image

### DIFF
--- a/onebranch/Dockerfile
+++ b/onebranch/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Version values referenced from https://hub.docker.com/_/microsoft-dotnet-aspnet
 # dotnet/sdk and dotnet/aspnet required to build working container.
-FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0. AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0 AS build
 WORKDIR /src
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0 AS runtime
 

--- a/onebranch/Dockerfile
+++ b/onebranch/Dockerfile
@@ -3,9 +3,9 @@
 #
 # Version values referenced from https://hub.docker.com/_/microsoft-dotnet-aspnet
 # dotnet/sdk and dotnet/aspnet required to build working container.
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0. AS build
 WORKDIR /src
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0 AS runtime
 
 # The ./src/out path below points to the finalized build bits created by the pipeline.
 # The path is relative to the "Docker build context" specified by the parameter dockerFileContextPath


### PR DESCRIPTION
## Why make this change?

- Due to change in the docker image, deployment to ACA started failing.

## What is this change?

- reverting back to using linux image for DAB

## How was this tested?

- verified the docker task in one branch using the linux image
