### PR TITLE
Reverting Original Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,15 @@
-#
-# Build and copy GraphQL binaries and run them.
-#
 # Version values referenced from https://hub.docker.com/_/microsoft-dotnet-aspnet
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0. AS build
+
+
 WORKDIR /src
+COPY [".", "./"]
+RUN dotnet build "./src/Service/Azure.DataApiBuilder.Service.csproj" -c Docker -o /out -r linux-x64
+
 FROM mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0 AS runtime
 
-# The ./src/out path below points to the finalized build bits created by the pipeline.
-# The path is relative to the "Docker build context" specified by the parameter dockerFileContextPath
-# in task: onebranch.pipeline.imagebuildinfo@1
-# The "Docker build context" contains all the files that will be used by the command "docker build"
-# OneBranch uses the injected task Copy Artifacts to
-# copy artifacts from pipeline artifacts: "/mnt/{...}/out" 
-# to the container running the docker tasks: /mnt/{...}/docker/artifacts/
-COPY ./src/out/engine/net6.0 /App
-
-# Change working directory to the /App folder within the Docker image and configure
-# how Data Api buider is started when the container runs.
+COPY --from=build /out /App
 WORKDIR /App
 ENV ASPNETCORE_URLS=http://+:5000
 ENTRYPOINT ["dotnet", "Azure.DataApiBuilder.Service.dll"]


### PR DESCRIPTION

## Why make this change?

- This is redundant and we need to preserve the original dockerfile as someone could be still using it.

## What is this change?

- Reverting this file to the original Dockerfile. Since we already have onebranch related Dockerfile: https://github.com/Azure/data-api-builder/blob/main/onebranch/Dockerfile

