### PR TITLE
Update Dockerfile to copy Linux instead of Windows build contents

### DIFF
--- a/onebranch/Dockerfile
+++ b/onebranch/Dockerfile
@@ -14,7 +14,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0 AS runtime
 # OneBranch uses the injected task Copy Artifacts to
 # copy artifacts from pipeline artifacts: "/mnt/{...}/out" 
 # to the container running the docker tasks: /mnt/{...}/docker/artifacts/
-COPY ./src/out/engine/net6.0 /App
+COPY ./ /App
 
 # Change working directory to the /App folder within the Docker image and configure
 # how Data Api buider is started when the container runs.


### PR DESCRIPTION
## Why make this change?

- Currently it is copying the windows build file. which is breaking a container scenario as it expects linux build files.

## What is this change?

- updated the onebranch dockerfile to not copy the windows build.
- instead it should copy the all the files from the directory specified in the docker task in our one branch pipeline.
- we have updated the docker task to use only the linux build while runnning the docker build task.

## How was this tested?
- verified the files in the container
![image](https://github.com/Azure/data-api-builder/assets/102276754/6a82a7d6-70aa-4c65-919b-e89fc158a242)

