### PR TITLE
Ensure environment variables works for child files.

### DIFF
--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -196,7 +196,7 @@ public record RuntimeConfig
 
             foreach (string dataSourceFile in DataSourceFiles.SourceFiles)
             {
-                if (loader.TryLoadConfig(dataSourceFile, out RuntimeConfig? config))
+                if (loader.TryLoadConfig(dataSourceFile, out RuntimeConfig? config, true))
                 {
                     try
                     {

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -196,7 +196,7 @@ public record RuntimeConfig
 
             foreach (string dataSourceFile in DataSourceFiles.SourceFiles)
             {
-                if (loader.TryLoadConfig(dataSourceFile, out RuntimeConfig? config, true))
+                if (loader.TryLoadConfig(dataSourceFile, out RuntimeConfig? config, replaceEnvVar: true))
                 {
                     try
                     {


### PR DESCRIPTION
## Why make this change?
When we are loading child config files, we were not setting replace env variable to true and hence child config environment variables were not being obeyed. This fix ensures that environment variables can be used for multi-db scenario.

## What is this change?
Adding true to runtimeconfig file.

## How was this tested?
Ran an integration test with two config files and an environment variable in the child file.
