### PR TITLE
Bump dab version in directory.build.props to 1.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <BaseOutputPath>..\out</BaseOutputPath>
-    <Version>0.13</Version>
+    <Version>1.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
## Why make this change?

- To align with next release, updating the version number.

## What is this change?

- Updates version `major.minor` in `Directory.Build.Props` file.

## How was this tested?

- [x] Integration Tests -> testing the *.Product.cspoj file functions which return DabUserAgentString
- [x] Unit Tests 