### PR TITLE
Update Npgsql to 7.0.7 for net6 

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -64,7 +64,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.29" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <!--Once dotnet restore properly resolves that 'Npgsql' 7.0.7 is not vulnerable, set this ref to 7.0.7.-->
-    <PackageVersion Include="Npgsql" Version="8.0.3" />
+    <PackageVersion Include="Npgsql" Version="7.0.7" />
   </ItemGroup>
 </Project>

--- a/src/Service.Tests/Unittests/SerializationDeserializationTests.cs
+++ b/src/Service.Tests/Unittests/SerializationDeserializationTests.cs
@@ -259,9 +259,6 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
         /// Temporarily ignore test for .net6 due to npgsql issue.
         /// </summary>
         [TestMethod]
-#if NET6_0
-        [Ignore]
-#endif
         public void TestDictionaryDatabaseObjectSerializationDeserialization()
         {
             InitializeObjects();


### PR DESCRIPTION
## Why make this change?

- Closes #2206
- As noted in #2207, now that false positive vulnerability alert no longer shows due to correct patched versions being recognized by dotnet restore.
- Merging Directory to 1.1 branch.

## What is this change?

- For .net6 updates npgsql to 7.0.7.
- Removes "ignore" tag on serialization/deserialization test that broke because of the npgsql version used.

## How was this tested?
- [x] Unit Tests 
  - `dotnet format` step passes without dotnet restore vulnerability alert.
  - unit test `TestDictionaryDatabaseObjectSerializationDeserialization` unignored
