### PR TITLE
`dab-manifest.json` include previously used file identifiers and point to .net6

### DIFF
--- a/scripts/create-manifest-file.ps1
+++ b/scripts/create-manifest-file.ps1
@@ -55,7 +55,7 @@ $latestBlock = @'
     "releaseType": "${releaseType}",
     "releaseDate": "${releaseDate}",
     "files": {
-        "linux-x64-net6":{
+        "linux-x64":{
             "url": "$($frameworkPlatformDownloadMetadata["net6.0_linux-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net6.0_linux-x64"])"
         },
@@ -63,7 +63,7 @@ $latestBlock = @'
             "url": "$($frameworkPlatformDownloadMetadata["net8.0_linux-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net8.0_linux-x64"])"
         },
-        "win-x64-net6":{
+        "win-x64":{
             "url": "$($frameworkPlatformDownloadMetadata["net6.0_win-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net6.0_win-x64"])"
         },
@@ -71,7 +71,7 @@ $latestBlock = @'
             "url": "$($frameworkPlatformDownloadMetadata["net8.0_win-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net8.0_win-x64"])"
         },
-        "osx-x64-net6":{
+        "osx-x64":{
             "url": "$($frameworkPlatformDownloadMetadata["net6.0_osx-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net6.0_osx-x64"])"
         },

--- a/scripts/create-manifest-file.ps1
+++ b/scripts/create-manifest-file.ps1
@@ -59,6 +59,10 @@ $latestBlock = @'
             "url": "$($frameworkPlatformDownloadMetadata["net6.0_linux-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net6.0_linux-x64"])"
         },
+        "linux-x64-net6":{
+            "url": "$($frameworkPlatformDownloadMetadata["net6.0_linux-x64"])",
+            "sha": "$($frameworkPlatformFileHashMetadata["net6.0_linux-x64"])"
+        },
         "linux-x64-net8":{
             "url": "$($frameworkPlatformDownloadMetadata["net8.0_linux-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net8.0_linux-x64"])"
@@ -67,11 +71,19 @@ $latestBlock = @'
             "url": "$($frameworkPlatformDownloadMetadata["net6.0_win-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net6.0_win-x64"])"
         },
+        "win-x64-net6":{
+            "url": "$($frameworkPlatformDownloadMetadata["net6.0_win-x64"])",
+            "sha": "$($frameworkPlatformFileHashMetadata["net6.0_win-x64"])"
+        },
         "win-x64-net8":{
             "url": "$($frameworkPlatformDownloadMetadata["net8.0_win-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net8.0_win-x64"])"
         },
         "osx-x64":{
+            "url": "$($frameworkPlatformDownloadMetadata["net6.0_osx-x64"])",
+            "sha": "$($frameworkPlatformFileHashMetadata["net6.0_osx-x64"])"
+        },
+        "osx-x64-net6":{
             "url": "$($frameworkPlatformDownloadMetadata["net6.0_osx-x64"])",
             "sha": "$($frameworkPlatformFileHashMetadata["net6.0_osx-x64"])"
         },


### PR DESCRIPTION
## Why make this change?

- Add back `<platform>-x64` file tag in the dab-manifest.json file (`linux-x64`, `osx-x64`, and `win-x64`)
  - This change will also maintain compat with SWA CLI: https://github.com/Azure/static-web-apps-cli/blob/0055b77b691704f0f383dce0498de851bb81e411/src/core/download-binary-helper.ts#L25
  - The following example is specifically linux but the file changes include all 3 platforms.
```json
 {
   "files": {
        "linux-x64":{
            "url": "$($frameworkPlatformDownloadMetadata["net6.0_linux-x64"])",
            "sha": "$($frameworkPlatformFileHashMetadata["net6.0_linux-x64"])"
        },
        "linux-x64-net6":{
            "url": "$($frameworkPlatformDownloadMetadata["net6.0_linux-x64"])",
            "sha": "$($frameworkPlatformFileHashMetadata["net6.0_linux-x64"])"
        }
}
}
```

## What is this change?

 - `1.1.7` just has `linux-x64-net6` and this update adds `linux-x64` back to the list and points to .net6 dab binaries. (we'll need to update this by November in alignment with [.NET6 going out of support.](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core#:~:text=.NET%206.0%20(LTS,Nov%2012%2C%202024)
