### PR TITLE
Use global package reference

### DIFF
--- a/src/Auth/Azure.DataApiBuilder.Auth.csproj
+++ b/src/Auth/Azure.DataApiBuilder.Auth.csproj
@@ -16,12 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.AspNetCore.Http" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Drawing.Common" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -37,7 +37,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 

--- a/src/Config/Azure.DataApiBuilder.Config.csproj
+++ b/src/Config/Azure.DataApiBuilder.Config.csproj
@@ -23,11 +23,6 @@
       <PackageReference Include="Microsoft.Data.SqlClient" />
       <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-      <PackageReference Include="StyleCop.Analyzers">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
       <PackageReference Include="Humanizer" />
       <PackageReference Include="Npgsql" />
   </ItemGroup>

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -25,10 +25,6 @@
     <PackageReference Include="Microsoft.OData.Core" />
     <PackageReference Include="Microsoft.OData.Edm" />
     <PackageReference Include="Microsoft.OpenApi" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="Newtonsoft.Json" />
@@ -42,7 +38,7 @@
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-    
+
   <ItemGroup>
     <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj" />
     <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -39,7 +39,6 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageVersion Include="Polly" Version="7.2.3" />
     <PackageVersion Include="NJsonSchema" Version="10.9.0" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.3" />
@@ -69,5 +68,8 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageVersion Include="Npgsql" Version="7.0.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -45,7 +45,6 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.1.2" />
     <PackageVersion Include="System.IO.Abstractions" Version="21.0.2" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="21.0.2" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Verify.MsTest" Version="23.6.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="2.3.0" />
     <PackageVersion Include="ZiggyCreatures.FusionCache" Version="1.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -61,13 +61,13 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
     <PackageVersion Include="Npgsql" Version="8.0.3" />
   </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="6.0.29" />
-        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.29" />
-        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.29" />
-        <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.29" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-        <PackageVersion Include="Npgsql" Version="7.0.7" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="6.0.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.29" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageVersion Include="Npgsql" Version="7.0.7" />
+  </ItemGroup>
 </Project>

--- a/src/Product/Azure.DataApiBuilder.Product.csproj
+++ b/src/Product/Azure.DataApiBuilder.Product.csproj
@@ -13,8 +13,4 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-  </ItemGroup>
-    
 </Project>

--- a/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
+++ b/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
@@ -24,11 +24,6 @@
     <PackageReference Include="HotChocolate.Types.NodaTime" />
     <PackageReference Include="Humanizer" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
+++ b/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
@@ -43,10 +43,6 @@
     </PackageReference>
     <PackageReference Include="HotChocolate" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="Verify.MSTest" />
     <PackageReference Include="Verify.DiffPlex" />

--- a/src/Service/Azure.DataApiBuilder.Service.csproj
+++ b/src/Service/Azure.DataApiBuilder.Service.csproj
@@ -12,7 +12,7 @@
     <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
       <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <InternalsVisibleTo Include="Azure.DataApiBuilder.Service.Tests" />
     </ItemGroup>
@@ -73,14 +73,9 @@
         <PackageReference Include="Npgsql" />
         <PackageReference Include="Polly" />
         <PackageReference Include="DotNetEnv" />
-        <PackageReference Include="StyleCop.Analyzers">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
         <PackageReference Include="System.CommandLine" />
         <PackageReference Include="System.IO.Abstractions" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
         <PackageReference Include="ZiggyCreatures.FusionCache" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
- use `GlobalPackageReference` for `StyleCop.Analyzers`
- remove `Microsoft.SourceLink.GitHub` since the source link and this package had been included in .NET 8 SDK

https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management#global-package-references

https://github.com/dotnet/sourcelink?tab=readme-ov-file#using-source-link-in-net-projects