### PR TITLE
Fixing DateTime null parse issue in datawarehouse queries.

### DIFF
--- a/src/Core/Resolvers/DWSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/DWSqlQueryBuilder.cs
@@ -108,7 +108,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 // If the column is not a subquery column and is not a string, cast it to string
                 if (!subQueryColumn && structure.GetColumnSystemType(column.ColumnName) != typeof(string))
                 {
-                    col_value = $"CAST([{col_value}] AS NVARCHAR(MAX))";
+                    // 121 ensures the time precision is kept:https://learn.microsoft.com/en-us/sql/t-sql/data-types/date-transact-sql?view=fabric&preserve-view=true
+                    col_value = $"CONVERT(NVARCHAR(MAX), [{col_value}], 121)";
 
                     Type col_type = structure.GetColumnSystemType(column.ColumnName);
 

--- a/src/Core/Services/ExecutionHelper.cs
+++ b/src/Core/Services/ExecutionHelper.cs
@@ -165,8 +165,8 @@ namespace Azure.DataApiBuilder.Service.Services
                     FloatType => fieldValue.GetDouble(), // spec
                     SingleType => fieldValue.GetSingle(),
                     DecimalType => fieldValue.GetDecimal(),
-                    DateTimeType => DateTimeOffset.Parse(fieldValue.GetString()!, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal),
-                    DateType => DateTimeOffset.Parse(fieldValue.GetString()!),
+                    DateTimeType => DateTimeOffset.TryParse(fieldValue.GetString()!, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.AssumeUniversal, out DateTimeOffset date) ? date : null, // for DW when datetime is null it will be in "" due to stringagg parsing and hence we need to ensure parsing is correct.
+                    DateType => DateTimeOffset.TryParse(fieldValue.GetString()!, out DateTimeOffset date) ? date : null,
                     LocalTimeType => LocalTimePattern.ExtendedIso.Parse(fieldValue.GetString()!).Value,
                     ByteArrayType => fieldValue.GetBytesFromBase64(),
                     BooleanType => fieldValue.GetBoolean(), // spec

--- a/src/Service.Tests/DatabaseSchema-DwSql.sql
+++ b/src/Service.Tests/DatabaseSchema-DwSql.sql
@@ -49,7 +49,8 @@ COMMIT;
 CREATE TABLE books(
     id int NOT NULL,
     title varchar(2048) NOT NULL,
-    publisher_id int NOT NULL
+    publisher_id int NOT NULL,
+    published_date datetime NULL
 );
 
 CREATE TABLE book_website_placements(
@@ -330,6 +331,8 @@ VALUES (1, 'Awesome book', 1234),
 (12, 'Time to Eat 2', 1941),
 (13, 'Before Sunrise', 1234),
 (14, 'Before Sunset', 1234);
+
+INSERT INTO books(id, title, publisher_id, published_date) VALUES (15, 'Before Sunset 2', 1234, '2023-08-21 15:11:04');
 
 INSERT INTO book_website_placements(id, book_id, price) VALUES (1, 1, 100), (2, 2, 50), (3, 3, 23), (4, 5, 33);
 

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/DwSqlGraphQLQueryTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/DwSqlGraphQLQueryTests.cs
@@ -208,6 +208,16 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
         }
 
         /// <summary>
+        /// Get all instances of a type with nullable datetime fields
+        /// </summary>
+        [TestMethod]
+        public async Task TestQueryingTypeWithNullableDateTimeFields()
+        {
+            string msSqlQuery = $"SELECT id, title, published_date FROM books ORDER BY id asc FOR JSON PATH, INCLUDE_NULL_VALUES";
+            await TestQueryingTypeWithNullableDateTimeFields(msSqlQuery);
+        }
+
+        /// <summary>
         /// Get all instances of a type with nullable string fields
         /// </summary>
         [TestMethod]

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/GraphQLQueryTestBase.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/GraphQLQueryTestBase.cs
@@ -991,6 +991,29 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
         }
 
         /// <summary>
+        /// Get all instances of a type with nullable datetime fields
+        /// </summary>
+        [TestMethod]
+        public async Task TestQueryingTypeWithNullableDateTimeFields(string dbQuery)
+        {
+            string graphQLQueryName = "books";
+            string graphQLQuery = @"{
+                books(first: 100) {
+                    items {
+                        id
+                        title
+                        published_date
+                    }
+                }
+            }";
+
+            JsonElement actual = await ExecuteGraphQLRequestAsync(graphQLQuery, graphQLQueryName, isAuthenticated: true);
+            string expected = await GetDatabaseResultAsync(dbQuery);
+
+            SqlTestHelper.PerformTestEqualJsonStrings(expected, actual.GetProperty("items").ToString());
+        }
+
+        /// <summary>
         /// Test to check graphQL support for aliases(arbitrarily set by user while making request).
         /// book_id and book_title are aliases used for corresponding query fields.
         /// The response for the query will contain the alias instead of raw db column.


### PR DESCRIPTION
## Why make this change?
When we moved to the new form of query execution: https://github.com/Azure/data-api-builder/pull/2068, we got rid of the resolver middleware that had the function: 
`        public static bool RepresentsNullValue(JsonElement element)
        {
            return (string.IsNullOrEmpty(element.ToString()) && element.GetRawText() == "null");
        }`

which would check if the returned string was null. This was useful for datetime values in datawarehouse where because of the use of string agg we have to return null as a string. 

The error that is seen is:         "The string 'null' was not recognized as a valid DateTime. There is an unknown word starting at index '0'.
## What is this change?
This change switches to leveraging tryparse for the datetime field value. This allows us to handle the null case, as if the string is null, tryparse will just fail and return null for date. 

## How was this tested?
A test has been added to ensure that datetime null case is handled.
