### PR TITLE
Adding Sql pool is warming up error code to list of transient exceptions

### DIFF
--- a/src/Core/Resolvers/MsSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MsSqlDbExceptionParser.cs
@@ -36,7 +36,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 // https://github.com/dotnet/efcore/blob/main/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
                 "20", "64", "121", "233", "601", "617", "669", "921", "997", "1203", "1204", "1205", "1221", "1807", "3935", "3960",
                 "3966", "4060", "4221", "8628", "8645", "8651", "9515", "10053", "10054", "10060", "10922", "10928", "10929", "10936",
-                "14355", "17197", "20041", "40197", "40501", "40613", "41301", "41302", "41305", "41325", "41839", "49918", "49919", "49920",
+                "14355", "17197", "20041", "40197", "40501", "40613", "41301", "41302", "41305", "41325", "41839", "42109", "49918", "49919", "49920",
 
                 // Transient error codes compiled from:
                 //  https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconfigurableretryfactory?view=sqlclient-dotnet-standard-5.0


### PR DESCRIPTION
## Why make this change?
Datawarehouse's can have cold start up issues leading to sql error: The SQL pool is warming up. Please try again. 
This is a transient exception and the recommendation is to just retry and connect back to the server:https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/relational-databases/errors-events/mssqlserver-42109-database-engine-error.md. 

## What is this change?
This change adds the error code for the Sql pool is warming up into the transient error code list, ensuring the retry logic comes into play if this error comes up. For the code please see: https://github.com/dotnet/efcore/blob/main/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs

## How was this tested?
1. Existing integration tests cover the logic for retry on transient exception codes.
