### PR TITLE
Add MaxResponseSizeMB to runtime config.

### DIFF
--- a/src/Cli.Tests/ModuleInitializer.cs
+++ b/src/Cli.Tests/ModuleInitializer.cs
@@ -55,6 +55,10 @@ static class ModuleInitializer
         VerifierSettings.IgnoreMember<DataSource>(dataSource => dataSource.DatabaseTypeNotSupportedMessage);
         // Ignore DefaultDataSourceName as that's not serialized in our config file.
         VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.DefaultDataSourceName);
+        // Ignore MaxResponseSizeMB as as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<HostOptions>(options => options.MaxResponseSizeMB);
+        // Ignore UserProvidedMaxResponseSizeMB as that's not serialized in our config file.
+        VerifierSettings.IgnoreMember<HostOptions>(options => options.UserProvidedMaxResponseSizeMB);
         // Customise the path where we store snapshots, so they are easier to locate in a PR review.
         VerifyBase.DerivePathInfo(
             (sourceFile, projectDirectory, type, method) => new(

--- a/src/Config/Converters/HostOptionsConverterFactory.cs
+++ b/src/Config/Converters/HostOptionsConverterFactory.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.DataApiBuilder.Config.ObjectModel;
+
+namespace Azure.DataApiBuilder.Config.Converters;
+
+/// <summary>
+/// Defines how DAB reads and writes an entity's cache options (JSON).
+/// </summary>
+internal class HostOptionsConvertorFactory : JsonConverterFactory
+{
+    /// <inheritdoc/>
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert.IsAssignableTo(typeof(HostOptions));
+    }
+
+    /// <inheritdoc/>
+    public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        return new HostOptionsConverter();
+    }
+
+    private class HostOptionsConverter : JsonConverter<HostOptions>
+    {
+        /// <summary>
+        /// Defines how DAB reads host options and defines which values are
+        /// used to instantiate HostOptions.
+        /// </summary>
+        /// <exception cref="JsonException">Thrown when improperly formatted cache options are provided.</exception>
+        public override HostOptions? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return JsonSerializer.Deserialize<HostOptions>(ref reader, options);
+        }
+
+        /// <summary>
+        /// When writing the HostOptions back to a JSON file, only write the MaxResponseSizeMB property
+        /// if the property is user provided. This avoids polluting the written JSON file with a property
+        /// the user most likely ommitted when writing the original DAB runtime config file.
+        /// This Write operation is only used when a RuntimeConfig object is serialized to JSON.
+        /// </summary>
+        public override void Write(Utf8JsonWriter writer, HostOptions value, JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WritePropertyName("cors");
+            JsonSerializer.Serialize(writer, value.Cors, options);
+            writer.WritePropertyName("authentication");
+            JsonSerializer.Serialize(writer, value.Authentication, options);
+            writer.WritePropertyName("mode");
+            JsonSerializer.Serialize(writer, value.Mode, options);
+
+            if (value?.UserProvidedMaxResponseSizeMB is true)
+            {
+                writer.WritePropertyName("max-response-size-mb");
+                JsonSerializer.Serialize(writer, value.MaxResponseSizeMB, options);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/Config/Converters/HostOptionsConverterFactory.cs
+++ b/src/Config/Converters/HostOptionsConverterFactory.cs
@@ -8,7 +8,7 @@ using Azure.DataApiBuilder.Config.ObjectModel;
 namespace Azure.DataApiBuilder.Config.Converters;
 
 /// <summary>
-/// Defines how DAB reads and writes an entity's cache options (JSON).
+/// Defines how DAB reads and writes host options.
 /// </summary>
 internal class HostOptionsConvertorFactory : JsonConverterFactory
 {
@@ -29,8 +29,9 @@ internal class HostOptionsConvertorFactory : JsonConverterFactory
         /// <summary>
         /// Defines how DAB reads host options and defines which values are
         /// used to instantiate HostOptions.
+        /// Uses default deserialize.
         /// </summary>
-        /// <exception cref="JsonException">Thrown when improperly formatted cache options are provided.</exception>
+        /// <exception cref="JsonException">Thrown when improperly formatted host options are provided.</exception>
         public override HostOptions? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return JsonSerializer.Deserialize<HostOptions>(ref reader, options);

--- a/src/Config/Converters/HostOptionsConverterFactory.cs
+++ b/src/Config/Converters/HostOptionsConverterFactory.cs
@@ -35,9 +35,9 @@ internal class HostOptionsConvertorFactory : JsonConverterFactory
         public override HostOptions? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             // Remove the converter so we don't recurse.
-            JsonSerializerOptions innerOptions = new(options);
-            innerOptions.Converters.Remove(innerOptions.Converters.First(c => c is HostOptionsConvertorFactory));
-            return JsonSerializer.Deserialize<HostOptions>(ref reader, options);
+            JsonSerializerOptions jsonSerializerOptions = new(options);
+            jsonSerializerOptions.Converters.Remove(jsonSerializerOptions.Converters.First(c => c is HostOptionsConvertorFactory));
+            return JsonSerializer.Deserialize<HostOptions>(ref reader, jsonSerializerOptions);
         }
 
         /// <summary>

--- a/src/Config/Converters/HostOptionsConverterFactory.cs
+++ b/src/Config/Converters/HostOptionsConverterFactory.cs
@@ -34,6 +34,9 @@ internal class HostOptionsConvertorFactory : JsonConverterFactory
         /// <exception cref="JsonException">Thrown when improperly formatted host options are provided.</exception>
         public override HostOptions? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
+            // Remove the converter so we don't recurse.
+            JsonSerializerOptions innerOptions = new(options);
+            innerOptions.Converters.Remove(innerOptions.Converters.First(c => c is HostOptionsConvertorFactory));
             return JsonSerializer.Deserialize<HostOptions>(ref reader, options);
         }
 

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -64,12 +64,12 @@ public record HostOptions
     /// <summary>
     /// Flag which informs CLI and JSON serializer whether to write MaxResponseSizeMB.
     /// property and value to the runtime config file.
-    /// When user doesn't provide the MaxResponseSizeMBproperty/value, which signals DAB to use the default,
+    /// When user doesn't provide the MaxResponseSizeMB property/value, which signals DAB to use the default,
     /// the DAB CLI should not write the default value to a serialized config.
     /// This is because the user's intent is to use DAB's default value which could change
     /// and DAB CLI writing the property and value would lose the user's intent.
     /// This is because if the user were to use the CLI created config, MaxResponseSizeMB
-    /// property/value specified would be interpreted by DAB as "user explicitly default-page-size."
+    /// property/value specified would be interpreted by DAB as "user explicitly set MaxResponseSizeMB."
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
     [MemberNotNullWhen(true, nameof(MaxResponseSizeMB))]

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -64,12 +64,13 @@ public record HostOptions
     /// <summary>
     /// Flag which informs CLI and JSON serializer whether to write MaxResponseSizeMB.
     /// property and value to the runtime config file.
-    /// When user doesn't provide the MaxResponseSizeMB property/value, which signals DAB to use the default,
-    /// the DAB CLI should not write the default value to a serialized config.
+    /// When user doesn't provide the MaxResponseSizeMB property/value or provides a null value, which signals DAB to use the default,
+    /// the DAB CLI will not write the default value to a serialized config.
     /// This is because the user's intent is to use DAB's default value which could change
     /// and DAB CLI writing the property and value would lose the user's intent.
     /// This is because if the user were to use the CLI created config, MaxResponseSizeMB
-    /// property/value specified would be interpreted by DAB as "user explicitly set MaxResponseSizeMB."
+    /// property/value specified would be interpreted by DAB as "user explicitly set MaxResponseSizeMB.
+    /// UserProvidedMaxResponseSizeMB is true only when a user provides a non-null value
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
     [MemberNotNullWhen(true, nameof(MaxResponseSizeMB))]

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -13,8 +13,10 @@ public record HostOptions
     /// <summary>
     /// Dab engine can at maximum handle 158 MB of data in a single response from a source.
     /// Json deserialization of a response into a string has a limit of 166,666,666 bytes which when converted to MB is 158 MB.
-    /// ref: enforcing code: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs#L103
-    /// ref: Json constant: https://github.com/stephentoub/runtime/blob/main/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+    /// ref: enforcing code:
+    /// .net8: https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs#L80
+    /// .net6: https://github.com/dotnet/runtime/blob/v8.0.0/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.cs#75
+    /// ref: Json constant: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs#L80
     /// </summary>
     private const int MAX_RESPONSE_LENGTH_DAB_ENGINE_MB = 158;
 

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -37,7 +37,7 @@ public record HostOptions
         if (this.MaxResponseSizeMB is not null && (this.MaxResponseSizeMB < 1 || this.MaxResponseSizeMB > MAX_RESPONSE_LENGTH_DAB_ENGINE_MB))
         {
             throw new DataApiBuilderException(
-                message: $"{nameof(RuntimeConfig.Runtime.Host.MaxResponseSizeMB)} must be greater than 0 and <= 187 MB.",
+                message: $"{nameof(RuntimeConfig.Runtime.Host.MaxResponseSizeMB)} must be greater than 0 and <= {MAX_RESPONSE_LENGTH_DAB_ENGINE_MB} MB.",
                 statusCode: HttpStatusCode.ServiceUnavailable,
                 subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
         }

--- a/src/Config/ObjectModel/HostOptions.cs
+++ b/src/Config/ObjectModel/HostOptions.cs
@@ -1,6 +1,45 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Net;
+using System.Text.Json.Serialization;
+using Azure.DataApiBuilder.Service.Exceptions;
+
 namespace Azure.DataApiBuilder.Config.ObjectModel;
 
-public record HostOptions(CorsOptions? Cors, AuthenticationOptions? Authentication, HostMode Mode = HostMode.Production);
+public record HostOptions
+{
+    /// <summary>
+    /// Dab engine can at maximum handle 187 MB of data in a single response from a source.
+    /// Json deserialization of a response into a string has a limit of 197020041 bytes which when converted to MB is 187 MB.
+    /// </summary>
+    private const int MAX_RESPONSE_LENGTH_DAB_ENGINE_MB = 187;
+
+    [JsonPropertyName("cors")]
+    public CorsOptions? Cors { get; init; }
+
+    [JsonPropertyName("authentication")]
+    public AuthenticationOptions? Authentication { get; init; }
+
+    [JsonPropertyName("mode")]
+    public HostMode Mode { get; init; }
+
+    [JsonPropertyName("max-response-size-mb")]
+    public int? MaxResponseSizeMB { get; init; }
+
+    public HostOptions(CorsOptions? Cors, AuthenticationOptions? Authentication, HostMode Mode = HostMode.Production, int? MaxResponseSizeMB = null)
+    {
+        this.Cors = Cors;
+        this.Authentication = Authentication;
+        this.Mode = Mode;
+        this.MaxResponseSizeMB = MaxResponseSizeMB;
+
+        if (this.MaxResponseSizeMB is not null && (this.MaxResponseSizeMB < 1 || this.MaxResponseSizeMB > MAX_RESPONSE_LENGTH_DAB_ENGINE_MB))
+        {
+            throw new DataApiBuilderException(
+                message: $"{nameof(RuntimeConfig.Runtime.Host.MaxResponseSizeMB)} must be greater than 0 and <= 187 MB.",
+                statusCode: HttpStatusCode.ServiceUnavailable,
+                subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
+        }
+    }
+}

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -495,6 +495,11 @@ public record RuntimeConfig
         return (uint?)Runtime?.Pagination?.MaxPageSize ?? PaginationOptions.MAX_PAGE_SIZE;
     }
 
+    public int? MaxResponseSizeMB()
+    {
+        return Runtime?.Host?.MaxResponseSizeMB;
+    }
+
     /// <summary>
     /// Get the pagination limit from the runtime configuration.
     /// </summary>

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -500,6 +500,12 @@ public record RuntimeConfig
         return Runtime?.Host?.MaxResponseSizeMB;
     }
 
+    public bool MaxResponseSizeLogicEnabled()
+    {
+        // If the user has provided a max response size, we should use new logic to enforce it.
+        return Runtime?.Host?.UserProvidedMaxResponseSizeMB ?? false;
+    }
+
     /// <summary>
     /// Get the pagination limit from the runtime configuration.
     /// </summary>

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -181,6 +181,7 @@ public abstract class RuntimeConfigLoader
         options.Converters.Add(new MultipleCreateOptionsConverter());
         options.Converters.Add(new MultipleMutationOptionsConverter(options));
         options.Converters.Add(new DataSourceConverterFactory(replaceEnvVar));
+        options.Converters.Add(new HostOptionsConvertorFactory());
 
         if (replaceEnvVar)
         {

--- a/src/Core/Resolvers/MsSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MsSqlDbExceptionParser.cs
@@ -36,7 +36,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 // https://github.com/dotnet/efcore/blob/main/src/EFCore.SqlServer/Storage/Internal/SqlServerTransientExceptionDetector.cs
                 "20", "64", "121", "233", "601", "617", "669", "921", "997", "1203", "1204", "1205", "1221", "1807", "3935", "3960",
                 "3966", "4060", "4221", "8628", "8645", "8651", "9515", "10053", "10054", "10060", "10922", "10928", "10929", "10936",
-                "14355", "17197", "20041", "40197", "40501", "40613", "41301", "41302", "41305", "41325", "41839", "49918", "49919", "49920",
+                "14355", "17197", "20041", "40197", "40501", "40613", "41301", "41302", "41305", "41325", "41839", "42109", "49918", "49919", "49920",
 
                 // Transient error codes compiled from:
                 //  https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlconfigurableretryfactory?view=sqlclient-dotnet-standard-5.0

--- a/src/Service.Tests/ModuleInitializer.cs
+++ b/src/Service.Tests/ModuleInitializer.cs
@@ -59,6 +59,10 @@ static class ModuleInitializer
         VerifierSettings.IgnoreMember<DataSource>(dataSource => dataSource.DatabaseTypeNotSupportedMessage);
         // Ignore DefaultDataSourceName as that's not serialized in our config file.
         VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.DefaultDataSourceName);
+        // Ignore MaxResponseSizeMB as as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<HostOptions>(options => options.MaxResponseSizeMB);
+        // Ignore UserProvidedMaxResponseSizeMB as that's not serialized in our config file.
+        VerifierSettings.IgnoreMember<HostOptions>(options => options.UserProvidedMaxResponseSizeMB);
         // Customise the path where we store snapshots, so they are easier to locate in a PR review.
         VerifyBase.DerivePathInfo(
             (sourceFile, projectDirectory, type, method) => new(

--- a/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
@@ -2436,7 +2436,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         public void ValidateMaxResponseSizeInConfig(
             int? providedMaxResponseSizeMB,
             int? expectedMaxResponseSizeMB,
-            bool exceptionExpected,
+            bool isExceptionExpected,
             string expectedExceptionMessage)
         {
             try
@@ -2454,7 +2454,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             }
             catch (DataApiBuilderException ex)
             {
-                Assert.IsTrue(exceptionExpected);
+                Assert.IsTrue(isExceptionExpected);
                 Assert.AreEqual(expectedExceptionMessage, ex.Message);
             }
         }

--- a/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigValidationUnitTests.cs
@@ -2414,6 +2414,48 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             }
         }
 
+        /// <summary>
+        /// Test to validate the max response size option in the runtime config.
+        /// </summary>
+        /// <param name="exceptionExpected">should there be an exception.</param>
+        /// <param name="maxDbResponseSizeMB">maxResponse size input</param>
+        /// <param name="expectedExceptionMessage">expected exception message in case there is exception.</param>
+        /// <param name="expectedMaxResponseSize">expected value in config.</param>
+        [DataTestMethod]
+        [DataRow(false, null, "", null,
+            DisplayName = "MaxDbResponseSizeMB should be null when no value provided in config.")]
+        [DataRow(false, 64, "", 64,
+            DisplayName = "Valid inputs of MaxResponseSize must be accepted and set in the config.")]
+        [DataRow(true, -1, $"{nameof(RuntimeConfig.Runtime.Host.MaxResponseSizeMB)} must be greater than 0 and <= 187 MB.", null,
+            DisplayName = "Valid inputs of MaxResponseSize must be accepted and set in the config.")]
+        [DataRow(true, 188, $"{nameof(RuntimeConfig.Runtime.Host.MaxResponseSizeMB)} must be greater than 0 and <= 187 MB.", null,
+            DisplayName = "Valid inputs of MaxResponseSize must be accepted and set in the config.")]
+        public void ValidateMaxResponseSizeInConfig(
+            bool exceptionExpected,
+            int? maxDbResponseSizeMB,
+            string expectedExceptionMessage,
+            int? expectedMaxResponseSize = null)
+        {
+            try
+            {
+                RuntimeConfig runtimeConfig = new(
+                    Schema: "UnitTestSchema",
+                    DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, "", Options: null),
+                    Runtime: new(
+                        Rest: new(),
+                        GraphQL: new(),
+                        Host: new(Cors: null, Authentication: null, MaxResponseSizeMB: maxDbResponseSizeMB)
+                    ),
+                    Entities: new(new Dictionary<string, Entity>()));
+                Assert.AreEqual(expectedMaxResponseSize, runtimeConfig.MaxResponseSizeMB());
+            }
+            catch (DataApiBuilderException ex)
+            {
+                Assert.IsTrue(exceptionExpected);
+                Assert.AreEqual(expectedExceptionMessage, ex.Message);
+            }
+        }
+
         private static RuntimeConfigValidator InitializeRuntimeConfigValidator()
         {
             MockFileSystem fileSystem = new();


### PR DESCRIPTION
## Why make this change?
This change adds in a new property to the host parameter of runtime config called MaxResponseSizeMB. This property will allow users to configure the amount of data that their host platform's memory can handle when streaming data from the underlying datasources.

## What is this change?
This change adds the maxresponseSizeMB property to the runtime config. In addition, it adds an accessor for that property which would be needed to implement the actual logic of streaming. 

## How was this tested?
Unit tests are added.
