### PR TITLE
change hardcoded string prefixes and suffixes to constants

### DIFF
--- a/src/Service.GraphQLBuilder/GraphQLNaming.cs
+++ b/src/Service.GraphQLBuilder/GraphQLNaming.cs
@@ -30,6 +30,8 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
 
         public const string LINKING_OBJECT_PREFIX = "linkingObject";
 
+        public const string PK_QUERY_SUFFIX = "_by_pk";
+
         /// <summary>
         /// Enforces the GraphQL naming restrictions on <paramref name="name"/>.
         /// Completely removes invalid characters from the input parameter: name.
@@ -175,7 +177,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
         /// <returns>Name of the primary key query.</returns>
         public static string GenerateByPKQueryName(string entityName, Entity entity)
         {
-            return $"{FormatNameForField(GetDefinedSingularName(entityName, entity))}_by_pk";
+            return $"{FormatNameForField(GetDefinedSingularName(entityName, entity))}{PK_QUERY_SUFFIX}";
         }
 
         /// <summary>

--- a/src/Service.GraphQLBuilder/Mutations/DeleteMutationBuilder.cs
+++ b/src/Service.GraphQLBuilder/Mutations/DeleteMutationBuilder.cs
@@ -12,6 +12,8 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations
 {
     public static class DeleteMutationBuilder
     {
+        public const string DELETE_MUTATION_PREFIX = "delete";
+
         /// <summary>
         /// Generate the `delete` mutation field for the GraphQL mutations for a given Object Definition
         /// ReturnEntityName can be different from dbEntityName in cases where user wants summary results returned (through the DBOperationResult entity)
@@ -70,7 +72,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations
             string singularName = GetDefinedSingularName(name.Value, configEntity);
             return new(
                 null,
-                new NameNode($"delete{singularName}"),
+                new NameNode($"{DELETE_MUTATION_PREFIX}{singularName}"),
                 new StringValueNode($"Delete a {singularName}"),
                 inputValues,
                 new NamedTypeNode(returnEntityName),

--- a/src/Service.GraphQLBuilder/Mutations/UpdateAndPatchMutationBuilder.cs
+++ b/src/Service.GraphQLBuilder/Mutations/UpdateAndPatchMutationBuilder.cs
@@ -14,6 +14,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations
     public static class UpdateAndPatchMutationBuilder
     {
         public const string INPUT_ARGUMENT_NAME = "item";
+        public const string UPDATE_MUTATION_PREFIX = "update";
 
         /// <summary>
         /// This method is used to determine if a field is allowed to be sent from the client in a Update/Patch mutation (eg, id field is not settable during update).
@@ -211,7 +212,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Mutations
             string returnEntityName,
             IEnumerable<string>? rolesAllowedForMutation = null,
             EntityActionOperation operation = EntityActionOperation.Update,
-            string operationNamePrefix = "update")
+            string operationNamePrefix = UPDATE_MUTATION_PREFIX)
         {
             InputObjectTypeDefinitionNode input = GenerateUpdateInputType(
                 inputs,


### PR DESCRIPTION
## Why make this change?

Converted some hardcoded query and mutation prefix and suffix strings to public constants. This way, other services relying on these string values can directly consume the constants, so if they every change values on DAB side, it won't break the other services.

## What is this change?

Replaced some hardcoded strings with constants with the same values in query builder and mutation builder files
