### PR TITLE
Bump Azure.Identity to 1.11.4

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.11.2" />
+    <PackageVersion Include="Azure.Identity" Version="1.11.4" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />


### PR DESCRIPTION
## Why make this change?

- Closes #2263
- Issue alerted to us via failed Dotnet format (which runs dotnet restore) and the GitHubAdvisory fails the pipeline step.

## What is this change?

- Updates Directory.Packages.props to point to newest version after adding it to the Nuget Feed DAB references.

