### PR TITLE
Enforce data streaming limits stored procedure

### DIFF
--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -9,7 +9,6 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
-using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -442,9 +441,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 else
                                 {
                                     int columnSize = (int)schemaRow["ColumnSize"];
-                                    string dataTypeName = (string)schemaRow["DataTypeName"];
                                     availableBytes -= StreamDataIntoDbResultSetRow(
-                                        dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, dataTypeName, availableBytes);
+                                        dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, availableBytes);
                                 }
 
                             }
@@ -496,9 +494,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 else
                                 {
                                     int columnSize = (int)schemaRow["ColumnSize"];
-                                    string dataType = (string)schemaRow["DataTypeName"];
                                     availableBytes -= StreamDataIntoDbResultSetRow(
-                                        dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, dataType, availableBytes);
+                                        dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, availableBytes);
                                 }
                             }
                             else
@@ -723,9 +720,9 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="columnName">columnName to read</param>
         /// <param name="ordinal">ordinal of column.</param>
 
-        internal int StreamDataIntoDbResultSetRow(DbDataReader dbDataReader, DbResultSetRow dbResultSetRow, string columnName, int columnSize, int ordinal, string dataTypeName, long availableBytes)
+        internal int StreamDataIntoDbResultSetRow(DbDataReader dbDataReader, DbResultSetRow dbResultSetRow, string columnName, int columnSize, int ordinal, long availableBytes)
         {
-            Type systemType = TypeHelper.GetSystemTypeFromSqlDbType(dataTypeName);
+            Type systemType = dbDataReader.GetFieldType(ordinal);
             int dataRead;
 
             if (systemType == typeof(string))

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -490,7 +490,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             {
                                 if (ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
                                 {
-                                    dbResultSetRow.Columns.Add(columnName, dbDataReader[colIndex]);
+                                    dbResultSetRow.Columns.Add(columnName, dbDataReader[columnName]);
                                 }
                                 else
                                 {
@@ -747,7 +747,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             {
                 dataRead = columnSize;
                 ValidateSize(availableBytes, dataRead);
-                dbResultSetRow.Columns.Add(columnName, dbDataReader[ordinal]);
+                dbResultSetRow.Columns.Add(columnName, dbDataReader[columnName]);
             }
 
             return dataRead;

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -735,7 +735,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
                 dbResultSetRow.Columns.Add(columnName, jsonString.ToString());
             }
-            else if (systemType == typeof(byte[]) || systemType == typeof(byte))
+            else if (systemType == typeof(byte[]))
             {
                 dataRead = StreamByteData(
                     dbDataReader: dbDataReader, availableSize: availableBytes, ordinal: ordinal, out byte[]? result);

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -442,7 +442,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 else
                                 {
                                     int columnSize = (int)schemaRow["ColumnSize"];
-                                    string dataTypeName = (string)schemaRow["DataType"];
+                                    string dataTypeName = (string)schemaRow["DataTypeName"];
                                     availableBytes -= StreamDataIntoDbResultSetRow(
                                         dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, dataTypeName, availableBytes);
                                 }
@@ -496,7 +496,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 else
                                 {
                                     int columnSize = (int)schemaRow["ColumnSize"];
-                                    string dataType = (string)schemaRow["DataType"];
+                                    string dataType = (string)schemaRow["DataTypeName"];
                                     availableBytes -= StreamDataIntoDbResultSetRow(
                                         dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, dataType, availableBytes);
                                 }

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -438,7 +438,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             {
                                 if (ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
                                 {
-                                    dbResultSetRow.Columns.Add(columnName, dbDataReader[colIndex]);
+                                    dbResultSetRow.Columns.Add(columnName, dbDataReader[columnName]);
                                 }
                                 else
                                 {

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -727,7 +727,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             Type systemType = TypeHelper.GetSystemTypeFromSqlDbType(dataTypeName);
             int dataRead;
 
-            if (systemType == typeof(string))
+            if (systemType == typeof(string) || systemType == typeof(DateTime))
             {
                 StringBuilder jsonString = new();
                 dataRead = StreamData(

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -679,7 +679,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             char[] buffer = new char[resultFieldSize];
 
             // read entire field into buffer and reduce available size.
-            dbDataReader.GetChars(ordinal: 0, dataOffset: 0, buffer: buffer, bufferOffset: 0, length: buffer.Length);
+            dbDataReader.GetChars(ordinal: ordinal, dataOffset: 0, buffer: buffer, bufferOffset: 0, length: buffer.Length);
 
             resultJsonString.Append(buffer);
             return buffer.Length;

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -434,7 +434,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             int colIndex = dbDataReader.GetOrdinal(columnName);
                             if (!dbDataReader.IsDBNull(colIndex))
                             {
-                                if (ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
+                                if (!ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
                                 {
                                     dbResultSetRow.Columns.Add(columnName, dbDataReader[columnName]);
                                 }
@@ -487,7 +487,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             int colIndex = dbDataReader.GetOrdinal(columnName);
                             if (!dbDataReader.IsDBNull(colIndex))
                             {
-                                if (ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
+                                if (!ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
                                 {
                                     dbResultSetRow.Columns.Add(columnName, dbDataReader[columnName]);
                                 }

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -691,7 +691,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="dbDataReader">DbDataReader.</param>
         /// <param name="availableSize">Available buffer.</param>
         /// <param name="ordinal"> ordinal of column being read</param>
-        /// <param name="resultBytes">jsonString to read into.</param>
+        /// <param name="resultBytes">bytes array to read result into.</param>
         /// <returns>size of data read in bytes.</returns>
         internal int StreamByteData(DbDataReader dbDataReader, long availableSize, int ordinal, out byte[]? resultBytes)
         {
@@ -703,12 +703,20 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
             resultBytes = new byte[resultFieldSize];
 
-            // read entire field into buffer and reduce available size.
             dbDataReader.GetBytes(ordinal: 0, dataOffset: 0, buffer: resultBytes, bufferOffset: 0, length: resultBytes.Length);
 
             return resultBytes.Length;
         }
 
+        /// <summary>
+        /// Streams a column into the dbResultSetRow
+        /// </summary>
+        /// <param name="dbDataReader">DbDataReader</param>
+        /// <param name="dbResultSetRow">Result set row to read into</param>
+        /// <param name="availableBytes">Available bytes to read.</param>
+        /// <param name="columnName">columnName to read</param>
+        /// <param name="ordinal">ordinal of column.</param>
+        /// <returns>bytes of data read.</returns>
         internal int StreamDataIntoDbResultSetRow(DbDataReader dbDataReader, DbResultSetRow dbResultSetRow, long availableBytes, string columnName, int ordinal)
         {
             // check for large object columns

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -426,7 +426,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                         foreach (DataRow schemaRow in schemaTable.Rows)
                         {
                             string columnName = (string)schemaRow["ColumnName"];
-                            int columnSize = (int)schemaRow["ColumnSize"];
 
                             if (args is not null && !args.Contains(columnName))
                             {
@@ -442,8 +441,10 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 }
                                 else
                                 {
+                                    int columnSize = (int)schemaRow["ColumnSize"];
+                                    string dataTypeName = (string)schemaRow["DataType"];
                                     availableBytes -= StreamDataIntoDbResultSetRow(
-                                        dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, availableBytes);
+                                        dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, dataTypeName, availableBytes);
                                 }
 
                             }
@@ -495,8 +496,9 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 else
                                 {
                                     int columnSize = (int)schemaRow["ColumnSize"];
+                                    string dataType = (string)schemaRow["DataType"];
                                     availableBytes -= StreamDataIntoDbResultSetRow(
-                                        dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, availableBytes);
+                                        dbDataReader, dbResultSetRow, columnName, columnSize, ordinal: colIndex, dataType, availableBytes);
                                 }
                             }
                             else
@@ -721,10 +723,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="columnName">columnName to read</param>
         /// <param name="ordinal">ordinal of column.</param>
 
-        internal int StreamDataIntoDbResultSetRow(DbDataReader dbDataReader, DbResultSetRow dbResultSetRow, string columnName, int columnSize, int ordinal, long availableBytes)
+        internal int StreamDataIntoDbResultSetRow(DbDataReader dbDataReader, DbResultSetRow dbResultSetRow, string columnName, int columnSize, int ordinal, string dataTypeName, long availableBytes)
         {
-            // check for large object columns
-            string dataTypeName = dbDataReader.GetDataTypeName(ordinal);
             Type systemType = TypeHelper.GetSystemTypeFromSqlDbType(dataTypeName);
             int dataRead;
 

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -436,7 +436,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             int colIndex = dbDataReader.GetOrdinal(columnName);
                             if (!dbDataReader.IsDBNull(colIndex))
                             {
-                                if (!ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
+                                if (ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
                                 {
                                     dbResultSetRow.Columns.Add(columnName, dbDataReader[colIndex]);
                                 }
@@ -487,7 +487,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                             int colIndex = dbDataReader.GetOrdinal(columnName);
                             if (!dbDataReader.IsDBNull(colIndex))
                             {
-                                if (!ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
+                                if (ConfigProvider.GetConfig().MaxResponseSizeLogicEnabled())
                                 {
                                     dbResultSetRow.Columns.Add(columnName, dbDataReader[colIndex]);
                                 }

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -442,7 +442,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 }
                                 else
                                 {
-                                    availableBytes -= StreamDataIntoDbResultSetRow(dbDataReader, dbResultSetRow, availableBytes, columnName, colIndex);
+                                    availableBytes -= StreamDataIntoDbResultSetRow(
+                                        dbDataReader, dbResultSetRow, availableBytes, columnName, ordinal:colIndex);
                                 }
 
                             }
@@ -493,7 +494,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 }
                                 else
                                 {
-                                    availableBytes -= StreamDataIntoDbResultSetRow(dbDataReader, dbResultSetRow, availableBytes, columnName, colIndex);
+                                    availableBytes -= StreamDataIntoDbResultSetRow(
+                                        dbDataReader, dbResultSetRow, availableBytes, columnName, ordinal:colIndex);
                                 }
                             }
                             else
@@ -695,7 +697,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <returns>size of data read in bytes.</returns>
         internal int StreamByteData(DbDataReader dbDataReader, long availableSize, int ordinal, out byte[]? resultBytes)
         {
-            long resultFieldSize = dbDataReader.GetBytes(ordinal: ordinal, dataOffset: 0, buffer: null, bufferOffset: 0, length: 0);
+            long resultFieldSize = dbDataReader.GetBytes(
+                ordinal: ordinal, dataOffset: 0, buffer: null, bufferOffset: 0, length: 0);
 
             // if the size of the field is less than available size, then we can read the entire field.
             // else we throw exception.
@@ -727,13 +730,15 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             if (systemType == typeof(string))
             {
                 StringBuilder jsonString = new();
-                dataRead = StreamData(dbDataReader, availableBytes, jsonString, ordinal);
+                dataRead = StreamData(
+                    dbDataReader: dbDataReader, availableSize: availableBytes, resultJsonString: jsonString, ordinal: ordinal);
 
                 dbResultSetRow.Columns.Add(columnName, jsonString.ToString());
             }
             else if (systemType == typeof(byte[]) || systemType == typeof(byte))
             {
-                dataRead = StreamByteData(dbDataReader, availableBytes, ordinal, out byte[]? result);
+                dataRead = StreamByteData(
+                    dbDataReader:dbDataReader, availableSize:availableBytes, ordinal: ordinal, out byte[]? result);
 
                 dbResultSetRow.Columns.Add(columnName, result);
             }
@@ -779,7 +784,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 long availableSize = _maxResponseSizeBytes;
                 while (await ReadAsync(dbDataReader))
                 {
-                    availableSize -= StreamData(dbDataReader, availableSize, jsonString, 0);
+                    availableSize -= StreamData(
+                        dbDataReader:dbDataReader, availableSize:availableSize, resultJsonString: jsonString, ordinal:0);
                 }
             }
 

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -443,7 +443,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 else
                                 {
                                     availableBytes -= StreamDataIntoDbResultSetRow(
-                                        dbDataReader, dbResultSetRow, availableBytes, columnName, ordinal:colIndex);
+                                        dbDataReader, dbResultSetRow, availableBytes, columnName, ordinal: colIndex);
                                 }
 
                             }
@@ -495,7 +495,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                                 else
                                 {
                                     availableBytes -= StreamDataIntoDbResultSetRow(
-                                        dbDataReader, dbResultSetRow, availableBytes, columnName, ordinal:colIndex);
+                                        dbDataReader, dbResultSetRow, availableBytes, columnName, ordinal: colIndex);
                                 }
                             }
                             else
@@ -706,7 +706,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
             resultBytes = new byte[resultFieldSize];
 
-            dbDataReader.GetBytes(ordinal: 0, dataOffset: 0, buffer: resultBytes, bufferOffset: 0, length: resultBytes.Length);
+            dbDataReader.GetBytes(ordinal: ordinal, dataOffset: 0, buffer: resultBytes, bufferOffset: 0, length: resultBytes.Length);
 
             return resultBytes.Length;
         }
@@ -738,7 +738,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             else if (systemType == typeof(byte[]) || systemType == typeof(byte))
             {
                 dataRead = StreamByteData(
-                    dbDataReader:dbDataReader, availableSize:availableBytes, ordinal: ordinal, out byte[]? result);
+                    dbDataReader: dbDataReader, availableSize: availableBytes, ordinal: ordinal, out byte[]? result);
 
                 dbResultSetRow.Columns.Add(columnName, result);
             }
@@ -785,7 +785,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 while (await ReadAsync(dbDataReader))
                 {
                     availableSize -= StreamData(
-                        dbDataReader:dbDataReader, availableSize:availableSize, resultJsonString: jsonString, ordinal:0);
+                        dbDataReader: dbDataReader, availableSize: availableSize, resultJsonString: jsonString, ordinal: 0);
                 }
             }
 

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -670,7 +670,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="resultJsonString">jsonString to read into.</param>
         /// <param name="ordinal">Ordinal of column being read.</param>
         /// <returns>size of data read in bytes.</returns>
-        internal int StreamData(DbDataReader dbDataReader, long availableSize, StringBuilder resultJsonString, int ordinal)
+        internal int StreamCharData(DbDataReader dbDataReader, long availableSize, StringBuilder resultJsonString, int ordinal)
         {
             long resultFieldSize = dbDataReader.GetChars(ordinal: ordinal, dataOffset: 0, buffer: null, bufferOffset: 0, length: 0);
 
@@ -719,7 +719,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <param name="availableBytes">Available bytes to read.</param>
         /// <param name="columnName">columnName to read</param>
         /// <param name="ordinal">ordinal of column.</param>
-
+        /// <returns>size of data read in bytes</returns>
         internal int StreamDataIntoDbResultSetRow(DbDataReader dbDataReader, DbResultSetRow dbResultSetRow, string columnName, int columnSize, int ordinal, long availableBytes)
         {
             Type systemType = dbDataReader.GetFieldType(ordinal);
@@ -728,7 +728,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             if (systemType == typeof(string))
             {
                 StringBuilder jsonString = new();
-                dataRead = StreamData(
+                dataRead = StreamCharData(
                     dbDataReader: dbDataReader, availableSize: availableBytes, resultJsonString: jsonString, ordinal: ordinal);
 
                 dbResultSetRow.Columns.Add(columnName, jsonString.ToString());
@@ -781,7 +781,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 long availableSize = _maxResponseSizeBytes;
                 while (await ReadAsync(dbDataReader))
                 {
-                    availableSize -= StreamData(
+                    // We only have a single column and hence when streaming data, we pass in 0 as the ordinal.
+                    availableSize -= StreamCharData(
                         dbDataReader: dbDataReader, availableSize: availableSize, resultJsonString: jsonString, ordinal: 0);
                 }
             }

--- a/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
@@ -393,7 +393,6 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
             string[] columnNames = { "StringColumn1", "StringColumn2", "ByteColumn", "ByteColumn2", "IntColumn" };
-            string[] columnTypes = { "varchar", "nvarchar", "image", "binary", "int" };
             int[] columnSize = { 1024 * 1024, 1024 * 1024, 1024 * 1024, 1024 * 1024, 4 };
 
             FileSystem fileSystem = new();
@@ -431,7 +430,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 {
                     availableSize -= msSqlQueryExecutor.StreamDataIntoDbResultSetRow(
                         dbDataReader.Object, dbResultSetRow, columnName: columnNames[i],
-                        columnSize: columnSize[i], ordinal: i, dataTypeName: columnTypes[i], availableBytes: availableSize);
+                        columnSize: columnSize[i], ordinal: i, availableBytes: availableSize);
                     Assert.IsTrue(dbResultSetRow.Columns.ContainsKey(columnNames[i]));
                 }
             }

--- a/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
@@ -439,7 +439,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             {
                 Assert.IsTrue(exceptionExpected);
                 Assert.AreEqual(HttpStatusCode.RequestEntityTooLarge, ex.StatusCode);
-                Assert.AreEqual("The JSON result size exceeds max result size of 5MB. Please use pagination to reduce size of result.", ex.Message);
+                Assert.AreEqual("The JSON result size exceeds max result size of 4MB. Please use pagination to reduce size of result.", ex.Message);
             }
         }
 

--- a/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
@@ -423,7 +423,11 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 dbDataReader.Setup(d => d.HasRows).Returns(true);
                 dbDataReader.Setup(x => x.GetChars(It.IsAny<int>(), It.IsAny<long>(), It.IsAny<char[]>(), It.IsAny<int>(), It.IsAny<int>())).Returns(1024 * 1024);
                 dbDataReader.Setup(x => x.GetBytes(It.IsAny<int>(), It.IsAny<long>(), It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>())).Returns(1024 * 1024);
-
+                dbDataReader.Setup(x => x.GetFieldType(0)).Returns(typeof(string));
+                dbDataReader.Setup(x => x.GetFieldType(1)).Returns(typeof(string));
+                dbDataReader.Setup(x => x.GetFieldType(2)).Returns(typeof(byte[]));
+                dbDataReader.Setup(x => x.GetFieldType(3)).Returns(typeof(byte[]));
+                dbDataReader.Setup(x => x.GetFieldType(4)).Returns(typeof(int));
                 int availableSize = (int)runtimeConfig.MaxResponseSizeMB() * 1024 * 1024;
                 DbResultSetRow dbResultSetRow = new();
                 for (int i = 0; i < readDataLoops; i++)

--- a/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
@@ -358,14 +358,14 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             try
             {
-                // Test for general queries and mutations
                 Mock<DbDataReader> dbDataReader = new();
                 dbDataReader.Setup(d => d.HasRows).Returns(true);
                 dbDataReader.Setup(x => x.GetChars(It.IsAny<int>(), It.IsAny<long>(), It.IsAny<char[]>(), It.IsAny<int>(), It.IsAny<int>())).Returns(1024 * 1024);
                 int availableSize = (int)runtimeConfig.MaxResponseSizeMB() * 1024 * 1024;
                 for (int i = 0; i < readDataLoops; i++)
                 {
-                    availableSize -= msSqlQueryExecutor.StreamData(dbDataReader: dbDataReader.Object, availableSize: availableSize, resultJsonString: new(), 0);
+                    availableSize -= msSqlQueryExecutor.StreamData(
+                        dbDataReader: dbDataReader.Object, availableSize: availableSize, resultJsonString: new(), ordinal:0);
                 }
 
             }
@@ -430,7 +430,8 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 DbResultSetRow dbResultSetRow = new();
                 for (int i = 0; i < readDataLoops; i++)
                 {
-                    availableSize -= msSqlQueryExecutor.StreamDataIntoDbResultSetRow(dbDataReader: dbDataReader.Object, dbResultSetRow: dbResultSetRow, availableBytes: availableSize, columnName: columnNames[i], i);
+                    availableSize -= msSqlQueryExecutor.StreamDataIntoDbResultSetRow(
+                        dbDataReader: dbDataReader.Object, dbResultSetRow: dbResultSetRow, availableBytes: availableSize, columnName: columnNames[i], ordinal: i);
                     Assert.IsTrue(dbResultSetRow.Columns.ContainsKey(columnNames[i]));
                 }
             }

--- a/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
@@ -365,7 +365,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 for (int i = 0; i < readDataLoops; i++)
                 {
                     availableSize -= msSqlQueryExecutor.StreamData(
-                        dbDataReader: dbDataReader.Object, availableSize: availableSize, resultJsonString: new(), ordinal:0);
+                        dbDataReader: dbDataReader.Object, availableSize: availableSize, resultJsonString: new(), ordinal: 0);
                 }
 
             }


### PR DESCRIPTION
## Why make this change?
This change is to give the user the option to decide how much data they want to be able to load into the application memory on the execution of a stored procedure. The restriction is put in place by limiting the amount of data that can be returned by the stored procedure.

## What is this change?

This changes edits the stored procedure read logic to stream results from the db. Based on the type of data returned by a column, the appropriate read data streaming function is used (GetBytes, GetChars etc). Only large object types require explicitly streaming from the db (https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-types-transact-sql?view=sql-server-ver16). Currently the large object types we support map to either string objects (for example: nvarchar, varchar, ntext) or byte[] objects (for example: Image)

For stored procedure, we get the information about the result set of the stored procedure and create dbResultSetRows which go into our data table. To create these rows, we read column by column from the dbDataReader. The columnIndex is got from the columnName which can be retrieved from resultset info of the stored procedure. Hence while streaming, we need to specify the ordinal of the column we want to read.

## How was this tested?

unit tests added.
