### PR TITLE
Update the retry policy for tsql query execution

### DIFF
--- a/src/Core/Resolvers/MsSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MsSqlDbExceptionParser.cs
@@ -48,11 +48,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
                 // These errors mainly occur when the SQL Server client can't connect to the server.
                 // This may happen when the client cannot resolve the name of the server or the name of the server is incorrect.
-                "53", "11001",
-
-                // Transient error codes compiled from:
-                // https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver16
-                "18456"
+                "53", "11001"
             });
 
             ConflictExceptionCodes.UnionWith(new List<string>

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -30,7 +30,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
         // The maximum number of attempts that can be made to execute the query successfully in addition to the first attempt.
         // So to say in case of transient exceptions, the query will be executed (_maxRetryCount + 1) times at max.
-        private static int _maxRetryCount = 5;
+        private static int _maxRetryCount = 2;
 
         private AsyncRetryPolicy _retryPolicyAsync;
 

--- a/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/Unittests/SqlQueryExecutorUnitTests.cs
@@ -140,7 +140,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         [TestMethod, TestCategory(TestCategory.MSSQL)]
         public async Task TestRetryPolicyExhaustingMaxAttempts()
         {
-            int maxRetries = 5;
+            int maxRetries = 2;
             int maxAttempts = maxRetries + 1; // 1 represents the original attempt to execute the query in addition to retries.
             RuntimeConfig mockConfig = new(
                Schema: "",


### PR DESCRIPTION
## Changes
1. Updates retry policy for QueryExecutor to attempt 3 times instead of 5 times as per guidance
2. Remove sql error number 18456 from the list of transient exceptions which would result in retries. 18456 is a fatal error.


## Why make this change?
Sql Error 18456 occurs when using invalid authentication methods such as invalid audience or expired token or credentials. There is a permanent error hence no benefit from retrying. 
Ref: https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-18456-database-engine-error?view=sql-server-ver16
    
Additionally, the number of retries of 5 means that it would take considerable for user to see the error returned. This does not bode well for GraphQL queries which are an interactive scenario.     
Ref: https://learn.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#retry-usage-guidance-3


## How was this tested?
- Manual testing to ensure retry attempts down to 2 down from 5 via breakpoints
- Manual testing to reproduce error 18456 and ensure no retries via breakpoints
- Unit tests
