### PR TITLE
Cultural Invariant Conversion of datatypes during mutation

### DIFF
--- a/src/Core/Resolvers/SqlMutationEngine.cs
+++ b/src/Core/Resolvers/SqlMutationEngine.cs
@@ -3,7 +3,6 @@
 
 using System.Data;
 using System.Data.Common;
-using System.Globalization;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -161,7 +160,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                         // If the number of records affected by DELETE were zero,
                         if (resultProperties is not null
                             && resultProperties.TryGetValue(nameof(DbDataReader.RecordsAffected), out object? value)
-                            && Convert.ToInt32(value, CultureInfo.InvariantCulture) == 0)
+                            && Convert.ToInt32(value) == 0)
                         {
                             // the result was not null previously, it indicates this DELETE lost
                             // a concurrent request race. Hence, empty the non-null result.
@@ -506,7 +505,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     // DbDataReader.RecordsAffected contains the number of rows changed deleted. 0 if no records were deleted.
                     // When the flow reaches this code block and the number of records affected is 0, then it means that no failure occurred at the database layer
                     // and that the item identified by the specified PK was not found.
-                    if (Convert.ToInt32(value, CultureInfo.InvariantCulture) == 0)
+                    if (Convert.ToInt32(value) == 0)
                     {
                         string prettyPrintPk = "<" + string.Join(", ", context.PrimaryKeyValuePairs.Select(kv_pair => $"{kv_pair.Key}: {kv_pair.Value}")) + ">";
 

--- a/src/Core/Resolvers/SqlMutationEngine.cs
+++ b/src/Core/Resolvers/SqlMutationEngine.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using System.Data.Common;
+using System.Globalization;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -160,7 +161,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                         // If the number of records affected by DELETE were zero,
                         if (resultProperties is not null
                             && resultProperties.TryGetValue(nameof(DbDataReader.RecordsAffected), out object? value)
-                            && Convert.ToInt32(value) == 0)
+                            && Convert.ToInt32(value, CultureInfo.InvariantCulture) == 0)
                         {
                             // the result was not null previously, it indicates this DELETE lost
                             // a concurrent request race. Hence, empty the non-null result.
@@ -505,7 +506,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     // DbDataReader.RecordsAffected contains the number of rows changed deleted. 0 if no records were deleted.
                     // When the flow reaches this code block and the number of records affected is 0, then it means that no failure occurred at the database layer
                     // and that the item identified by the specified PK was not found.
-                    if (Convert.ToInt32(value) == 0)
+                    if (Convert.ToInt32(value, CultureInfo.InvariantCulture) == 0)
                     {
                         string prettyPrintPk = "<" + string.Join(", ", context.PrimaryKeyValuePairs.Select(kv_pair => $"{kv_pair.Key}: {kv_pair.Value}")) + ">";
 

--- a/src/Core/Services/TypeHelper.cs
+++ b/src/Core/Services/TypeHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Net;
 using Azure.DataApiBuilder.Core.Services.OpenAPI;
 using Azure.DataApiBuilder.Service.Exceptions;
@@ -304,12 +305,12 @@ namespace Azure.DataApiBuilder.Core.Services
             SyntaxKind valueKind = node.Kind;
             return valueKind switch
             {
-                SyntaxKind.IntValue => Convert.ToInt32(node.Value), // spec
-                SyntaxKind.FloatValue => Convert.ToDouble(node.Value), // spec
-                SyntaxKind.BooleanValue => Convert.ToBoolean(node.Value), // spec
-                SyntaxKind.StringValue => Convert.ToString(node.Value), // spec
+                SyntaxKind.IntValue => Convert.ToInt32(node.Value, CultureInfo.InvariantCulture), // spec
+                SyntaxKind.FloatValue => Convert.ToDouble(node.Value, CultureInfo.InvariantCulture), // spec
+                SyntaxKind.BooleanValue => Convert.ToBoolean(node.Value, CultureInfo.InvariantCulture), // spec
+                SyntaxKind.StringValue => Convert.ToString(node.Value, CultureInfo.InvariantCulture), // spec
                 SyntaxKind.NullValue => null, // spec
-                _ => Convert.ToString(node.Value)
+                _ => Convert.ToString(node.Value, CultureInfo.InvariantCulture)
             };
         }
 

--- a/src/Core/Services/TypeHelper.cs
+++ b/src/Core/Services/TypeHelper.cs
@@ -307,7 +307,7 @@ namespace Azure.DataApiBuilder.Core.Services
             {
                 SyntaxKind.IntValue => Convert.ToInt32(node.Value, CultureInfo.InvariantCulture), // spec
                 SyntaxKind.FloatValue => Convert.ToDouble(node.Value, CultureInfo.InvariantCulture), // spec
-                SyntaxKind.BooleanValue => Convert.ToBoolean(node.Value, CultureInfo.InvariantCulture), // spec
+                SyntaxKind.BooleanValue => Convert.ToBoolean(node.Value), // spec
                 SyntaxKind.StringValue => Convert.ToString(node.Value, CultureInfo.InvariantCulture), // spec
                 SyntaxKind.NullValue => null, // spec
                 _ => Convert.ToString(node.Value, CultureInfo.InvariantCulture)

--- a/src/Service.Tests/CosmosTests/MutationTests.cs
+++ b/src/Service.Tests/CosmosTests/MutationTests.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.NamingPolicies;
 using Azure.DataApiBuilder.Config.ObjectModel;
@@ -1081,7 +1080,7 @@ mutation ($id: ID!, $partitionKeyValue: String!, $item: PatchPlanetInput!) {
         [DataRow("en-DE")]
         public async Task CanCreateItemWithCultureInvariant(string cultureInfo)
         {
-            CultureInfo ci = new (cultureInfo);
+            CultureInfo ci = new(cultureInfo);
             CultureInfo.DefaultThreadCurrentCulture = ci;
 
             // Run mutation Add planet;

--- a/src/Service.Tests/CosmosTests/TestBase.cs
+++ b/src/Service.Tests/CosmosTests/TestBase.cs
@@ -46,7 +46,7 @@ type Planet @model(name:""PlanetAlias"") {
     id : ID!,
     name : String,
     character: Character,
-    age : Int,
+    age : Float,
     dimension : String,
     earth: Earth,
     tags: [String!],


### PR DESCRIPTION
## Why make this change?

It addresses https://github.com/Azure/data-api-builder/issues/2284 bug raised by the customer.

**Note:** Made change in`src/Core/Resolvers/SqlMutationEngine.cs` just for consistency.

## What is this change?
Made sure datatype conversion is `CultureInfo.InvariantCulture`

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

## Sample Request(s)

- Example REST and/or GraphQL request to demonstrate modifications
- Example of CLI usage to demonstrate modifications
