### PR TITLE
[Cherrypick] [Port] Modified capitalization in metadata queries 

### DIFF
--- a/src/Core/Resolvers/DWSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/DWSqlQueryBuilder.cs
@@ -324,10 +324,10 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         public string BuildQueryToGetReadOnlyColumns(string schemaParamName, string tableParamName)
         {
             // For 'timestamp' columns sc.is_computed = 0.
-            string query = "SELECT ifsc.column_name from sys.columns as sc INNER JOIN INFORMATION_SCHEMA.COLUMNS as ifsc " +
-                "ON (sc.is_computed = 1 or ifsc.data_type = 'timestamp') " +
-                $"AND sc.object_id = object_id({schemaParamName}+'.'+{tableParamName}) and ifsc.table_name = {tableParamName} " +
-                $"AND ifsc.table_schema = {schemaParamName} and ifsc.column_name = sc.name;";
+            string query = "SELECT ifsc.COLUMN_NAME from sys.columns as sc INNER JOIN INFORMATION_SCHEMA.COLUMNS as ifsc " +
+                "ON (sc.is_computed = 1 or ifsc.DATA_TYPE = 'timestamp') " +
+                $"AND sc.object_id = object_id({schemaParamName}+'.'+{tableParamName}) AND ifsc.TABLE_SCHEMA = {schemaParamName} " +
+                $"AND ifsc.TABLE_NAME = {tableParamName} AND ifsc.COLUMN_NAME = sc.name;";
 
             return query;
         }

--- a/src/Core/Resolvers/MsSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/MsSqlQueryBuilder.cs
@@ -509,10 +509,10 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         public string BuildQueryToGetReadOnlyColumns(string schemaParamName, string tableParamName)
         {
             // For 'timestamp' columns sc.is_computed = 0.
-            string query = "SELECT ifsc.column_name from sys.columns as sc INNER JOIN information_schema.columns as ifsc " +
-                "ON (sc.is_computed = 1 or ifsc.data_type = 'timestamp') " +
-                $"AND sc.object_id = object_id({schemaParamName}+'.'+{tableParamName}) and ifsc.table_name = {tableParamName} " +
-                $"AND ifsc.table_schema = {schemaParamName} and ifsc.column_name = sc.name;";
+            string query = "SELECT ifsc.COLUMN_NAME from sys.columns as sc INNER JOIN INFORMATION_SCHEMA.COLUMNS as ifsc " +
+                "ON (sc.is_computed = 1 or ifsc.DATA_TYPE = 'timestamp') " +
+                $"AND sc.object_id = object_id({schemaParamName}+'.'+{tableParamName}) AND ifsc.TABLE_SCHEMA = {schemaParamName} " +
+                $"AND ifsc.TABLE_NAME = {tableParamName} AND ifsc.COLUMN_NAME = sc.name;";
 
             return query;
         }

--- a/src/Core/Resolvers/MySqlQueryBuilder.cs
+++ b/src/Core/Resolvers/MySqlQueryBuilder.cs
@@ -356,8 +356,8 @@ WHERE
         /// <inheritdoc/>
         public string BuildQueryToGetReadOnlyColumns(string schemaParamName, string tableParamName)
         {
-            string query = "select column_name as column_name from information_schema.columns " +
-                $"where table_schema = {schemaParamName} and table_name = {tableParamName} and generation_expression != '';";
+            string query = "select COLUMN_NAME as COLUMN_NAME from INFORMATION_SCHEMA.COLUMNS " +
+                $"where TABLE_SCHEMA = {schemaParamName} and TABLE_NAME = {tableParamName} and GENERATION_EXPRESSION != '';";
             return query;
         }
 

--- a/src/Core/Resolvers/PostgresQueryBuilder.cs
+++ b/src/Core/Resolvers/PostgresQueryBuilder.cs
@@ -228,7 +228,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <inheritdoc/>
         public string BuildQueryToGetReadOnlyColumns(string schemaParamName, string tableParamName)
         {
-            string query = "SELECT attname AS column_name FROM pg_attribute " +
+            string query = $"SELECT attname AS {QuoteIdentifier("COLUMN_NAME")} FROM pg_attribute " +
                 $"WHERE attrelid = ({schemaParamName} || '.' || {tableParamName})::regclass AND attgenerated = 's';";
             return query;
         }

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1841,7 +1841,7 @@ namespace Azure.DataApiBuilder.Core.Services
             foreach (DbResultSetRow readOnlyFieldRowWithProperties in readOnlyFieldRowsWithProperties.Rows)
             {
                 Dictionary<string, object?> readOnlyFieldInfo = readOnlyFieldRowWithProperties.Columns;
-                string fieldName = (string)readOnlyFieldInfo["column_name"]!;
+                string fieldName = (string)readOnlyFieldInfo["COLUMN_NAME"]!;
                 readOnlyFields.Add(fieldName);
             }
 


### PR DESCRIPTION
## Port metadata

- Porting from `main` to `release/1.2`
  - Issue: #1896 
  - PR: #1921

## Why make this change?

- Resolves #1896

## What is this change?

- These changes impact API builder startup. The query output has not been modified, but certain field references are capitalized.
- The proper case is used to avoid "field not found" and "key field not found" errors when the database collation is case-sensitive.

## How was this tested?

- [x] Integration Tests - Ran locally; about 5 tests failed, but it was the same ones that failed before modifications
- [ ] Unit Tests

## Sample Request(s)
- N/A