### PR TITLE
[Cherrypick][Port] Cultural Invariant Conversion of datatypes during mutation

### DIFF
--- a/src/Core/Services/TypeHelper.cs
+++ b/src/Core/Services/TypeHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Net;
 using Azure.DataApiBuilder.Core.Services.OpenAPI;
 using Azure.DataApiBuilder.Service.Exceptions;
@@ -304,12 +305,12 @@ namespace Azure.DataApiBuilder.Core.Services
             SyntaxKind valueKind = node.Kind;
             return valueKind switch
             {
-                SyntaxKind.IntValue => Convert.ToInt32(node.Value), // spec
-                SyntaxKind.FloatValue => Convert.ToDouble(node.Value), // spec
+                SyntaxKind.IntValue => Convert.ToInt32(node.Value, CultureInfo.InvariantCulture), // spec
+                SyntaxKind.FloatValue => Convert.ToDouble(node.Value, CultureInfo.InvariantCulture), // spec
                 SyntaxKind.BooleanValue => Convert.ToBoolean(node.Value), // spec
-                SyntaxKind.StringValue => Convert.ToString(node.Value), // spec
+                SyntaxKind.StringValue => Convert.ToString(node.Value, CultureInfo.InvariantCulture), // spec
                 SyntaxKind.NullValue => null, // spec
-                _ => Convert.ToString(node.Value)
+                _ => Convert.ToString(node.Value, CultureInfo.InvariantCulture)
             };
         }
 

--- a/src/Service.Tests/CosmosTests/MutationTests.cs
+++ b/src/Service.Tests/CosmosTests/MutationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
@@ -1072,6 +1073,31 @@ mutation ($id: ID!, $partitionKeyValue: String!, $item: PatchPlanetInput!) {
             Assert.AreEqual(patchResponse.GetProperty("tags").ToString(), JsonSerializer.Serialize(update.tags));
             Assert.AreEqual(patchResponse.GetProperty("stars").ToString(), JsonSerializer.Serialize(update.stars));
             Assert.AreEqual(patchResponse.GetProperty("moons").ToString(), JsonSerializer.Serialize(update.moons));
+        }
+
+        [TestMethod]
+        [DataRow("en-US")]
+        [DataRow("en-DE")]
+        public async Task CanCreateItemWithCultureInvariant(string cultureInfo)
+        {
+            CultureInfo ci = new(cultureInfo);
+            CultureInfo.DefaultThreadCurrentCulture = ci;
+
+            // Run mutation Add planet;
+            string id = Guid.NewGuid().ToString();
+            const string name = "test_name";
+            string mutation = $@"
+mutation {{
+    createPlanet (item: {{ id: ""{id}"", name: ""{name}"", age: 10.15 }}) {{
+        id
+        name
+        age
+    }}
+}}";
+            JsonElement response = await ExecuteGraphQLRequestAsync("createPlanet", mutation, variables: new());
+
+            // Validate results
+            Assert.AreEqual(Convert.ToDouble(10.15, CultureInfo.InvariantCulture), response.GetProperty("age").GetDouble());
         }
 
         /// <summary>

--- a/src/Service.Tests/CosmosTests/TestBase.cs
+++ b/src/Service.Tests/CosmosTests/TestBase.cs
@@ -46,7 +46,7 @@ type Planet @model(name:""PlanetAlias"") {
     id : ID!,
     name : String,
     character: Character,
-    age : Int,
+    age : Float,
     dimension : String,
     earth: Earth,
     tags: [String!],


### PR DESCRIPTION
## Port Metadata
- porting from `main` to `release/1.2`
  - Issue: #2284 
  - PR: #2307

## Why make this change?

It addresses https://github.com/Azure/data-api-builder/issues/2284 bug raised by the customer.

~~**Note:** Made change in`src/Core/Resolvers/SqlMutationEngine.cs` just for consistency.~~ [SL: this was in original PR, but is not accurate, since no changes to SqlMutationEngine.cs are included

## What is this change?
Made sure datatype conversion is `CultureInfo.InvariantCulture`