### PR TITLE
Add new cli configure options

### DIFF
--- a/src/Cli.Tests/ConfigureOptionsTests.cs
+++ b/src/Cli.Tests/ConfigureOptionsTests.cs
@@ -153,6 +153,7 @@ namespace Cli.Tests
 
         /// <summary>
         /// Tests the update of the database type in the runtime config.
+        /// dab configure `--data-source.database-type {dbType}`
         /// This method verifies that the database type can be updated to various valid values, including different cases,
         /// and ensures that the config file is correctly modified and parsed after the update.
         /// </summary>
@@ -173,14 +174,16 @@ namespace Cli.Tests
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
 
-            // Act
             ConfigureOptions options = new(
                 dataSourceDatabaseType: dbType,
                 config: TEST_RUNTIME_CONFIG_FILE
             );
-            Assert.IsTrue(TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!));
+
+            // Act
+            bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
 
             // Assert
+            Assert.IsTrue(isSuccess);
             string updatedConfig = _fileSystem!.File.ReadAllText(TEST_RUNTIME_CONFIG_FILE);
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out config));
             Assert.IsNotNull(config.Runtime);
@@ -191,7 +194,8 @@ namespace Cli.Tests
         /// Tests the update of the database type from CosmosDB_NoSQL to MSSQL in the runtime config.
         /// This method verifies that the database type can be changed from CosmosDB_NoSQL to MSSQL and that the 
         /// specific MSSQL option 'set-session-context' is correctly added to the configuration and the specific
-        /// cosmosDB options are removed. 
+        /// cosmosDB options are removed.
+        /// Command: dab configure --data-source.database-type mssql --data-source.options.set-session-context true 
         /// </summary>
         [TestMethod]
         public void TestDatabaseTypeUpdateCosmosDB_NoSQLToMSSQL()
@@ -204,15 +208,17 @@ namespace Cli.Tests
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_COSMOSDB_NOSQL_CONFIG, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
 
-            // Act
             ConfigureOptions options = new(
                 dataSourceDatabaseType: "mssql",
                 dataSourceOptionsSetSessionContext: true,
                 config: TEST_RUNTIME_CONFIG_FILE
             );
-            Assert.IsTrue(TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!));
+
+            // Act
+            bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
 
             // Assert
+            Assert.IsTrue(isSuccess);
             string updatedConfig = _fileSystem!.File.ReadAllText(TEST_RUNTIME_CONFIG_FILE);
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out config));
             Assert.IsNotNull(config.Runtime);
@@ -227,6 +233,8 @@ namespace Cli.Tests
         /// Tests the update of the database type from MSSQL to CosmosDB_NoSQL in the runtime config.
         /// This method verifies that the database type can be changed from MSSQL to CosmosDB_NoSQL and that the 
         /// specific CosmosDB_NoSQL options such as database, container, and schema are correctly added to the config.
+        /// Command: dab configure --data-source.database-type cosmosdb_nosql
+        /// --data-source.options.database testdb --data-source.options.container testcontainer --data-source.options.schema testschema.gql
         /// </summary>
         [TestMethod]
         public void TestDatabaseTypeUpdateMSSQLToCosmosDB_NoSQL()
@@ -239,7 +247,6 @@ namespace Cli.Tests
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
 
-            // Act
             ConfigureOptions options = new(
                 dataSourceDatabaseType: "cosmosdb_nosql",
                 dataSourceOptionsDatabase: "testdb",
@@ -247,9 +254,12 @@ namespace Cli.Tests
                 dataSourceOptionsSchema: "testschema.gql",
                 config: TEST_RUNTIME_CONFIG_FILE
             );
-            Assert.IsTrue(TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!));
+
+            // Act
+            bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
 
             // Assert
+            Assert.IsTrue(isSuccess);
             string updatedConfig = _fileSystem!.File.ReadAllText(TEST_RUNTIME_CONFIG_FILE);
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out config));
             Assert.IsNotNull(config.Runtime);
@@ -276,14 +286,16 @@ namespace Cli.Tests
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
 
-            // Act
             ConfigureOptions options = new(
                 dataSourceDatabaseType: "invalid",
                 config: TEST_RUNTIME_CONFIG_FILE
             );
 
+            // Act
+            bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
+
             // Assert
-            Assert.IsFalse(TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!));
+            Assert.IsTrue(isSuccess);
         }
 
         /// <summary>
@@ -302,7 +314,6 @@ namespace Cli.Tests
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
 
-            // Act
             ConfigureOptions options = new(
                 dataSourceOptionsDatabase: "testdb",
                 dataSourceOptionsContainer: "testcontainer",
@@ -310,8 +321,11 @@ namespace Cli.Tests
                 config: TEST_RUNTIME_CONFIG_FILE
             );
 
+            // Act
+            bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
+
             // Assert
-            Assert.IsFalse(TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!));
+            Assert.IsTrue(isSuccess);
         }
 
         /// <summary>
@@ -330,15 +344,17 @@ namespace Cli.Tests
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
 
-            // Act
             ConfigureOptions options = new(
                 dataSourceDatabaseType: "mysql",
                 dataSourceOptionsSetSessionContext: true,
                 config: TEST_RUNTIME_CONFIG_FILE
             );
 
+            // Act
+            bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
+
             // Assert
-            Assert.IsFalse(TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!));
+            Assert.IsTrue(isSuccess);
         }
     }
 }

--- a/src/Cli.Tests/ConfigureOptionsTests.cs
+++ b/src/Cli.Tests/ConfigureOptionsTests.cs
@@ -295,7 +295,7 @@ namespace Cli.Tests
             bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
 
             // Assert
-            Assert.IsTrue(isSuccess);
+            Assert.IsFalse(isSuccess);
         }
 
         /// <summary>
@@ -325,7 +325,7 @@ namespace Cli.Tests
             bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
 
             // Assert
-            Assert.IsTrue(isSuccess);
+            Assert.IsFalse(isSuccess);
         }
 
         /// <summary>
@@ -354,7 +354,7 @@ namespace Cli.Tests
             bool isSuccess = TryConfigureSettings(options, _runtimeConfigLoader!, _fileSystem!);
 
             // Assert
-            Assert.IsTrue(isSuccess);
+            Assert.IsFalse(isSuccess);
         }
     }
 }

--- a/src/Cli.Tests/ConfigureOptionsTests.cs
+++ b/src/Cli.Tests/ConfigureOptionsTests.cs
@@ -167,12 +167,7 @@ namespace Cli.Tests
         public void TestDatabaseTypeUpdate(string dbType)
         {
             // Arrange
-            _fileSystem!.AddFile(TEST_RUNTIME_CONFIG_FILE, new MockFileData(INITIAL_CONFIG));
-
-            Assert.IsTrue(_fileSystem!.File.Exists(TEST_RUNTIME_CONFIG_FILE));
-
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
-            Assert.IsNotNull(config.Runtime);
+            SetupFileSystemWithInitialConfig(INITIAL_CONFIG);
 
             ConfigureOptions options = new(
                 dataSourceDatabaseType: dbType,
@@ -185,7 +180,7 @@ namespace Cli.Tests
             // Assert
             Assert.IsTrue(isSuccess);
             string updatedConfig = _fileSystem!.File.ReadAllText(TEST_RUNTIME_CONFIG_FILE);
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out config));
+            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
             Assert.AreEqual(config.DataSource.DatabaseType, Enum.Parse<DatabaseType>(dbType, ignoreCase: true));
         }
@@ -201,12 +196,7 @@ namespace Cli.Tests
         public void TestDatabaseTypeUpdateCosmosDB_NoSQLToMSSQL()
         {
             // Arrange
-            _fileSystem!.AddFile(TEST_RUNTIME_CONFIG_FILE, new MockFileData(INITIAL_COSMOSDB_NOSQL_CONFIG));
-
-            Assert.IsTrue(_fileSystem!.File.Exists(TEST_RUNTIME_CONFIG_FILE));
-
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_COSMOSDB_NOSQL_CONFIG, out RuntimeConfig? config));
-            Assert.IsNotNull(config.Runtime);
+            SetupFileSystemWithInitialConfig(INITIAL_COSMOSDB_NOSQL_CONFIG);
 
             ConfigureOptions options = new(
                 dataSourceDatabaseType: "mssql",
@@ -220,7 +210,7 @@ namespace Cli.Tests
             // Assert
             Assert.IsTrue(isSuccess);
             string updatedConfig = _fileSystem!.File.ReadAllText(TEST_RUNTIME_CONFIG_FILE);
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out config));
+            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
             Assert.AreEqual(config.DataSource.DatabaseType, DatabaseType.MSSQL);
             Assert.AreEqual(config.DataSource.Options!.GetValueOrDefault("set-session-context", false), true);
@@ -240,12 +230,7 @@ namespace Cli.Tests
         public void TestDatabaseTypeUpdateMSSQLToCosmosDB_NoSQL()
         {
             // Arrange
-            _fileSystem!.AddFile(TEST_RUNTIME_CONFIG_FILE, new MockFileData(INITIAL_CONFIG));
-
-            Assert.IsTrue(_fileSystem!.File.Exists(TEST_RUNTIME_CONFIG_FILE));
-
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
-            Assert.IsNotNull(config.Runtime);
+            SetupFileSystemWithInitialConfig(INITIAL_CONFIG);
 
             ConfigureOptions options = new(
                 dataSourceDatabaseType: "cosmosdb_nosql",
@@ -261,7 +246,7 @@ namespace Cli.Tests
             // Assert
             Assert.IsTrue(isSuccess);
             string updatedConfig = _fileSystem!.File.ReadAllText(TEST_RUNTIME_CONFIG_FILE);
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out config));
+            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(updatedConfig, out RuntimeConfig? config));
             Assert.IsNotNull(config.Runtime);
             Assert.AreEqual(config.DataSource.DatabaseType, DatabaseType.CosmosDB_NoSQL);
             Assert.AreEqual(config.DataSource.Options!.GetValueOrDefault("database"), "testdb");
@@ -279,12 +264,7 @@ namespace Cli.Tests
         public void TestConfiguringInvalidDatabaseType()
         {
             // Arrange
-            _fileSystem!.AddFile(TEST_RUNTIME_CONFIG_FILE, new MockFileData(INITIAL_CONFIG));
-
-            Assert.IsTrue(_fileSystem!.File.Exists(TEST_RUNTIME_CONFIG_FILE));
-
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
-            Assert.IsNotNull(config.Runtime);
+            SetupFileSystemWithInitialConfig(INITIAL_CONFIG);
 
             ConfigureOptions options = new(
                 dataSourceDatabaseType: "invalid",
@@ -307,12 +287,7 @@ namespace Cli.Tests
         public void TestFailureWhenAddingCosmosDbOptionsToMSSQLDatabase()
         {
             // Arrange
-            _fileSystem!.AddFile(TEST_RUNTIME_CONFIG_FILE, new MockFileData(INITIAL_CONFIG));
-
-            Assert.IsTrue(_fileSystem!.File.Exists(TEST_RUNTIME_CONFIG_FILE));
-
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
-            Assert.IsNotNull(config.Runtime);
+            SetupFileSystemWithInitialConfig(INITIAL_CONFIG);
 
             ConfigureOptions options = new(
                 dataSourceOptionsDatabase: "testdb",
@@ -337,12 +312,7 @@ namespace Cli.Tests
         public void TestFailureWhenAddingSetSessionContextToMySQLDatabase()
         {
             // Arrange
-            _fileSystem!.AddFile(TEST_RUNTIME_CONFIG_FILE, new MockFileData(INITIAL_CONFIG));
-
-            Assert.IsTrue(_fileSystem!.File.Exists(TEST_RUNTIME_CONFIG_FILE));
-
-            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(INITIAL_CONFIG, out RuntimeConfig? config));
-            Assert.IsNotNull(config.Runtime);
+            SetupFileSystemWithInitialConfig(INITIAL_CONFIG);
 
             ConfigureOptions options = new(
                 dataSourceDatabaseType: "mysql",
@@ -355,6 +325,22 @@ namespace Cli.Tests
 
             // Assert
             Assert.IsFalse(isSuccess);
+        }
+
+        /// <summary>
+        /// Sets up the mock file system with an initial configuration file.
+        /// This method adds a config file to the mock file system and verifies its existence.
+        /// It also attempts to parse the config file to ensure it is valid.
+        /// </summary>
+        /// <param name="jsonConfig">The config file data as a json string.</param>
+        private void SetupFileSystemWithInitialConfig(string jsonConfig)
+        {
+            _fileSystem!.AddFile(TEST_RUNTIME_CONFIG_FILE, new MockFileData(jsonConfig));
+
+            Assert.IsTrue(_fileSystem!.File.Exists(TEST_RUNTIME_CONFIG_FILE));
+
+            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(jsonConfig, out RuntimeConfig? config));
+            Assert.IsNotNull(config.Runtime);
         }
     }
 }

--- a/src/Cli.Tests/EndToEndTests.cs
+++ b/src/Cli.Tests/EndToEndTests.cs
@@ -1110,6 +1110,7 @@ public class EndToEndTests
 
     /// <summary>
     /// Tests that the CLI can update the database type in the configuration file and is case insensitive.
+    /// Command: dab configure --data-source.database-type {dbType}
     /// </summary>
     /// <param name="dbType">The database type to be set in the configuration.</param>
     /// <param name="isSuccess">Expected success or failure of the operation.</param>

--- a/src/Cli.Tests/EndToEndTests.cs
+++ b/src/Cli.Tests/EndToEndTests.cs
@@ -1107,4 +1107,32 @@ public class EndToEndTests
         Assert.IsNotNull(runtimeConfig.Runtime.Rest);
         Assert.AreEqual(isRequestBodyStrict, runtimeConfig.Runtime.Rest.RequestBodyStrict);
     }
+
+    /// <summary>
+    /// Tests that the CLI can update the database type in the configuration file and is case insensitive.
+    /// </summary>
+    /// <param name="dbType">The database type to be set in the configuration.</param>
+    /// <param name="isSuccess">Expected success or failure of the operation.</param>
+    [DataTestMethod]
+    [DataRow("mysql", true, DisplayName = "Successful update with a valid value for database type")]
+    [DataRow("msql", false, DisplayName = "Failure as invalid value for database type")]
+    [DataRow("postgres", false, DisplayName = "Failure as invalid value for database type for PostgreSQL")]
+    [DataRow("POSTgreSQL", true, DisplayName = "Successful update with a valid value for database type for PostgreSQL with varying case")]
+    public void TestUpdateDatabaseType(string dbType, bool isSuccess)
+    {
+        // Initialize the config file.
+        string[] initArgs = { "init", "-c", TEST_RUNTIME_CONFIG_FILE, "--host-mode", "development", "--database-type",
+            "mssql", "--connection-string", TEST_ENV_CONN_STRING };
+        Program.Execute(initArgs, _cliLogger!, _fileSystem!, _runtimeConfigLoader!);
+
+        Assert.IsTrue(_runtimeConfigLoader!.TryLoadConfig(TEST_RUNTIME_CONFIG_FILE, out RuntimeConfig? runtimeConfig));
+        Assert.IsNotNull(runtimeConfig);
+
+        // Act
+        string[] runtimeArgs = { "configure", "-c", TEST_RUNTIME_CONFIG_FILE, "--data-source.database-type", dbType };
+        int isError = Program.Execute(runtimeArgs, _cliLogger!, _fileSystem!, _runtimeConfigLoader!);
+
+        // Assert
+        Assert.AreEqual(isSuccess, isError == 0);
+    }
 }

--- a/src/Cli.Tests/TestHelper.cs
+++ b/src/Cli.Tests/TestHelper.cs
@@ -84,6 +84,18 @@ namespace Cli.Tests
             }
         ";
 
+        public const string SAMPLE_SCHEMA_DATA_SOURCE_COSMOSDB_NOSQL = SCHEMA_PROPERTY + "," + @"
+            ""data-source"": {
+              ""database-type"": ""cosmosdb_nosql"",
+              ""connection-string"": """ + SAMPLE_TEST_CONN_STRING + @""",
+              ""options"": {
+                ""database"": ""testldb"",
+                ""container"": ""testcontainer"",
+                ""schema"": ""testschema.gql""
+              }
+            }
+        ";
+
         /// <summary>
         /// Data source property of the config json with an invalid connection string. This is used for
         /// constructing the required config json strings for unit tests. Config json constructed using
@@ -228,6 +240,7 @@ namespace Cli.Tests
         /// A minimal valid config json without any entities. This config string is used in unit tests.
         /// </summary>
         public const string INITIAL_CONFIG = $"{{{SAMPLE_SCHEMA_DATA_SOURCE},{RUNTIME_SECTION}}}";
+        public const string INITIAL_COSMOSDB_NOSQL_CONFIG = $"{{{SAMPLE_SCHEMA_DATA_SOURCE_COSMOSDB_NOSQL},{RUNTIME_SECTION}}}";
 
         /// <summary>
         /// A minimal config json without any entities. This config is invalid as it contains an empty connection

--- a/src/Cli/Commands/ConfigureOptions.cs
+++ b/src/Cli/Commands/ConfigureOptions.cs
@@ -53,7 +53,7 @@ namespace Cli.Commands
         [Option("data-source.options.schema", Required = false, HelpText = "Schema path for Cosmos DB for NoSql.")]
         public string? DataSourceOptionsSchema { get; }
 
-        [Option("data-source.options.set-session-context", Required = false, HelpText = "Set session context. Allowed values: true, false (default: false).")]
+        [Option("data-source.options.set-session-context", Required = false, HelpText = "Enable session context. Allowed values: true (default), false.")]
         public bool? DataSourceOptionsSetSessionContext { get; }
 
         [Option("runtime.graphql.depth-limit", Required = false, HelpText = "Max allowed depth of the nested query. Allowed values: (0,2147483647] inclusive. Default is infinity. Use -1 to remove limit.")]

--- a/src/Cli/Commands/ConfigureOptions.cs
+++ b/src/Cli/Commands/ConfigureOptions.cs
@@ -19,12 +19,42 @@ namespace Cli.Commands
     public class ConfigureOptions : Options
     {
         public ConfigureOptions(
+            string? dataSourceDatabaseType = null,
+            string? dataSourceConnectionString = null,
+            string? dataSourceOptionsDatabase = null,
+            string? dataSourceOptionsContainer = null,
+            string? dataSourceOptionsSchema = null,
+            bool? dataSourceOptionsSetSessionContext = null,
             int? depthLimit = null,
             string? config = null)
             : base(config)
         {
+            DataSourceDatabaseType = dataSourceDatabaseType;
+            DataSourceConnectionString = dataSourceConnectionString;
+            DataSourceOptionsDatabase = dataSourceOptionsDatabase;
+            DataSourceOptionsContainer = dataSourceOptionsContainer;
+            DataSourceOptionsSchema = dataSourceOptionsSchema;
+            DataSourceOptionsSetSessionContext = dataSourceOptionsSetSessionContext;
             DepthLimit = depthLimit;
         }
+
+        [Option("data-source.database-type", Required = false, HelpText = "Database type. Allowed values: MSSQL, PostgreSQL, CosmosDB_NoSQL, MySQL.")]
+        public string? DataSourceDatabaseType { get; }
+
+        [Option("data-source.connection-string", Required = false, HelpText = "Connection string for the data source.")]
+        public string? DataSourceConnectionString { get; }
+
+        [Option("data-source.options.database", Required = false, HelpText = "Database name for Cosmos DB for NoSql.")]
+        public string? DataSourceOptionsDatabase { get; }
+
+        [Option("data-source.options.container", Required = false, HelpText = "Container name for Cosmos DB for NoSql.")]
+        public string? DataSourceOptionsContainer { get; }
+
+        [Option("data-source.options.schema", Required = false, HelpText = "Schema path for Cosmos DB for NoSql.")]
+        public string? DataSourceOptionsSchema { get; }
+
+        [Option("data-source.options.set-session-context", Required = false, HelpText = "Set session context. Allowed values: true, false (default: false).")]
+        public bool? DataSourceOptionsSetSessionContext { get; }
 
         [Option("runtime.graphql.depth-limit", Required = false, HelpText = "Max allowed depth of the nested query. Allowed values: (0,2147483647] inclusive. Default is infinity. Use -1 to remove limit.")]
         public int? DepthLimit { get; }

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -527,6 +527,11 @@ namespace Cli
                 return false;
             }
 
+            if (!TryConfigureDataSourceOptions(options, ref runtimeConfig))
+            {
+                return false;
+            }
+
             if (options.DepthLimit is not null && !TryUpdateDepthLimit(options, ref runtimeConfig))
             {
                 return false;
@@ -567,7 +572,7 @@ namespace Cli
                 dataSourceConnectionString = options.DataSourceConnectionString;
             }
 
-            Dictionary<string, object?> dbOptions = new();
+            Dictionary<string, object?>? dbOptions = null;
             HyphenatedNamingPolicy namingPolicy = new();
 
             if (DatabaseType.CosmosDB_NoSQL.Equals(dbType))
@@ -590,6 +595,7 @@ namespace Cli
                     return false;
                 }
 
+                dbOptions = dbOptions ?? new();
                 dbOptions.Add(namingPolicy.ConvertName(nameof(MsSqlOptions.SetSessionContext)), options.DataSourceOptionsSetSessionContext.Value);
             }
 
@@ -608,20 +614,23 @@ namespace Cli
         /// <param name="dbOptions">The dictionary to which the CosmosDB-specific options will be added.</param>
         /// <param name="options">The configuration options provided by the user.</param>
         /// <param name="namingPolicy">The naming policy used to convert option names to the desired format.</param>
-        private static void AddCosmosDbOptions(Dictionary<string, object?> dbOptions, ConfigureOptions options, HyphenatedNamingPolicy namingPolicy)
+        private static void AddCosmosDbOptions(Dictionary<string, object?>? dbOptions, ConfigureOptions options, HyphenatedNamingPolicy namingPolicy)
         {
             if (!string.IsNullOrWhiteSpace(options.DataSourceOptionsDatabase))
             {
+                dbOptions = dbOptions ?? new();
                 dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Database)), options.DataSourceOptionsDatabase);
             }
 
             if (!string.IsNullOrWhiteSpace(options.DataSourceOptionsContainer))
             {
+                dbOptions = dbOptions ?? new();
                 dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Container)), options.DataSourceOptionsContainer);
             }
 
             if (!string.IsNullOrWhiteSpace(options.DataSourceOptionsSchema))
             {
+                dbOptions = dbOptions ?? new();
                 dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Schema)), options.DataSourceOptionsSchema);
             }
         }
@@ -652,11 +661,6 @@ namespace Cli
                     _logger.LogError("Invalid depth limit. Specify a depth limit > 0 or remove the existing depth limit by specifying -1.");
                     return false;
                 }
-            }
-
-            if (!TryConfigureDataSourceOptions(options, ref runtimeConfig))
-            {
-                return false;
             }
 
             // Try to update the depth limit in the runtime configuration

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -545,7 +545,7 @@ namespace Cli
         /// Configures the data source options for the runtimeconfig based on the provided options.
         /// This method updates the database type, connection string, and other database-specific options in the config file.
         /// It validates the provided database type and ensures that options specific to certain database types are correctly applied.
-        /// If any validation fails, it logs an error and returns false.
+        /// When validation fails, this function logs the validation errors and returns false.
         /// </summary>
         /// <param name="options">The configuration options provided by the user.</param>
         /// <param name="runtimeConfig">The runtime configuration to be updated. This parameter is passed by reference and must not be null if the method returns true.</param>
@@ -603,7 +603,7 @@ namespace Cli
             DataSource dataSource = new(dbType, dataSourceConnectionString, dbOptions);
             runtimeConfig = runtimeConfig with { DataSource = dataSource };
 
-            return true;
+            return runtimeConfig != null;
         }
 
         /// <summary>

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -12,6 +12,7 @@ using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Service;
 using Cli.Commands;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 using static Cli.Utils;
 
 namespace Cli
@@ -572,7 +573,7 @@ namespace Cli
                 dataSourceConnectionString = options.DataSourceConnectionString;
             }
 
-            Dictionary<string, object?>? dbOptions = null;
+            Dictionary<string, object?>? dbOptions = new();
             HyphenatedNamingPolicy namingPolicy = new();
 
             if (DatabaseType.CosmosDB_NoSQL.Equals(dbType))
@@ -595,10 +596,10 @@ namespace Cli
                     return false;
                 }
 
-                dbOptions = dbOptions ?? new();
                 dbOptions.Add(namingPolicy.ConvertName(nameof(MsSqlOptions.SetSessionContext)), options.DataSourceOptionsSetSessionContext.Value);
             }
 
+            dbOptions = dbOptions.IsNullOrEmpty() ? null : dbOptions;
             DataSource dataSource = new(dbType, dataSourceConnectionString, dbOptions);
             runtimeConfig = runtimeConfig with { DataSource = dataSource };
 
@@ -614,23 +615,20 @@ namespace Cli
         /// <param name="dbOptions">The dictionary to which the CosmosDB-specific options will be added.</param>
         /// <param name="options">The configuration options provided by the user.</param>
         /// <param name="namingPolicy">The naming policy used to convert option names to the desired format.</param>
-        private static void AddCosmosDbOptions(Dictionary<string, object?>? dbOptions, ConfigureOptions options, HyphenatedNamingPolicy namingPolicy)
+        private static void AddCosmosDbOptions(Dictionary<string, object?> dbOptions, ConfigureOptions options, HyphenatedNamingPolicy namingPolicy)
         {
             if (!string.IsNullOrWhiteSpace(options.DataSourceOptionsDatabase))
             {
-                dbOptions = dbOptions ?? new();
                 dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Database)), options.DataSourceOptionsDatabase);
             }
 
             if (!string.IsNullOrWhiteSpace(options.DataSourceOptionsContainer))
             {
-                dbOptions = dbOptions ?? new();
                 dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Container)), options.DataSourceOptionsContainer);
             }
 
             if (!string.IsNullOrWhiteSpace(options.DataSourceOptionsSchema))
             {
-                dbOptions = dbOptions ?? new();
                 dbOptions.Add(namingPolicy.ConvertName(nameof(CosmosDbNoSQLDataSourceOptions.Schema)), options.DataSourceOptionsSchema);
             }
         }


### PR DESCRIPTION
## Why make this change?

- Closes #2295 
  - This change will allow user to update data-source options.
  - Also, it makes CLI more powerful and developer friendly.

## What is this change?

- Introducing new options for configure command to update data-source options.

| Configuration File Property Path                                        | CLI Flag                                                           | Data Type | Nullable |
|-------------------------------------------------------------------------|--------------------------------------------------------------------|-----------|----------|
| data-source.<br/>database-type                                          | <nobr>--data-source.database-type</nobr>                           | String: `MSSQL`, `PostgreSQL`, `CosmosDB_NoSQL`, `MySQL` | ✅  |
| data-source.<br/>connection-string                                      | <nobr>--data-source.connection-string</nobr>                       | String    | ✅        |
| data-source.<br/>options.database                                       | <nobr>--data-source.options.database</nobr>                        | String    | ✅       |
| data-source.<br/>options.container                                      | <nobr>--data-source.options.container</nobr>                       | String    | ✅       |
| data-source.<br/>options.schema                                         | <nobr>--data-source.options.schema</nobr>                          | String    | ✅       |
| data-source.<br/>options.set-session-context                            | <nobr>--data-source.options.set-session-context</nobr>             | Boolean: `true`, `false` (default: `false`) | ✅   |


## NOTES:
Certain properties that are specific to database can only be updated with the correct databaseType.
For Example: If the database type initially was MSSQL, and we give cosmosDBoptions without specifying the new dbType as cosmosDB_NoSQL, the command will fail.
For better usability, we will also allow users to first update the dbType to cosmosDB_NoSQL and then in a new command provide the cosmosDB specifig options, since using all the options in one command can be very long and errornous. 


## How was this tested?

- [x] End-End Tests
- [x] Unit Tests

## Sample Request(s)

- To update to mssql
`dab configure --data-source.database-type mssql --data-source.options.set-session-context true`

- To update to cosmosDB_NoSQL
   #### Single command
  `dab configure --data-source.database-type cosmosdb_nosql --data-source.options.database testdbname --data-source.options.schema testschema.gql`

  #### Break the command
  1. `dab configure --data-source.database-type cosmosdb_nosql`
  2. `dab configure --data-source.options.database testdbname --data-source.options.schema testschema.gql`