### PR TITLE
Replace internal references to RuntimeConfig with immutable copies to maintain consistent states

### DIFF
--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -59,7 +59,9 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
             RuntimeConfig runtimeConfig = runtimeConfigProvider.GetConfig();
             _runtimeConfigProvider = runtimeConfigProvider;
             _fileSystem = fileSystem;
-            // Make a copy of the runtime entities to guarantee consistency
+            // Many classes have references to the RuntimeConfig, therefore to guarantee
+            // that the Runtime Entities are not mutated by another class we make a copy of them
+            // to store internally.
             _runtimeConfigEntities = new RuntimeEntities(runtimeConfig.Entities.Entities);
             _databaseType = runtimeConfig.DataSource.DatabaseType;
 

--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -24,8 +24,8 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
         private readonly IFileSystem _fileSystem;
         private readonly DatabaseType _databaseType;
         private CosmosDbNoSQLDataSourceOptions _cosmosDb;
-        private readonly RuntimeConfigProvider _runtimeConfigProvider;
         private readonly RuntimeEntities _runtimeConfigEntities;
+        private readonly bool _isDevelopmentMode;
         private Dictionary<string, string> _partitionKeyPaths = new();
 
         /// <summary>
@@ -63,6 +63,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
             // that the Runtime Entities are not mutated by another class we make a copy of them
             // to store internally.
             _runtimeConfigEntities = new RuntimeEntities(runtimeConfig.Entities.Entities);
+            _isDevelopmentMode = runtimeConfig.IsDevelopmentMode();
             _databaseType = runtimeConfig.DataSource.DatabaseType;
 
             CosmosDbNoSQLDataSourceOptions? cosmosDb = runtimeConfig.DataSource.GetTypedOptions<CosmosDbNoSQLDataSourceOptions>();
@@ -603,7 +604,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
         // state on development mode in case a hot-reload
         public bool IsDevelopmentMode()
         {
-            return _runtimeConfigProvider.GetConfig().IsDevelopmentMode();
+            return _isDevelopmentMode;
         }
 
         public bool TryGetExposedFieldToBackingFieldMap(string entityName, [NotNullWhen(true)] out IReadOnlyDictionary<string, string>? mappings)

--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -600,7 +600,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
         }
 
         // Use the runtimeConfigProvider to ensure we have current up to date
-        // state on development mode in case a hot
+        // state on development mode in case a hot-reload
         public bool IsDevelopmentMode()
         {
             return _runtimeConfigProvider.GetConfig().IsDevelopmentMode();

--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -57,7 +57,6 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
         public CosmosSqlMetadataProvider(RuntimeConfigProvider runtimeConfigProvider, IFileSystem fileSystem)
         {
             RuntimeConfig runtimeConfig = runtimeConfigProvider.GetConfig();
-            _runtimeConfigProvider = runtimeConfigProvider;
             _fileSystem = fileSystem;
             // Many classes have references to the RuntimeConfig, therefore to guarantee
             // that the Runtime Entities are not mutated by another class we make a copy of them

--- a/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/CosmosSqlMetadataProvider.cs
@@ -599,8 +599,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
             return string.Empty;
         }
 
-        // Use the runtimeConfigProvider to ensure we have current up to date
-        // state on development mode in case a hot-reload
+        // Use the internal, immutable copy so that we always return consistent results.
         public bool IsDevelopmentMode()
         {
             return _isDevelopmentMode;

--- a/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
+++ b/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
@@ -140,7 +140,7 @@ namespace Azure.DataApiBuilder.Core.Services
                     {
                         new() { Url = url }
                     },
-                    Paths = BuildPaths(),
+                    Paths = BuildPaths(runtimeConfig),
                     Components = components
                 };
                 _openApiDocument = doc;
@@ -170,9 +170,8 @@ namespace Azure.DataApiBuilder.Core.Services
         /// "/EntityName"
         /// </example>
         /// <returns>All possible paths in the DAB engine's REST API endpoint.</returns>
-        private OpenApiPaths BuildPaths()
+        private OpenApiPaths BuildPaths(RuntimeConfig runtimeConfig)
         {
-            RuntimeConfig runtimeConfig = _runtimeConfigProvider.GetConfig();
             OpenApiPaths pathsCollection = new();
 
             string defaultDataSourceName = runtimeConfig.DefaultDataSourceName;

--- a/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
+++ b/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
@@ -192,13 +192,17 @@ namespace Azure.DataApiBuilder.Core.Services
 
                 // Entities which disable their REST endpoint must not be included in
                 // the OpenAPI description document.
-                Entity? entity;
-                if (entities.TryGetValue(entityName, out entity) && entity is not null)
+                if (entities.TryGetValue(entityName, out Entity? entity) && entity is not null)
                 {
                     if (!entity.Rest.Enabled)
                     {
                         continue;
                     }
+                }
+
+                if (entity is null)
+                {
+                    continue;
                 }
 
                 // Explicitly exclude setting the tag's Description property since the Name property is self-explanatory.
@@ -599,7 +603,7 @@ namespace Azure.DataApiBuilder.Core.Services
         /// <param name="entity">The entity.</param>
         /// <param name="dbObject">Database object metadata, indicating entity SourceType</param>
         /// <returns>Collection of OpenAPI OperationTypes and whether they should be created.</returns>
-        private static Dictionary<OperationType, bool> GetConfiguredRestOperations(Entity? entity, DatabaseObject dbObject)
+        private static Dictionary<OperationType, bool> GetConfiguredRestOperations(Entity entity, DatabaseObject dbObject)
         {
             Dictionary<OperationType, bool> configuredOperations = new()
             {

--- a/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
+++ b/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
@@ -199,8 +199,7 @@ namespace Azure.DataApiBuilder.Core.Services
                         continue;
                     }
                 }
-
-                if (entity is null)
+                else
                 {
                     continue;
                 }


### PR DESCRIPTION
## Why make this change?

closes https://github.com/Azure/data-api-builder/issues/2321

## What is this change?

Hot-Reload will mean refreshing the `RuntimeConfig` that the `RuntimeConfigProvider` retrieves. To make sure that we have consistency throughout DAB, we refactor how certain classes store the `RuntimeConfig` to guarantee consistency within that class and with DAB. For the `CosmosSqlMetadataProvider` this means that we make a copy of the Entities at the time of construction and store that copy for use within the class. We also save the state of the `isDevelopmentMode` function from the runtimeConfig to keep this class consistent to the `RuntimeConfig` at time of construction. This guarantees that no other class can modify those Entities and we will have a consistent state throughout the life of the `CosmosSqlMetadataProvider`. For the `OpenApiDocumentor` we change the class to get a fresh `RuntimeConfig` when it's public facing functions are called so that the output of those functions matches the current state of DAB.

## How was this tested?

Against our current test suite. This will be tested from a hot-reload perspective with the hot-reload integration tests.

## Sample Request(s)

Any request will work.