### PR TITLE
Fix context sql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Version values referenced from https://hub.docker.com/_/microsoft-dotnet-aspnet
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0. AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 
 WORKDIR /src
 COPY [".", "./"]
-RUN dotnet build "./src/Service/Azure.DataApiBuilder.Service.csproj" -c Docker -o /out -r linux-x64
+RUN dotnet build "./src/Service/Azure.DataApiBuilder.Service.csproj" -f net8.0 -o /out -r linux-x64 --self-contained
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-cbl-mariner2.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 
 COPY --from=build /out /App
 WORKDIR /App

--- a/src/Auth/Azure.DataApiBuilder.Auth.csproj
+++ b/src/Auth/Azure.DataApiBuilder.Auth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>

--- a/src/Cli.Tests/Cli.Tests.csproj
+++ b/src/Cli.Tests/Cli.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Cli</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Config/Azure.DataApiBuilder.Config.csproj
+++ b/src/Config/Azure.DataApiBuilder.Config.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>

--- a/src/Config/ObjectModel/AuthenticationOptions.cs
+++ b/src/Config/ObjectModel/AuthenticationOptions.cs
@@ -17,6 +17,7 @@ public record AuthenticationOptions(string Provider = nameof(EasyAuthType.Static
     public const string CLIENT_PRINCIPAL_HEADER = "X-MS-CLIENT-PRINCIPAL";
     public const string NAME_CLAIM_TYPE = "name";
     public const string ROLE_CLAIM_TYPE = "roles";
+    public const string ORIGINAL_ROLE_CLAIM_TYPE = "original_roles";
 
     /// <summary>
     /// Returns whether the configured Provider matches an

--- a/src/Core/Authorization/AuthorizationResolver.cs
+++ b/src/Core/Authorization/AuthorizationResolver.cs
@@ -604,9 +604,14 @@ public class AuthorizationResolver : IAuthorizationResolver
             // into a list and storing that in resolvedClaims using the claimType as the key.
             foreach (Claim claim in identity.Claims)
             {
-                // 'roles' claim has already been processed.
+                // 'roles' claim has already been processed. But we preserve the original 'roles' claim
                 if (claim.Type.Equals(AuthenticationOptions.ROLE_CLAIM_TYPE))
                 {
+                    if(!resolvedClaims.TryAdd(AuthenticationOptions.ORIGINAL_ROLE_CLAIM_TYPE, new List<Claim>() { claim }))
+                    {
+                        resolvedClaims[AuthenticationOptions.ORIGINAL_ROLE_CLAIM_TYPE].Add(claim);
+                    }
+
                     continue;
                 }
 

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -217,9 +217,9 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             foreach ((string claimType, string claimValue) in sessionParams)
             {
                 string paramName = $"{SESSION_PARAM_NAME}{counter.Next()}";
-                parameters.Add(paramName, new(claimValue));
+                parameters.Add(paramName, new(claimValue));          
                 // Append statement to set read only param value - can be set only once for a connection.
-                string statementToSetReadOnlyParam = "EXEC sp_set_session_context " + $"'{claimType}', " + paramName + ", @read_only = 1;";
+                string statementToSetReadOnlyParam = "EXEC sp_set_session_context " + $"'{claimType}', " + paramName + ", @read_only = 0;";
                 sessionMapQuery = sessionMapQuery.Append(statementToSetReadOnlyParam);
             }
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
     <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/src/Product/Azure.DataApiBuilder.Product.csproj
+++ b/src/Product/Azure.DataApiBuilder.Product.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>

--- a/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
+++ b/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>

--- a/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
+++ b/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <OutputPath>$(BaseOutputPath)\tests</OutputPath>

--- a/src/Service/.config/dotnet-tools.json
+++ b/src/Service/.config/dotnet-tools.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {}
+}

--- a/src/Service/Azure.DataApiBuilder.Service.csproj
+++ b/src/Service/Azure.DataApiBuilder.Service.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <Configurations>Debug;Release;Docker</Configurations>
         <OutputPath>$(BaseOutputPath)\engine</OutputPath>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
@@ -36,6 +36,10 @@
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Docker|net8.0|AnyCPU'">
+      <Optimize>True</Optimize>
+    </PropertyGroup>
+
     <ItemGroup>
         <Content Update="appsettings*.json">
             <CopyToOutputDirectory>$(CopyToOutputDirectoryAction)</CopyToOutputDirectory>
@@ -45,7 +49,6 @@
 
     <ItemGroup>
         <Watch Remove="dab-config.CosmosDb_NoSql.json" />
-        <Watch Remove="dab-config.json" />
         <Watch Remove="dab-config.MsSql.json" />
         <Watch Remove="dab-config.MySql.json" />
         <Watch Remove="dab-config.PostgreSql.json" />

--- a/src/Service/Properties/PublishProfiles/crweudev01.pubxml
+++ b/src/Service/Properties/PublishProfiles/crweudev01.pubxml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <WebPublishMethod>Container</WebPublishMethod>
+    <ContainerPublishMethod>NetSdk</ContainerPublishMethod>
+    <ResourceId>/subscriptions/d81425a2-a8ea-4ea4-9bdd-ca9db5cdfbc6/resourceGroups/rg-weu-api/providers/Microsoft.ContainerRegistry/registries/crweudev01</ResourceId>
+    <ResourceName>crweudev01</ResourceName>
+    <ResourceGroup>rg-weu-api</ResourceGroup>
+    <Subscription>sub-mdm-weu-dev</Subscription>
+    <RegistryUrl>crweudev01.azurecr.io</RegistryUrl>
+    <UserName />
+    <PublishImageTag>latest</PublishImageTag>
+    <PublishProvider>ContainerRegistry</PublishProvider>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <ProjectGuid>208fc26c-a21c-4c96-98ee-f10fdaeac508</ProjectGuid>
+    <_TargetId>NetSdkAzureContainerRegistry</_TargetId>
+    <SiteUrlToLaunchAfterPublish />
+    <LaunchSiteAfterPublish>true</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>false</ExcludeApp_Data>
+    <TargetFramework>net8.0</TargetFramework>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Why make this change?

- Fixes #2341 (partly)
  - do not set the session context in SQL server with read_only = 1 as this prevents us from doing a second request on the same connection
  - keep a copy of the original 'roles' from the JWT token so we can use it on the SQL Filter Predicate to accurately implement row level security

## What is this change?

The changes itself are quite simple and should break nothing, see the diff :-)


## How was this tested?

I have not created/adapted any tests yet. Just looking for comments before I go there.

## Sample Request(s)

Sample of a JWT token (only the relevant part)
`{
  "aud": "api://ddcf6b31-5d01-407d-97cf-8efefc455d32",
  "iss": "https://sts.windows.net/9215c785-95c3-49b0-bdba-2062df5aedb5/",
  "roles": [
    "user",
    "Allow_Customer_OPS025235",
    "Allow_Customer_OPS004095"
  ],
  "ver": "1.0"
}`

X-MS-API-ROLE: user

before my change the extra 'roles' that do not match the X-MS-API-ROLE header would never reach the database context.
With my change you can do things like this in SQL Predicates to filter out only subsets of the data:

`CREATE FUNCTION dbo.ops_fact_order_Predicate(@CustomerNo varchar(max))
RETURNS TABLE
WITH SCHEMABINDING
AS RETURN SELECT 1 AS fn_securitypredicate_result
WHERE @CustomerNo in (
		select trim(replace(replace(replace([value], '"', ''), ']', ''), 'Allow_Customer_', '')) 
		from STRING_SPLIT ( 
			CAST(SESSION_CONTEXT(N'original_roles') as varchar(max)) 
			, ',' 
			, 0) 
			where trim(replace(replace([value], '"', ''), ']', '')) like 'Allow_Customer%'
		)

CREATE SECURITY POLICY dbo.ops_fact_order_Policy
ADD FILTER PREDICATE dbo.ops_fact_order_Predicate(CustomerNo)
ON [gold_ops].[ops_fact_order];`

