### PR TITLE
Culture Invariant Tests for SQL

### DIFF
--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/GraphQLMutationTestBase.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/GraphQLMutationTestBase.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Globalization;
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -1116,7 +1116,6 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
         /// <summary>
         /// Performs create item on different Windows Regional format settings and validate that the data type Float is correct
         /// </summary>
-        [TestMethod]
         public async Task CanCreateItemWithCultureInvariant(string cultureInfo, string dbQuery)
         {
             CultureInfo ci = new(cultureInfo);
@@ -1138,7 +1137,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
             JsonElement response = await ExecuteGraphQLRequestAsync(graphQLMutation, graphQLMutationName, isAuthenticated: true);
             string dbResponse = await GetDatabaseResultAsync(dbQuery);
             using JsonDocument dbResponseJson = JsonDocument.Parse(dbResponse);
-            
+
             // Validate results
             Assert.AreEqual(Convert.ToDouble(dbResponseJson.RootElement.GetProperty("total").GetDouble(), CultureInfo.InvariantCulture), response.GetProperty("total").GetDouble());
         }

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/GraphQLMutationTestBase.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/GraphQLMutationTestBase.cs
@@ -1129,7 +1129,6 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
                         item_name
                         subtotal
                         tax
-                        total
                     }
                 }
             ";
@@ -1139,7 +1138,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
             using JsonDocument dbResponseJson = JsonDocument.Parse(dbResponse);
 
             // Validate results
-            Assert.AreEqual(Convert.ToDouble(dbResponseJson.RootElement.GetProperty("total").GetDouble(), CultureInfo.InvariantCulture), response.GetProperty("total").GetDouble());
+            Assert.AreEqual(Convert.ToDouble(dbResponseJson.RootElement.GetProperty("subtotal").GetDouble(), CultureInfo.InvariantCulture), response.GetProperty("subtotal").GetDouble());
         }
 
         #endregion

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/MsSqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/MsSqlGraphQLMutationTests.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Configuration;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -797,8 +795,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
                 SELECT TOP 1 [table0].[id] AS [id],
                     [table0].[item_name] AS [item_name],
                     [table0].[subtotal] AS [subtotal],
-                    [table0].[tax] AS [tax],
-                    [table0].[total] AS [total]
+                    [table0].[tax] AS [tax]
                 FROM [dbo].[sales] AS [table0]
                 WHERE [table0].[item_name] = 'test_name'
                 ORDER BY [table0].[id] ASC

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/MsSqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/MsSqlGraphQLMutationTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Configuration;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -780,6 +782,32 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
             ";
 
             await InsertIntoInsertableComplexView(msSqlQuery);
+        }
+
+        /// <summary>
+        /// <code>Do: </code> create an entry with a type Float
+        /// <code>Check: </code> that the type Float of new entry can be correctly viewed in different regional format settings
+        /// </summary>
+        [TestMethod]
+        [DataRow("en-US")]
+        [DataRow("en-DE")]
+        public async Task CanCreateItemWithCultureInvariant(string cultureInfo)
+        {
+            string msSqlQuery = @"
+                SELECT TOP 1 [table0].[id] AS [id],
+                    [table0].[item_name] AS [item_name],
+                    [table0].[subtotal] AS [subtotal],
+                    [table0].[tax] AS [tax],
+                    [table0].[total] AS [total]
+                FROM [dbo].[sales] AS [table0]
+                WHERE [table0].[item_name] = 'test_name'
+                ORDER BY [table0].[id] ASC
+                FOR JSON PATH,
+                    INCLUDE_NULL_VALUES,
+                    WITHOUT_ARRAY_WRAPPER
+            ";
+
+            await CanCreateItemWithCultureInvariant(cultureInfo, msSqlQuery);
         }
 
         /// <summary>

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
@@ -600,6 +600,32 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
             await InsertIntoInsertableComplexView(mySqlQuery);
         }
 
+        /// <summary>
+        /// <code>Do: </code> create an entry with a type Float
+        /// <code>Check: </code> that the type Float of new entry can be correctly viewed in different regional format settings
+        /// </summary>
+        [TestMethod]
+        [DataRow("en-US")]
+        [DataRow("en-DE")]
+        public async Task CanCreateItemWithCultureInvariant(string cultureInfo)
+        {
+            string msSqlQuery = @"
+                SELECT JSON_OBJECT('id', `subq`.`id`, 'item_name', `subq`.`item_name`, 'subtotal', `subq`.`subtotal`, 'tax', `subq`.`tax`, 'total', `subq`.`total`) AS `data`
+                FROM (
+                    SELECT `table0`.`id` AS `id`,
+                        `table0`.`item_name` AS `item_name`,
+                        `table0`.`subtotal` AS `subtotal`,
+                        `table0`.`tax` AS `tax`,
+                        `table0`.`total` AS `total`
+                    FROM `sales` AS `table0`
+                    WHERE `table0`.`item_name` = 'test_name'
+                    ORDER BY `table0`.`id` ASC LIMIT 1
+                    ) AS `subq`
+            ";
+
+            await CanCreateItemWithCultureInvariant(cultureInfo, msSqlQuery);
+        }
+
         /// <inheritdoc/>
         [TestMethod]
         [Ignore]

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/MySqlGraphQLMutationTests.cs
@@ -610,13 +610,12 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
         public async Task CanCreateItemWithCultureInvariant(string cultureInfo)
         {
             string msSqlQuery = @"
-                SELECT JSON_OBJECT('id', `subq`.`id`, 'item_name', `subq`.`item_name`, 'subtotal', `subq`.`subtotal`, 'tax', `subq`.`tax`, 'total', `subq`.`total`) AS `data`
+                SELECT JSON_OBJECT('id', `subq`.`id`, 'item_name', `subq`.`item_name`, 'subtotal', `subq`.`subtotal`, 'tax', `subq`.`tax`) AS `data`
                 FROM (
                     SELECT `table0`.`id` AS `id`,
                         `table0`.`item_name` AS `item_name`,
                         `table0`.`subtotal` AS `subtotal`,
-                        `table0`.`tax` AS `tax`,
-                        `table0`.`total` AS `total`
+                        `table0`.`tax` AS `tax`
                     FROM `sales` AS `table0`
                     WHERE `table0`.`item_name` = 'test_name'
                     ORDER BY `table0`.`id` ASC LIMIT 1

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/PostgreSqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/PostgreSqlGraphQLMutationTests.cs
@@ -599,6 +599,32 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
             await InsertIntoInsertableComplexView(postgresQuery);
         }
 
+        /// <summary>
+        /// <code>Do: </code> create an entry with a type Float
+        /// <code>Check: </code> that the type Float of new entry can be correctly viewed in different regional format settings
+        /// </summary>
+        [TestMethod]
+        [DataRow("en-US")]
+        [DataRow("en-DE")]
+        public async Task CanCreateItemWithCultureInvariant(string cultureInfo)
+        {
+            string msSqlQuery = @"
+                SELECT to_jsonb(subq) AS data
+                FROM
+                    (SELECT table0.id AS id,
+                        table0.item_name AS item_name,
+                        table0.subtotal AS subtotal,
+                        table0.tax AS tax,
+                        table0.total AS total
+                    FROM public.sales AS table0
+                    WHERE table0.item_name = 'test_name'
+                    ORDER BY table0.id ASC
+                    LIMIT 1) AS subq
+            ";
+
+            await CanCreateItemWithCultureInvariant(cultureInfo, msSqlQuery);
+        }
+
         /// <inheritdoc/>
         [TestMethod]
         [Ignore]

--- a/src/Service.Tests/SqlTests/GraphQLMutationTests/PostgreSqlGraphQLMutationTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLMutationTests/PostgreSqlGraphQLMutationTests.cs
@@ -614,8 +614,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLMutationTests
                     (SELECT table0.id AS id,
                         table0.item_name AS item_name,
                         table0.subtotal AS subtotal,
-                        table0.tax AS tax,
-                        table0.total AS total
+                        table0.tax AS tax
                     FROM public.sales AS table0
                     WHERE table0.item_name = 'test_name'
                     ORDER BY table0.id ASC


### PR DESCRIPTION
## Why make this change?

It addresses issue #2319. Helps ensure that there are SQL tests that mirror the Cosmos tests that were added before.

## What is this change?

Added test cases for SQL to make sure datatype conversion is `CultureInfo.InvariantCulture`

## How was this tested?

- [X] Integration Tests
- [ ] Unit Tests
