### PR TITLE
Fix export command

### DIFF
--- a/docs/design/dab-configure.md
+++ b/docs/design/dab-configure.md
@@ -1,0 +1,117 @@
+# Design Document: `dab configure` Command
+
+## Overview
+
+The `dab configure` command is designed to simplify updating config properties outside of entities section. This document outlines the design, functionality, and implementation details of the `dab configure` command.
+
+## Objectives
+
+- Add support to CLI to configure `data-source` and `runtime` section of the runtime config.
+
+- Ensure configurations are validated before being applied.
+
+## Command Syntax
+
+```sh
+
+dab configure [options]
+
+```
+
+### Options
+
+Some of the supported options:
+- `--config `: Specify the configuration file path.
+- `--runtime.graphql.depth-limit`: Max allowed depth of the nested query.
+- `--data-source.database-type`: Type of database to connect to.
+- `--data-source.options.schema`: Schema path for Cosmos DB for NoSql.
+- `--help`: Display help information about the command.
+
+### Naming Convention
+
+#### Configuration Structure
+The configuration file consists of three main sections:
+
+1. data-source: Defines the database connection and options.
+2. runtime: Configures the runtime settings for REST, GraphQL, and host settings.
+3. entities: Entity related information.
+
+`dab configure` is only for updating `data-source` and `runtime` section of the config. For `entites` section we already have `dab update` command.
+
+#### Naming the option
+
+1. Identify the section to configure. `data-source` or `runtime`.
+2. Indentity the property in that section to update.
+3. '.' is used for nesting.
+
+Example:
+```json
+{
+  "data-source": {
+    "database-type": "mssql",
+    "connection-string": "xxx",
+    "options": {
+      "set-session-context": true
+    }
+  },
+  "runtime": {
+    "rest": {
+      "enabled": true,
+      "path": "/api",
+      "request-body-strict": true
+    },
+    "graphql": {
+      "enabled": true,
+      "path": "/graphql",
+      "allow-introspection": true,
+      "multiple-mutations": {
+        "create": {
+          "enabled": true
+        }
+      }
+    },
+    "host": {
+      "cors": {
+        "origins": [
+          "http://localhost:5000"
+        ],
+        "allow-credentials": false
+      },
+      "authentication": {
+        "provider": "StaticWebApps"
+      },
+      "mode": "development"
+    }
+  }
+}
+```
+1. To update graphql path in the runtime section, the option name should be
+`--runtime.graphql.path`.
+2. To update `set-session-context` in data-source, the option name should be
+`--data-source.options.set-session-context`.
+
+
+## Implementation Details
+
+1. Add the New `dab configure` options in `ConfigureOptions.cs` located at `src\Cli\Commands\ConfigureOptions.cs`.
+
+2. Update the method `TryConfigureSettings` in `ConfigGenerator.cs` located at `src\Cli\ConfigGenerator.cs`.
+
+3. Use the excisting validation to make sure the user provided input is valid.
+
+4. Make sure the above method returns `false` in case of any failures and no changes should me made to the config in this case.
+
+5. If everything is correct, apply the change and return `true`.
+
+
+## Testing
+
+- Add Unit tests for command parsing and validation in `ConfigureOptionsTests.cs` located at `src\Cli.Tests\ConfigureOptionsTests.cs`.
+
+- Add Integration tests for end-to-end configuration scenarios in `EndToEndTests.cs` located at `src\Cli.Tests\EndToEndTests.cs`.
+
+- Manual testing for user interactions and error handling.
+
+## Conclusion
+
+The `dab configure` command provides a streamlined way to update config properties outside of entities section.

--- a/src/Cli.Tests/ExporterTests.cs
+++ b/src/Cli.Tests/ExporterTests.cs
@@ -1,65 +1,61 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// using System;
-// using System.Net.Http;
-// using System.Threading.Tasks;
-// using Moq;
-// using Xunit;
-// using HotChocolate.Language;
-// using System.IO.Abstractions;
-// using System.IO.Abstractions.TestingHelpers;
-// using HotChocolate.Utilities.Introspection;
-
 namespace Cli.Tests;
 
+/// <summary>
+/// Tests for Export Command in CLI.
+/// </summary>
 [TestClass]
 public class ExporterTests
 {
-    // [TestMethod]
-    // public void ExportGraphQL_RetriesWithHttpIfHttpsFails()
-    // {
-    //     // Arrange
-    //     Mock<HttpClient> httpsClientMock = new(MockBehavior.Strict);
-    //     Mock<HttpClient> httpClientMock = new(MockBehavior.Strict);
-    //     Mock<IntrospectionClient> introspectionClientMock = new();
-    //     MockFileSystem fileSystem = new();
+    /// <summary>
+    /// Tests the ExportGraphQLFromDabService method to ensure it logs correctly when the HTTPS endpoint works.
+    /// </summary>
+    [TestMethod]
+    public void ExportGraphQLFromDabService_LogsWhenHttpsWorks()
+    {
+        // Arrange
+        Mock<ILogger> mockLogger = new();
+        Mock<Exporter> mockExporter = new();
+        RuntimeConfig runtimeConfig = new(
+                Schema: "schema",
+                DataSource: new DataSource(DatabaseType.MSSQL, "", new()),
+                Runtime: new(Rest: new(), GraphQL: new(), Host: new(null, null)),
+                Entities: new(new Dictionary<string, Entity>())
+            );
 
-    //     ExportOptions options = new(true, "output", null, null);
-    //     RuntimeConfig runtimeConfig = new(
-    //             Schema: "schema",
-    //             DataSource: new DataSource(DatabaseType.MSSQL, "", new()),
-    //             Runtime: new(Rest: new(), GraphQL: new(), Host: new(null, null)),
-    //             Entities: new(new Dictionary<string, Entity>())
-    //         );
+        // Setup the mock to return a schema when the HTTPS endpoint is used
+        mockExporter.Setup(e => e.GetGraphQLSchema(runtimeConfig, false))
+                    .Returns("schema from HTTPS endpoint");
 
-    //     // Setup the HTTPS client to throw an exception
-    //     introspectionClientMock
-    //         .Setup(client => client.DownloadSchemaAsync(It.IsAny<HttpClient>()))
-    //         .ThrowsAsync(new Exception("HTTPS request failed"));
+        // Act
+        string result = mockExporter.Object.ExportGraphQLFromDabService(runtimeConfig, mockLogger.Object);
 
-    //     // Setup the HTTP client to return a valid schema
-    //     DocumentNode expectedSchema = new DocumentNode();
-    //     introspectionClientMock
-    //         .Setup(client => client.DownloadSchemaAsync(It.Is<HttpClient>(c => c.BaseAddress.Scheme == Uri.UriSchemeHttp)))
-    //         .ReturnsAsync(expectedSchema);
+        // Assert
+        Assert.AreEqual("schema from HTTPS endpoint", result);
+        mockLogger.Verify(logger => logger.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("schema from HTTPS endpoint.")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Never);
+    }
 
-    //     // Act
-    //     Exporter.ExportGraphQL(options, runtimeConfig, fileSystem);
-
-    //     // Assert
-    //     introspectionClientMock.Verify(client => client.DownloadSchemaAsync(It.Is<HttpClient>(c => c.BaseAddress.Scheme == Uri.UriSchemeHttps)), Times.Once);
-    //     introspectionClientMock.Verify(client => client.DownloadSchemaAsync(It.Is<HttpClient>(c => c.BaseAddress.Scheme == Uri.UriSchemeHttp)), Times.Once);
-    //     Assert.IsTrue(fileSystem.FileExists("output/schema.graphql"));
-    //     Assert.AreEqual(expectedSchema.ToString(), fileSystem.File.ReadAllText("output/schema.graphql"));
-    // }
-
+    /// <summary>
+    /// Tests the ExportGraphQLFromDabService method to ensure it logs correctly when the HTTPS endpoint fails and falls back to the HTTP endpoint.
+    /// This test verifies that:
+    /// 1. The method attempts to fetch the schema using the HTTPS endpoint first.
+    /// 2. If the HTTPS endpoint fails, it logs the failure and attempts to fetch the schema using the HTTP endpoint.
+    /// 3. The method logs the appropriate messages during the process.
+    /// 4. The method returns the schema fetched from the HTTP endpoint when the HTTPS endpoint fails.
+    /// </summary>
     [TestMethod]
     public void ExportGraphQLFromDabService_LogsFallbackToHttp_WhenHttpsFails()
     {
         // Arrange
-        Mock<ILogger> mockLogger = new ();
-        Mock<Exporter> mockExporter = new ();
+        Mock<ILogger> mockLogger = new();
+        Mock<Exporter> mockExporter = new();
         RuntimeConfig runtimeConfig = new(
                 Schema: "schema",
                 DataSource: new DataSource(DatabaseType.MSSQL, "", new()),
@@ -84,6 +80,59 @@ public class ExporterTests
             It.IsAny<Exception>(),
             It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
 
+        mockLogger.Verify(logger => logger.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to fetch schema from DAB Service using HTTPS endpoint. Trying with HTTP endpoint.")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests the ExportGraphQLFromDabService method to ensure it throws an exception when both the HTTPS and HTTP endpoints fail.
+    /// This test verifies that:
+    /// 1. The method attempts to fetch the schema using the HTTPS endpoint first.
+    /// 2. If the HTTPS endpoint fails, it logs the failure and attempts to fetch the schema using the HTTP endpoint.
+    /// 3. If both endpoints fail, the method throws an exception.
+    /// 4. The method logs the appropriate messages during the process.
+    /// </summary>
+    [TestMethod]
+    public void ExportGraphQLFromDabService_ThrowsException_WhenBothHttpsAndHttpFail()
+    {
+        // Arrange
+        Mock<ILogger> mockLogger = new();
+        Mock<Exporter> mockExporter = new() { CallBase = true };
+        RuntimeConfig runtimeConfig = new(
+                Schema: "schema",
+                DataSource: new DataSource(DatabaseType.MSSQL, "", new()),
+                Runtime: new(Rest: new(), GraphQL: new(), Host: new(null, null)),
+                Entities: new(new Dictionary<string, Entity>())
+            );
+
+        // Setup the mock to throw an exception when the HTTPS endpoint is used
+        mockExporter.Setup(e => e.GetGraphQLSchema(runtimeConfig, false))
+                    .Throws(new Exception("HTTPS endpoint failed"));
+
+        // Setup the mock to throw an exception when the HTTP endpoint is used
+        mockExporter.Setup(e => e.GetGraphQLSchema(runtimeConfig, true))
+                    .Throws(new Exception("Both HTTP and HTTPS endpoint failed"));
+
+        // Act & Assert
+        // Verify that the method throws an exception when both endpoints fail
+        Exception exception = Assert.ThrowsException<Exception>(() =>
+            mockExporter.Object.ExportGraphQLFromDabService(runtimeConfig, mockLogger.Object));
+
+        Assert.AreEqual("Both HTTP and HTTPS endpoint failed", exception.Message);
+
+        // Verify that the correct log message is generated when attempting to use the HTTPS endpoint
+        mockLogger.Verify(logger => logger.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Trying to fetch schema from DAB Service using HTTPS endpoint.")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+
+        // Verify that the correct log message is generated when falling back to the HTTP endpoint
         mockLogger.Verify(logger => logger.Log(
             LogLevel.Information,
             It.IsAny<EventId>(),

--- a/src/Cli.Tests/ExporterTests.cs
+++ b/src/Cli.Tests/ExporterTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// using System;
+// using System.Net.Http;
+// using System.Threading.Tasks;
+// using Moq;
+// using Xunit;
+// using HotChocolate.Language;
+// using System.IO.Abstractions;
+// using System.IO.Abstractions.TestingHelpers;
+// using HotChocolate.Utilities.Introspection;
+
+namespace Cli.Tests;
+
+[TestClass]
+public class ExporterTests
+{
+    // [TestMethod]
+    // public void ExportGraphQL_RetriesWithHttpIfHttpsFails()
+    // {
+    //     // Arrange
+    //     Mock<HttpClient> httpsClientMock = new(MockBehavior.Strict);
+    //     Mock<HttpClient> httpClientMock = new(MockBehavior.Strict);
+    //     Mock<IntrospectionClient> introspectionClientMock = new();
+    //     MockFileSystem fileSystem = new();
+
+    //     ExportOptions options = new(true, "output", null, null);
+    //     RuntimeConfig runtimeConfig = new(
+    //             Schema: "schema",
+    //             DataSource: new DataSource(DatabaseType.MSSQL, "", new()),
+    //             Runtime: new(Rest: new(), GraphQL: new(), Host: new(null, null)),
+    //             Entities: new(new Dictionary<string, Entity>())
+    //         );
+
+    //     // Setup the HTTPS client to throw an exception
+    //     introspectionClientMock
+    //         .Setup(client => client.DownloadSchemaAsync(It.IsAny<HttpClient>()))
+    //         .ThrowsAsync(new Exception("HTTPS request failed"));
+
+    //     // Setup the HTTP client to return a valid schema
+    //     DocumentNode expectedSchema = new DocumentNode();
+    //     introspectionClientMock
+    //         .Setup(client => client.DownloadSchemaAsync(It.Is<HttpClient>(c => c.BaseAddress.Scheme == Uri.UriSchemeHttp)))
+    //         .ReturnsAsync(expectedSchema);
+
+    //     // Act
+    //     Exporter.ExportGraphQL(options, runtimeConfig, fileSystem);
+
+    //     // Assert
+    //     introspectionClientMock.Verify(client => client.DownloadSchemaAsync(It.Is<HttpClient>(c => c.BaseAddress.Scheme == Uri.UriSchemeHttps)), Times.Once);
+    //     introspectionClientMock.Verify(client => client.DownloadSchemaAsync(It.Is<HttpClient>(c => c.BaseAddress.Scheme == Uri.UriSchemeHttp)), Times.Once);
+    //     Assert.IsTrue(fileSystem.FileExists("output/schema.graphql"));
+    //     Assert.AreEqual(expectedSchema.ToString(), fileSystem.File.ReadAllText("output/schema.graphql"));
+    // }
+
+    [TestMethod]
+    public void ExportGraphQLFromDabService_LogsFallbackToHttp_WhenHttpsFails()
+    {
+        // Arrange
+        Mock<ILogger> mockLogger = new ();
+        Mock<Exporter> mockExporter = new ();
+        RuntimeConfig runtimeConfig = new(
+                Schema: "schema",
+                DataSource: new DataSource(DatabaseType.MSSQL, "", new()),
+                Runtime: new(Rest: new(), GraphQL: new(), Host: new(null, null)),
+                Entities: new(new Dictionary<string, Entity>())
+            );
+
+        mockExporter.Setup(e => e.GetGraphQLSchema(runtimeConfig, false))
+                    .Throws(new Exception("HTTPS endpoint failed"));
+        mockExporter.Setup(e => e.GetGraphQLSchema(runtimeConfig, true))
+                    .Returns("Fallback schema");
+
+        // Act
+        string result = mockExporter.Object.ExportGraphQLFromDabService(runtimeConfig, mockLogger.Object);
+
+        // Assert
+        Assert.AreEqual("Fallback schema", result);
+        mockLogger.Verify(logger => logger.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Trying to fetch schema from DAB Service using HTTPS endpoint.")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+
+        mockLogger.Verify(logger => logger.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed to fetch schema from DAB Service using HTTPS endpoint. Trying with HTTP endpoint.")),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception, string>>()!), Times.Once);
+    }
+}

--- a/src/Cli/Commands/ExportOptions.cs
+++ b/src/Cli/Commands/ExportOptions.cs
@@ -3,6 +3,12 @@
 
 using Azure.DataApiBuilder.Core.Generator;
 using CommandLine;
+using System.IO.Abstractions;
+using Azure.DataApiBuilder.Config;
+using Azure.DataApiBuilder.Product;
+using Cli.Constants;
+using Microsoft.Extensions.Logging;
+using static Cli.Utils;
 
 namespace Cli.Commands
 {
@@ -59,5 +65,21 @@ namespace Cli.Commands
 
         [Option("sampling-group-count", HelpText = "Specify the number of groups for sampling. This option is applicable only when the 'TimePartitionedSampler' mode is selected.")]
         public int? GroupCount { get; }
+
+        public int Handler(ILogger logger, FileSystemRuntimeConfigLoader loader, IFileSystem fileSystem)
+        {
+            logger.LogInformation("{productName} {version}", PRODUCT_NAME, ProductInfo.GetProductVersion());
+            bool isSuccess = Exporter.Export(this, logger, loader, fileSystem);
+            if (isSuccess)
+            {
+                logger.LogInformation("Successfully exported the schema file.");
+                return CliReturnCode.SUCCESS;
+            }
+            else
+            {
+                logger.LogError("Failed to export the graphql schema.");
+                return CliReturnCode.GENERAL_ERROR;
+            }
+        }
     }
 }

--- a/src/Cli/Commands/ExportOptions.cs
+++ b/src/Cli/Commands/ExportOptions.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Azure.DataApiBuilder.Core.Generator;
-using CommandLine;
 using System.IO.Abstractions;
 using Azure.DataApiBuilder.Config;
+using Azure.DataApiBuilder.Core.Generator;
 using Azure.DataApiBuilder.Product;
 using Cli.Constants;
+using CommandLine;
 using Microsoft.Extensions.Logging;
 using static Cli.Utils;
 

--- a/src/Cli/Exporter.cs
+++ b/src/Cli/Exporter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IO.Abstractions;
+using System.Runtime.CompilerServices;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Generator;
@@ -10,6 +11,7 @@ using HotChocolate.Utilities.Introspection;
 using Microsoft.Extensions.Logging;
 using static Cli.Utils;
 
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 namespace Cli
 {
     /// <summary>
@@ -116,25 +118,41 @@ namespace Cli
             logger.LogInformation("Schema file exported successfully at {0}", options.OutputDirectory);
         }
 
+        /// <summary>
+        /// Fetches the GraphQL schema from the DAB service, attempting to use the HTTPS endpoint first.
+        /// If the HTTPS endpoint fails, it falls back to using the HTTP endpoint.
+        /// Logs the process of fetching the schema and any fallback actions taken.
+        /// </summary>
+        /// <param name="runtimeConfig">The runtime config object containing the GraphQL path.</param>
+        /// <param name="logger">The logger instance used to log information and errors during the schema fetching process.</param>
+        /// <returns>The GraphQL schema as a string.</returns>
         internal string ExportGraphQLFromDabService(RuntimeConfig runtimeConfig, ILogger logger)
         {
             string schemaText;
             // Fetch the schema from the GraphQL API
             logger.LogInformation("Fetching schema from GraphQL API.");
 
-            try{
+            try
+            {
                 logger.LogInformation("Trying to fetch schema from DAB Service using HTTPS endpoint.");
-                schemaText = GetGraphQLSchema(runtimeConfig, useFallbackURL:false);
+                schemaText = GetGraphQLSchema(runtimeConfig, useFallbackURL: false);
             }
-            catch{
+            catch
+            {
                 logger.LogInformation("Failed to fetch schema from DAB Service using HTTPS endpoint. Trying with HTTP endpoint.");
-                schemaText = GetGraphQLSchema(runtimeConfig, useFallbackURL:true);
+                schemaText = GetGraphQLSchema(runtimeConfig, useFallbackURL: true);
             }
 
             return schemaText;
         }
 
-        internal virtual string GetGraphQLSchema(RuntimeConfig runtimeConfig, bool useFallbackURL = false){
+        /// <summary>
+        /// Retrieves the GraphQL schema from the DAB service using either the HTTPS or HTTP endpoint based on the specified fallback option.
+        /// </summary>
+        /// <param name="runtimeConfig">The runtime configuration containing the GraphQL path and other settings.</param>
+        /// <param name="useFallbackURL">A boolean flag indicating whether to use the fallback HTTP endpoint. If false, the method attempts to use the HTTPS endpoint.</param>
+        internal virtual string GetGraphQLSchema(RuntimeConfig runtimeConfig, bool useFallbackURL = false)
+        {
             HttpClient client;
             if (!useFallbackURL)
             {

--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -67,7 +67,7 @@ namespace Cli
                     (ValidateOptions options) => options.Handler(cliLogger, loader, fileSystem),
                     (AddTelemetryOptions options) => options.Handler(cliLogger, loader, fileSystem),
                     (ConfigureOptions options) => options.Handler(cliLogger, loader, fileSystem),
-                    (ExportOptions options) => Exporter.Export(options, cliLogger, loader, fileSystem),
+                    (ExportOptions options) => options.Handler(cliLogger, loader, fileSystem),
                     errors => DabCliParserErrorHandler.ProcessErrorsAndReturnExitCode(errors));
 
             return result;


### PR DESCRIPTION
## Why make this change?

- Closes #1542 
  - With .Net deciding to remove HTTPS endpoint support by default,  `export` command started to fail as it uses HTTPS endpoint.

## What is this change?

- Added a fallback HTTP url, which will be used when HTTPS endpoint fails to fetch the graphql schema.

## How was this tested?

- [X] Unit Tests
- [X] Manual Tests

## Sample Request(s)
command:
`dab export --graphql -o ./testgqlschemaexport`

![image](https://github.com/user-attachments/assets/2bd4bf55-5899-407f-b44b-c35a9ecc49e9)


