### PR TITLE
Hot Reload File IO -> React to 1 file change notification per file change

### DIFF
--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -36,7 +36,7 @@ namespace Cli
 
             // Sets up the filesystem used for reading and writing runtime configuration files.
             IFileSystem fileSystem = new FileSystem();
-            FileSystemRuntimeConfigLoader loader = new(fileSystem, handler: null);
+            FileSystemRuntimeConfigLoader loader = new(fileSystem, handler: null, isCliLoader: true);
 
             return Execute(args, cliLogger, fileSystem, loader);
         }

--- a/src/Config/ConfigFileWatcher.cs
+++ b/src/Config/ConfigFileWatcher.cs
@@ -57,7 +57,7 @@ public class ConfigFileWatcher
         _fileWatcher = fileWatcher;
         _fileWatcher.Path = WatchedDirectory;
         _fileWatcher.Changed += OnConfigFileChange;
-        _runtimeConfigHash = FileUtilities.ComputeHash(_fileWatcher.FileSystem, filePath: WatchedDirectory + "/" + WatchedFile);
+        _runtimeConfigHash = FileUtilities.ComputeHash(_fileWatcher.FileSystem, filePath: Path.Combine(WatchedDirectory, WatchedFile));
     }
 
     /// <summary>

--- a/src/Config/ConfigFileWatcher.cs
+++ b/src/Config/ConfigFileWatcher.cs
@@ -1,38 +1,71 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.IO.Abstractions;
 using Azure.DataApiBuilder.Config.Utilities;
 
 namespace Azure.DataApiBuilder.Config;
 
 /// <summary>
 /// This class is responsible for monitoring the config file from the
-/// local file system, and if changes are detected, triggering the
-/// required logic to begin a hot reload scenario.
+/// local file system. This watcher maintains a file hash to only emit
+/// one event for each file change occurrence. Because .NET may raise >1
+/// event for 1 file change instance, this class swallows extraneous events.
+/// - "OnChanged is called when changes are made to the size, system attributes,
+/// last write time, last access time, or security permissions of a file or directory
+/// in the directory being monitored."
+/// - The file hashing mechanism is a solution suggested by .NET documentation
+/// to handle duplicate events evented for the same file change event.
 /// </summary>
+/// <seealso cref="https://learn.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher.onchanged?view=net-8.0#remarks"/>
+/// <seealso cref="https://learn.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher.notifyfilter?view=net-8.0"/>
+/// <seealso cref="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/change-tokens?view=aspnetcore-8.0#:~:text=exponential%20back%2Doff.-,Utilities/Utilities.cs%3A,-C%23"/>
 public class ConfigFileWatcher
 {
+    /// <summary>
+    /// Watches a specific file for modifications and alerts
+    /// this class when a change is detected.
+    /// </summary>
     private FileSystemWatcher? _fileWatcher;
-    private FileSystemRuntimeConfigLoader _configLoader;
+
+    /// <summary>
+    /// Hash of runtime config file.
+    /// Used to determine whether hot-reload should proceed due
+    /// to detecting new runtime config file content.
+    /// </summary>
     private byte[] _runtimeConfigHash;
-    public ConfigFileWatcher(FileSystemRuntimeConfigLoader configLoader, string directoryName, string configFileName)
+
+    /// <summary>
+    /// Orchestrates sending NewFileContentsDetected events to all subscribers.
+    /// </summary>
+    public event EventHandler? NewFileContentsDetected;
+
+    public ConfigFileWatcher(string directoryName, string configFileName)
     {
         _fileWatcher = new FileSystemWatcher(directoryName)
         {
             Filter = configFileName,
             EnableRaisingEvents = true
         };
-        _runtimeConfigHash = FileUtilities.ComputeHash(filePath: directoryName+"/"+configFileName);
 
-        _configLoader = configLoader;
+        _runtimeConfigHash = FileUtilities.ComputeHash(filePath: directoryName + "/" + configFileName);
         _fileWatcher.Changed += OnConfigFileChange;
     }
 
     /// <summary>
+    /// Raises the NewFileContentsDetected event which signals to listeners
+    /// that a new configuration has been detected. This will only be raised
+    /// for the first file-change event detected for a single file change.
+    /// </summary>
+    protected virtual void OnNewFileContentsDetected()
+    {
+        NewFileContentsDetected?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
     /// When a change is detected in the Config file being watched this trigger
-    /// function is called and handles the hot reload logic when appropriate,
-    /// ie: in a local development scenario.
+    /// function is called. It will compare the hash of the file to the cached hash
+    /// value in order to discard duplicate notifications for a file which has
+    /// only changed once.
     /// </summary>
     /// <param name="sender"></param>
     /// <param name="e"></param>
@@ -40,19 +73,17 @@ public class ConfigFileWatcher
     {
         try
         {
-            if (_fileWatcher is null || _configLoader.RuntimeConfig is null || !_configLoader.RuntimeConfig.IsDevelopmentMode())
+            if (_fileWatcher is not null)
             {
-                return;
-            }
-
-            // Multiple file change notifications may be raised for a single file change.
-            // Use file hashes to ensure that HotReload operation is only executed when a net-new
-            // runtime config is detected.
-            byte[] updatedRuntimeConfigFileHash = FileUtilities.ComputeHash(filePath: _fileWatcher.Path + "/" + _fileWatcher.Filter);
-            if (!_runtimeConfigHash.SequenceEqual(updatedRuntimeConfigFileHash))
-            {
-                _runtimeConfigHash = updatedRuntimeConfigFileHash;
-                _configLoader.HotReloadConfig(_configLoader.RuntimeConfig.DefaultDataSourceName);
+                // Multiple file change notifications may be raised for a single file change.
+                // Use file hashes to ensure that HotReload operation is only executed when a net-new
+                // runtime config is detected.
+                byte[] updatedRuntimeConfigFileHash = FileUtilities.ComputeHash(filePath: _fileWatcher.Path + "/" + _fileWatcher.Filter);
+                if (!_runtimeConfigHash.SequenceEqual(updatedRuntimeConfigFileHash))
+                {
+                    _runtimeConfigHash = updatedRuntimeConfigFileHash;
+                    OnNewFileContentsDetected();
+                }
             }
         }
         catch (Exception ex)

--- a/src/Config/ConfigFileWatcher.cs
+++ b/src/Config/ConfigFileWatcher.cs
@@ -87,7 +87,7 @@ public class ConfigFileWatcher
                 // Multiple file change notifications may be raised for a single file change.
                 // Use file hashes to ensure that HotReload operation is only executed when a net-new
                 // runtime config is detected.
-                byte[] updatedRuntimeConfigFileHash = FileUtilities.ComputeHash(_fileWatcher.FileSystem, filePath: WatchedDirectory + "/" + WatchedFile);
+                byte[] updatedRuntimeConfigFileHash = FileUtilities.ComputeHash(_fileWatcher.FileSystem, filePath: Path.Combine(WatchedDirectory, WatchedFile));
                 if (!_runtimeConfigHash.SequenceEqual(updatedRuntimeConfigFileHash))
                 {
                     _runtimeConfigHash = updatedRuntimeConfigFileHash;

--- a/src/Config/ConfigFileWatcher.cs
+++ b/src/Config/ConfigFileWatcher.cs
@@ -45,6 +45,9 @@ public class ConfigFileWatcher
                 return;
             }
 
+            // Multiple file change notifications may be raised for a single file change.
+            // Use file hashes to ensure that HotReload operation is only executed when a net-new
+            // runtime config is detected.
             byte[] updatedRuntimeConfigFileHash = FileUtilities.ComputeHash(filePath: _fileWatcher.Path + "/" + _fileWatcher.Filter);
             if (!_runtimeConfigHash.SequenceEqual(updatedRuntimeConfigFileHash))
             {

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -119,7 +119,7 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
         {
             try
             {
-                _configFileWatcher = new(GetConfigDirectoryName(), GetConfigFileName());
+                _configFileWatcher = new(new FileSystemWatcherWrapper(_fileSystem), GetConfigDirectoryName(), GetConfigFileName());
                 _configFileWatcher.NewFileContentsDetected += OnNewFileContentsDetected;
             }
             catch (Exception ex)

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -148,7 +148,10 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
         if (_fileSystem.File.Exists(path))
         {
             Console.WriteLine($"Loading config file from {path}.");
-            string json = _fileSystem.File.ReadAllText(path);
+            Console.WriteLine($"FullPath: {_fileSystem.Path.GetFullPath(path)}");
+            using FileSystemStream fs = _fileSystem.File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using StreamReader sr = new((FileStream)fs);
+            string json = sr.ReadToEnd();
             if (TryParseConfig(json, out RuntimeConfig, connectionString: _connectionString, replaceEnvVar: replaceEnvVar))
             {
                 if (TrySetupConfigFileWatcher())

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -175,15 +175,13 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     {
         if (_fileSystem.File.Exists(path))
         {
-            Console.WriteLine($"Loading config file from {path}.");
-            Console.WriteLine($"FullPath: {_fileSystem.Path.GetFullPath(path)}");
+            Console.WriteLine($"Loading config file from {_fileSystem.Path.GetFullPath(path)}.");
 
-            // Use File.OpenRead because DAB doesn't need write access to the file.
+            // Use File.ReadAllText because DAB doesn't need write access to the file
+            // and ensures the file handle is released immediately after reading.
             // Previous usage of File.Open may cause file locking issues when
             // actively using hot-reload and modifying the config file in a text editor.
-            using FileSystemStream fs = _fileSystem.File.OpenRead(path);
-            using StreamReader sr = new((FileStream)fs);
-            string json = sr.ReadToEnd();
+            string json = _fileSystem.File.ReadAllText(path);
             if (TryParseConfig(json, out RuntimeConfig, connectionString: _connectionString, replaceEnvVar: replaceEnvVar))
             {
                 if (TrySetupConfigFileWatcher())

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -146,7 +146,7 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
         {
             if (RuntimeConfig is not null && RuntimeConfig.IsDevelopmentMode())
             {
-                HotReloadConfig(RuntimeConfig.DefaultDataSourceName);
+                HotReloadConfig();
             }
         }
         catch (Exception ex)
@@ -226,7 +226,7 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     /// Hot Reloads the runtime config when the file watcher
     /// is active and detects a change to the underlying config file.
     /// </summary>
-    private void HotReloadConfig(string defaultDataSourceName, ILogger? logger = null)
+    private void HotReloadConfig(ILogger? logger = null)
     {
         logger?.LogInformation(message: "Starting hot-reload process for config: {ConfigFilePath}", ConfigFilePath);
         TryLoadConfig(ConfigFilePath, out _, replaceEnvVar: true);

--- a/src/Config/Utilities/FileUtilities.cs
+++ b/src/Config/Utilities/FileUtilities.cs
@@ -1,51 +1,71 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Security.Cryptography;
 
-namespace Azure.DataApiBuilder.Config.Utilities
+namespace Azure.DataApiBuilder.Config.Utilities;
+
+internal class FileUtilities
 {
-    internal class FileUtilities
+    /// <summary>
+    /// Computes a SHA1 hash of the file at the given path.
+    /// Includes an exponential back-off retry mechanism to accommodate
+    /// circumstances where the file may be in use by another process.
+    /// "SHA-1 (Secure Hash Algorithm 1) is a hash function which takes an input
+    /// and produces a 160-bit (20-byte) hash value known as a message digest
+    /// – typically rendered as 40 hexadecimal digits."
+    /// This utility function code is based on the example provided in the
+    /// .NET ChangeToken documentation.
+    /// </summary>
+    /// <param name="filePath">Abosolute file path or relative file path.</param>
+    /// <returns>20 byte message digest.</returns>
+    /// <seealso cref="https://en.wikipedia.org/wiki/SHA-1"/>
+    /// <seealso cref="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/change-tokens?view=aspnetcore-8.0#:~:text=exponential%20back%2Doff.-,Utilities/Utilities.cs%3A,-C%23"/>
+    /// <exception cref="FileNotFoundException">https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openread?view=net-8.0#exceptions</exception>
+    public static byte[] ComputeHash(string filePath)
     {
-        public static byte[] ComputeHash(string filePath)
-        {
-            int runCount = 1;
+        // Exponential back-off retry mechanism.
+        int runCount = 1;
 
-            while (runCount < 4)
+        // Arbitrary limit of 4 retries.
+        while (runCount < 4)
+        {
+            try
             {
-                try
+                if (File.Exists(filePath))
                 {
-                    if (File.Exists(filePath))
+                    // There are a number of reasons why "OpenRead" could fail with IOException.
+                    // DirectoryNotFound, EndOfStream, FileNotFound, FileLoad, PathTooLong, etc.
+                    // https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openread?view=net-8.0#exceptions
+                    // https://learn.microsoft.com/en-us/dotnet/api/system.io.ioexception?view=net-8.0#remarks
+                    using (FileStream fs = File.OpenRead(filePath))
                     {
-                        using (FileStream fs = File.OpenRead(filePath))
-                        {
-                            return System.Security.Cryptography.SHA1
-                                .Create().ComputeHash(fs);
-                        }
-                    }
-                    else
-                    {
-                        throw new FileNotFoundException();
+                        return SHA1.Create().ComputeHash(fs);
                     }
                 }
-                catch (IOException ex)
+                else
                 {
-                    Console.WriteLine($"IO Exception, retrying due to {ex.Message}");
-                    if (runCount == 3)
-                    {
-                        throw;
-                    }
-
-                    Thread.Sleep(TimeSpan.FromSeconds(Math.Pow(2, runCount)));
-                    runCount++;
+                    Console.WriteLine($"Path '{filePath}' not found in: " + Directory.GetCurrentDirectory());
+                    throw new FileNotFoundException();
                 }
             }
+            catch (IOException ex)
+            {
+                Console.WriteLine($"IO Exception, retrying due to {ex.Message}");
+                if (runCount == 3)
+                {
+                    throw;
+                }
 
-            return new byte[20];
+                Thread.Sleep(TimeSpan.FromSeconds(Math.Pow(2, runCount)));
+                runCount++;
+            }
         }
+
+        #if NET8_0_OR_GREATER
+        return new byte[SHA1.HashSizeInBytes];
+        #else
+        return new byte[20];
+        #endif
     }
 }

--- a/src/Config/Utilities/FileUtilities.cs
+++ b/src/Config/Utilities/FileUtilities.cs
@@ -8,18 +8,18 @@ namespace Azure.DataApiBuilder.Config.Utilities;
 internal class FileUtilities
 {
     /// <summary>
-    /// Computes a SHA1 hash of the file at the given path.
+    /// Computes the SHA256 hash for the input data (file contents) at the given path.
     /// Includes an exponential back-off retry mechanism to accommodate
     /// circumstances where the file may be in use by another process.
-    /// "SHA-1 (Secure Hash Algorithm 1) is a hash function which takes an input
-    /// and produces a 160-bit (20-byte) hash value known as a message digest
-    /// – typically rendered as 40 hexadecimal digits."
-    /// This utility function code is based on the example provided in the
+    /// "The hash is used as a unique value of fixed size representing a large amount of data.
+    /// Hashes of two sets of data should match if and only if the corresponding data also matches.
+    /// Small changes to the data result in large unpredictable changes in the hash."
+    /// This utility function code is based on and modified from the example provided in the
     /// .NET ChangeToken documentation.
     /// </summary>
     /// <param name="filePath">Abosolute file path or relative file path.</param>
-    /// <returns>20 byte message digest.</returns>
-    /// <seealso cref="https://en.wikipedia.org/wiki/SHA-1"/>
+    /// <returns>32 byte message digest.</returns>
+    /// <seealso cref="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.sha256?view=net-8.0#remarks"/>
     /// <seealso cref="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/change-tokens?view=aspnetcore-8.0#:~:text=exponential%20back%2Doff.-,Utilities/Utilities.cs%3A,-C%23"/>
     /// <exception cref="FileNotFoundException">https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openread?view=net-8.0#exceptions</exception>
     public static byte[] ComputeHash(string filePath)
@@ -27,21 +27,24 @@ internal class FileUtilities
         // Exponential back-off retry mechanism.
         int runCount = 1;
 
-        // Arbitrary limit of 4 retries.
+        // Arbitrary limit of 3 attempts to load the file.
+        // Maximum 8 seconds (2^3) of wait time due to retries.
         while (runCount < 4)
         {
             try
             {
                 if (File.Exists(filePath))
                 {
-                    // There are a number of reasons why "OpenRead" could fail with IOException.
+                    // There are a number of reasons why "ReadAllBytes" could fail with IOException.
                     // DirectoryNotFound, EndOfStream, FileNotFound, FileLoad, PathTooLong, etc.
+                    // However, one benefit to "ReadAllBytes" versus "OpenRead" is that "ReadAllBytes"
+                    // will closes the file handle once the operation is complete. This helps mitigate
+                    // some instances of the IO Exception "The process cannot access the file because
+                    // it is being used by another process."
                     // https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openread?view=net-8.0#exceptions
                     // https://learn.microsoft.com/en-us/dotnet/api/system.io.ioexception?view=net-8.0#remarks
-                    using (FileStream fs = File.OpenRead(filePath))
-                    {
-                        return SHA1.Create().ComputeHash(fs);
-                    }
+                    byte[] fileContents = File.ReadAllBytes(filePath);
+                    return SHA256.Create().ComputeHash(fileContents);
                 }
                 else
                 {
@@ -62,10 +65,10 @@ internal class FileUtilities
             }
         }
 
-        #if NET8_0_OR_GREATER
-        return new byte[SHA1.HashSizeInBytes];
-        #else
-        return new byte[20];
-        #endif
+#if NET8_0_OR_GREATER
+        return new byte[SHA256.HashSizeInBytes];
+#else
+        return new byte[32];
+#endif
     }
 }

--- a/src/Config/Utilities/FileUtilities.cs
+++ b/src/Config/Utilities/FileUtilities.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.IO.Abstractions;
 using System.Security.Cryptography;
 
 namespace Azure.DataApiBuilder.Config.Utilities;
@@ -17,12 +18,13 @@ internal class FileUtilities
     /// This utility function code is based on and modified from the example provided in the
     /// .NET ChangeToken documentation.
     /// </summary>
+    /// <param name="fileSystem">File system abstraction.</param>
     /// <param name="filePath">Abosolute file path or relative file path.</param>
     /// <returns>32 byte message digest.</returns>
     /// <seealso cref="https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.sha256?view=net-8.0#remarks"/>
     /// <seealso cref="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/change-tokens?view=aspnetcore-8.0#:~:text=exponential%20back%2Doff.-,Utilities/Utilities.cs%3A,-C%23"/>
     /// <exception cref="FileNotFoundException">https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openread?view=net-8.0#exceptions</exception>
-    public static byte[] ComputeHash(string filePath)
+    public static byte[] ComputeHash(IFileSystem fileSystem, string filePath)
     {
         // Exponential back-off retry mechanism.
         int runCount = 1;
@@ -33,7 +35,7 @@ internal class FileUtilities
         {
             try
             {
-                if (File.Exists(filePath))
+                if (fileSystem.File.Exists(filePath))
                 {
                     // There are a number of reasons why "ReadAllBytes" could fail with IOException.
                     // DirectoryNotFound, EndOfStream, FileNotFound, FileLoad, PathTooLong, etc.
@@ -43,7 +45,7 @@ internal class FileUtilities
                     // it is being used by another process."
                     // https://learn.microsoft.com/en-us/dotnet/api/system.io.file.openread?view=net-8.0#exceptions
                     // https://learn.microsoft.com/en-us/dotnet/api/system.io.ioexception?view=net-8.0#remarks
-                    byte[] fileContents = File.ReadAllBytes(filePath);
+                    byte[] fileContents = fileSystem.File.ReadAllBytes(filePath);
                     return SHA256.Create().ComputeHash(fileContents);
                 }
                 else

--- a/src/Config/Utilities/FileUtilities.cs
+++ b/src/Config/Utilities/FileUtilities.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.DataApiBuilder.Config.Utilities
+{
+    internal class FileUtilities
+    {
+        public static byte[] ComputeHash(string filePath)
+        {
+            int runCount = 1;
+
+            while (runCount < 4)
+            {
+                try
+                {
+                    if (File.Exists(filePath))
+                    {
+                        using (FileStream fs = File.OpenRead(filePath))
+                        {
+                            return System.Security.Cryptography.SHA1
+                                .Create().ComputeHash(fs);
+                        }
+                    }
+                    else
+                    {
+                        throw new FileNotFoundException();
+                    }
+                }
+                catch (IOException ex)
+                {
+                    Console.WriteLine($"IO Exception, retrying due to {ex.Message}");
+                    if (runCount == 3)
+                    {
+                        throw;
+                    }
+
+                    Thread.Sleep(TimeSpan.FromSeconds(Math.Pow(2, runCount)));
+                    runCount++;
+                }
+            }
+
+            return new byte[20];
+        }
+    }
+}

--- a/src/Service.Tests/Unittests/ConfigFileWatcherUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigFileWatcherUnitTests.cs
@@ -175,7 +175,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
         /// of the file contents differ from what was previously detected. For this test,
         /// the file contents differ MyValue -> MyChangedValue.
         /// The config file name is specific to this test in order to avoid concurrently
-        /// running tests from stepping over eachother due to acquiring a handle(s) to the file.
+        /// running tests from stepping over each other due to acquiring a handle(s) to the file.
         /// </summary>
         [TestMethod]
         public void ConfigFileWatcher_NotifiedOfOneNetNewChanges()

--- a/src/Service.Tests/Unittests/ConfigFileWatcherUnitTests.cs
+++ b/src/Service.Tests/Unittests/ConfigFileWatcherUnitTests.cs
@@ -11,22 +11,22 @@ using Azure.DataApiBuilder.Core.Configurations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
-namespace Azure.DataApiBuilder.Service.Tests.Unittests
-{
-    [TestClass]
-    public class ConfigFileWatcherUnitTests
-    {
+namespace Azure.DataApiBuilder.Service.Tests.Unittests;
 
-        private static string GenerateRuntimeSectionStringFromParams(
-            string restPath,
-            string gqlPath,
-            bool restEnabled,
-            bool gqlEnabled,
-            bool gqlIntrospection,
-            HostMode mode
-            )
-        {
-            string runtimeString = @"
+[TestClass]
+public class ConfigFileWatcherUnitTests
+{
+
+    private static string GenerateRuntimeSectionStringFromParams(
+        string restPath,
+        string gqlPath,
+        bool restEnabled,
+        bool gqlEnabled,
+        bool gqlIntrospection,
+        HostMode mode
+        )
+    {
+        string runtimeString = @"
 {
   ""$schema"": ""https://github.com/Azure/data-api-builder/releases/download/vmajor.minor.patch/dab.draft.schema.json"",
   ""data-source"": {
@@ -61,260 +61,268 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
   },
   ""entities"": {}
 }";
-            return runtimeString;
+        return runtimeString;
+    }
+
+    /// <summary>
+    /// Use the file system (not mocked) to create a hot reload
+    /// scenario of the REST runtime options and verify that we
+    /// correctly hot reload those options.
+    /// NOTE: This test is ignored until we have the possibility of turning
+    /// on hot reload.
+    /// </summary>
+    [TestMethod]
+    [Ignore]
+    public void HotReloadConfigRestRuntimeOptions()
+    {
+        // Arrange
+        // 1. Setup the strings that are turned into our initital and runtime config to reload.
+        // 2. Generate initial runtimeconfig, start file watching, and assert we have valid initial values.
+        string initialRestPath = "/api";
+        string updatedRestPath = "/rest";
+        string initialGQLPath = "/api";
+        string updatedGQLPath = "/gql";
+
+        bool initialRestEnabled = true;
+        bool updatedRestEnabled = false;
+        bool initialGQLEnabled = true;
+        bool updatedGQLEnabled = false;
+
+        bool initialGQLIntrospection = true;
+        bool updatedGQLIntrospection = false;
+
+        HostMode initialMode = HostMode.Development;
+        HostMode updatedMode = HostMode.Production;
+
+        string initialConfig = GenerateRuntimeSectionStringFromParams(
+            initialRestPath,
+            initialGQLPath,
+            initialRestEnabled,
+            initialGQLEnabled,
+            initialGQLIntrospection,
+            initialMode);
+
+        string updatedConfig = GenerateRuntimeSectionStringFromParams(
+            updatedRestPath,
+            updatedGQLPath,
+            updatedRestEnabled,
+            updatedGQLEnabled,
+            updatedGQLIntrospection,
+            updatedMode);
+
+        string configName = "hotreload-config.json";
+        if (File.Exists(configName))
+        {
+            File.Delete(configName);
         }
 
-        /// <summary>
-        /// Use the file system (not mocked) to create a hot reload
-        /// scenario of the REST runtime options and verify that we
-        /// correctly hot reload those options.
-        /// NOTE: This test is ignored until we have the possibility of turning
-        /// on hot reload.
-        /// </summary>
-        [TestMethod]
-        [Ignore]
-        public void HotReloadConfigRestRuntimeOptions()
+        // Not using mocked filesystem so we pick up real file changes for hot reload
+        FileSystem fileSystem = new();
+        fileSystem.File.WriteAllText(configName, initialConfig);
+        FileSystemRuntimeConfigLoader configLoader = new(fileSystem, handler: null, configName, string.Empty);
+        RuntimeConfigProvider configProvider = new(configLoader);
+
+        // Must GetConfig() to start file watching
+        RuntimeConfig runtimeConfig = configProvider.GetConfig();
+        string initialDefaultDataSourceName = runtimeConfig.DefaultDataSourceName;
+
+        // assert we have a valid config
+        Assert.IsNotNull(runtimeConfig);
+        Assert.AreEqual(initialRestEnabled, runtimeConfig.Runtime.Rest.Enabled);
+        Assert.AreEqual(initialRestPath, runtimeConfig.Runtime.Rest.Path);
+        Assert.AreEqual(initialGQLEnabled, runtimeConfig.Runtime.GraphQL.Enabled);
+        Assert.AreEqual(initialGQLPath, runtimeConfig.Runtime.GraphQL.Path);
+        Assert.AreEqual(initialGQLIntrospection, runtimeConfig.Runtime.GraphQL.AllowIntrospection);
+        Assert.AreEqual(initialMode, runtimeConfig.Runtime.Host.Mode);
+
+        // Simulate change to the config file
+        fileSystem.File.WriteAllText(configName, updatedConfig);
+
+        // Give ConfigFileWatcher enough time to hot reload the change
+        System.Threading.Thread.Sleep(1000);
+
+        // Act
+        // 1. Hot reload the runtime config
+        runtimeConfig = configProvider.GetConfig();
+        string updatedDefaultDataSourceName = runtimeConfig.DefaultDataSourceName;
+
+        // Assert
+        // 1. Assert we have the correct values after a hot reload.
+        Assert.AreEqual(updatedRestEnabled, runtimeConfig.Runtime.Rest.Enabled);
+        Assert.AreEqual(updatedRestPath, runtimeConfig.Runtime.Rest.Path);
+        Assert.AreEqual(updatedGQLEnabled, runtimeConfig.Runtime.GraphQL.Enabled);
+        Assert.AreEqual(updatedGQLPath, runtimeConfig.Runtime.GraphQL.Path);
+        Assert.AreEqual(updatedGQLIntrospection, runtimeConfig.Runtime.GraphQL.AllowIntrospection);
+        Assert.AreEqual(updatedMode, runtimeConfig.Runtime.Host.Mode);
+
+        // DefaultDataSourceName should not change after a hot reload.
+        Assert.AreEqual(initialDefaultDataSourceName, updatedDefaultDataSourceName);
+        if (File.Exists(configName))
         {
-            // Arrange
-            // 1. Setup the strings that are turned into our initital and runtime config to reload.
-            // 2. Generate initial runtimeconfig, start file watching, and assert we have valid initial values.
-            string initialRestPath = "/api";
-            string updatedRestPath = "/rest";
-            string initialGQLPath = "/api";
-            string updatedGQLPath = "/gql";
-
-            bool initialRestEnabled = true;
-            bool updatedRestEnabled = false;
-            bool initialGQLEnabled = true;
-            bool updatedGQLEnabled = false;
-
-            bool initialGQLIntrospection = true;
-            bool updatedGQLIntrospection = false;
-
-            HostMode initialMode = HostMode.Development;
-            HostMode updatedMode = HostMode.Production;
-
-            string initialConfig = GenerateRuntimeSectionStringFromParams(
-                initialRestPath,
-                initialGQLPath,
-                initialRestEnabled,
-                initialGQLEnabled,
-                initialGQLIntrospection,
-                initialMode);
-
-            string updatedConfig = GenerateRuntimeSectionStringFromParams(
-                updatedRestPath,
-                updatedGQLPath,
-                updatedRestEnabled,
-                updatedGQLEnabled,
-                updatedGQLIntrospection,
-                updatedMode);
-
-            string configName = "hotreload-config.json";
-            if (File.Exists(configName))
-            {
-                File.Delete(configName);
-            }
-
-            // Not using mocked filesystem so we pick up real file changes for hot reload
-            FileSystem fileSystem = new();
-            fileSystem.File.WriteAllText(configName, initialConfig);
-            FileSystemRuntimeConfigLoader configLoader = new(fileSystem, handler: null, configName, string.Empty);
-            RuntimeConfigProvider configProvider = new(configLoader);
-
-            // Must GetConfig() to start file watching
-            RuntimeConfig runtimeConfig = configProvider.GetConfig();
-            string initialDefaultDataSourceName = runtimeConfig.DefaultDataSourceName;
-
-            // assert we have a valid config
-            Assert.IsNotNull(runtimeConfig);
-            Assert.AreEqual(initialRestEnabled, runtimeConfig.Runtime.Rest.Enabled);
-            Assert.AreEqual(initialRestPath, runtimeConfig.Runtime.Rest.Path);
-            Assert.AreEqual(initialGQLEnabled, runtimeConfig.Runtime.GraphQL.Enabled);
-            Assert.AreEqual(initialGQLPath, runtimeConfig.Runtime.GraphQL.Path);
-            Assert.AreEqual(initialGQLIntrospection, runtimeConfig.Runtime.GraphQL.AllowIntrospection);
-            Assert.AreEqual(initialMode, runtimeConfig.Runtime.Host.Mode);
-
-            // Simulate change to the config file
-            fileSystem.File.WriteAllText(configName, updatedConfig);
-
-            // Give ConfigFileWatcher enough time to hot reload the change
-            System.Threading.Thread.Sleep(1000);
-
-            // Act
-            // 1. Hot reload the runtime config
-            runtimeConfig = configProvider.GetConfig();
-            string updatedDefaultDataSourceName = runtimeConfig.DefaultDataSourceName;
-
-            // Assert
-            // 1. Assert we have the correct values after a hot reload.
-            Assert.AreEqual(updatedRestEnabled, runtimeConfig.Runtime.Rest.Enabled);
-            Assert.AreEqual(updatedRestPath, runtimeConfig.Runtime.Rest.Path);
-            Assert.AreEqual(updatedGQLEnabled, runtimeConfig.Runtime.GraphQL.Enabled);
-            Assert.AreEqual(updatedGQLPath, runtimeConfig.Runtime.GraphQL.Path);
-            Assert.AreEqual(updatedGQLIntrospection, runtimeConfig.Runtime.GraphQL.AllowIntrospection);
-            Assert.AreEqual(updatedMode, runtimeConfig.Runtime.Host.Mode);
-
-            // DefaultDataSourceName should not change after a hot reload.
-            Assert.AreEqual(initialDefaultDataSourceName, updatedDefaultDataSourceName);
-            if (File.Exists(configName))
-            {
-                File.Delete(configName);
-            }
+            File.Delete(configName);
         }
+    }
 
-        #region ConfigFileWatcher NewFileContentsDetected event invocation tests
+    #region ConfigFileWatcher NewFileContentsDetected event invocation tests
 
-        private const string UNEXPECTED_INVOCATION_COUNT_ERR = "Unexpected number of invocations of the NewFileContentsDetected event.";
-        private const string FILECHANGE_EVENT_NOT_RAISED_ERR = "The file system's file-changed event was not raised.";
+    private const string UNEXPECTED_INVOCATION_COUNT_ERR = "Unexpected number of invocations of the NewFileContentsDetected event.";
+    private const string FILECHANGE_EVENT_NOT_RAISED_ERR = "The file system's file-changed event was not raised.";
 
-        /// <summary>
-        /// This test validates that overwriting a file with the different contents
-        /// results in ConfigFileWatcher's NewFileContentsDetected event being raised.
-        /// Internally, ConfigFileWatcher.NewFileContentsDetected is raised when the hash
-        /// of the file contents differ from what was previously detected. For this test,
-        /// the file contents differ MyValue -> MyChangedValue.
-        /// The config file name is specific to this test in order to avoid concurrently
-        /// running tests from stepping over each other due to acquiring a handle(s) to the file.
-        /// </summary>
-        [TestMethod]
-        public void ConfigFileWatcher_NotifiedOfOneNetNewChanges()
+    /// <summary>
+    /// This test validates that overwriting a file with different content
+    /// results in ConfigFileWatcher's NewFileContentsDetected event being raised.
+    /// Internally, ConfigFileWatcher.NewFileContentsDetected is raised when the hash
+    /// of the file's contents differ from what was previously detected.
+    /// - Original File Content: FirstValue
+    /// - New File Content: SecondValue
+    /// The config file name is specific to this test in order to avoid concurrently
+    /// running tests from stepping over each other due to acquiring a handle(s) to the file.
+    /// </summary>
+    [TestMethod]
+    public void ConfigFileWatcher_NotifiedOfOneNetNewChanges()
+    {
+        // Arrange
+        int fileChangeNotificationsReceived = 0;
+        string configName = "ConfigFileWatcher_NotifiedOfOneNetNewChanges.json";
+
+        // Mock filesystem calls for when FileUtilities.ComputeHash() utilizes the filesystem.
+        // For this test, we assume the file exists because we are validating the behavior
+        // of differing config file contents triggering a NewFileContentsDetected event.
+        IFileSystem fileSystem = Mock.Of<IFileSystem>();
+        Mock.Get(fileSystem).Setup(fs => fs.Directory.GetCurrentDirectory()).Returns(Directory.GetCurrentDirectory());
+        Mock.Get(fileSystem).Setup(fs => fs.File.Exists(It.IsAny<string>())).Returns(true);
+
+        // Mock file system to return different byte arrays for each read which occurs in
+        // FileUtilities.ComputeHash() called by ConfigFileWatcher.
+        // The first read occurs during ConfigFileWatcher's initialization.
+        // The subsequent reads trigger the behavior this test validates.
+        // Because a real file system returns >1 file changed event, there will be >1
+        // invocation of fs.File.ReadAllBytes.
+        // The first return of "SecondValue" will trigger a NewFileContentsDetected event.
+        // The second return of "SecondValue" will NOT trigger a NewFileContentsDetected event
+        // because that event has already been raised for "SecondValue".
+        Mock.Get(fileSystem).SetupSequence(fs => fs.File.ReadAllBytes(It.IsAny<string>()))
+            .Returns(Encoding.UTF8.GetBytes("FirstValue"))
+            .Returns(Encoding.UTF8.GetBytes("SecondValue"))
+            .Returns(Encoding.UTF8.GetBytes("SecondValue"));
+
+        Mock<IFileSystemWatcher> fileSystemWatcherMock = new();
+        fileSystemWatcherMock.Setup(mock => mock.FileSystem).Returns(fileSystem);
+
+        ConfigFileWatcher fileWatcher = new(fileSystemWatcherMock.Object, directoryName: Directory.GetCurrentDirectory(), configFileName: configName);
+        fileWatcher.NewFileContentsDetected += (sender, e) =>
         {
-            // Arrange
-            int fileChangeNotificationsReceived = 0;
-            string configName = "ConfigFileWatcher_NotifiedOfOneNetNewChanges.json";
+            // For testing, modification of fileChangeNotificationsRecieved
+            // should be atomic. 
+            Interlocked.Increment(ref fileChangeNotificationsReceived);
+        };
 
-            // Mock filesystem calls for when FileUtilities.ComputeHash() utilizes the filesystem.
-            // For this test, we assume the file exists because we are validating the behavior
-            // of differing config file contents triggering a NewFileContentsDetected event.
-            IFileSystem fileSystem = Mock.Of<IFileSystem>();
-            Mock.Get(fileSystem).Setup(fs => fs.Directory.GetCurrentDirectory()).Returns(Directory.GetCurrentDirectory());
-            Mock.Get(fileSystem).Setup(fs => fs.File.Exists(It.IsAny<string>())).Returns(true);
+        // Track the number of invocations so far so we can prove that
+        // fileSystemWatcherMock.Raise() actually triggers a "file changed" event.
+        int numberFileSystemWatcherMockInvocations = fileSystemWatcherMock.Invocations.Count;
 
-            // Mock file system to return different byte arrays for each read which occurs in
-            // FileUtilities.ComputeHash() called by ConfigFileWatcher.
-            // The first read occurs during ConfigFileWatcher's initialization
-            // The second read occurs during the manual invocation of a "file changed" event.
-            Mock.Get(fileSystem).SetupSequence(fs => fs.File.ReadAllBytes(It.IsAny<string>()))
-                .Returns(Encoding.UTF8.GetBytes("FirstValue"))
-                .Returns(Encoding.UTF8.GetBytes("SecondValue"))
-                .Returns(Encoding.UTF8.GetBytes("SecondValue"));
-
-            Mock<IFileSystemWatcher> fileSystemWatcherMock = new();
-            fileSystemWatcherMock.Setup(mock => mock.FileSystem).Returns(fileSystem);
-
-            ConfigFileWatcher fileWatcher = new(fileSystemWatcherMock.Object, directoryName: Directory.GetCurrentDirectory(), configFileName: configName);
-            fileWatcher.NewFileContentsDetected += (sender, e) =>
-            {
-                // For testing, modification of fileChangeNotificationsRecieved
-                // should be atomic. 
-                Interlocked.Increment(ref fileChangeNotificationsReceived);
-            };
-
-            // Track the number of invocations so far so we can prove that
-            // fileSystemWatcherMock.Raise() actually triggers a "file changed" event.
-            int numberFileSystemWatcherMockInvocations = fileSystemWatcherMock.Invocations.Count;
-
-            // Act
-            // Manually induce two "file changed" events to simulate a file change
-            // which is detected by ConfigFileWatcher's OnConfigFileChange() method.
-            // Upon detecting a net-new config (due to differing hash),
-            // ConfigFileWatcher triggers its NewFileContentsDetected event.
-            int expectedInvocationCount = 2;
-            for (int invocations = 1; invocations <= expectedInvocationCount; invocations++)
-            {
-                fileSystemWatcherMock.Raise(mock => mock.Changed += null, this, new FileSystemEventArgs(
-                    changeType: WatcherChangeTypes.Changed,
-                    directory: fileSystem.Directory.GetCurrentDirectory(),
-                    name: configName));
-            }
-
-            // Assert
-            // Even though the ConfigFileWatcher's NewFileContentsDetected is raised,
-            // we still expected the underlying FileSystemWatcher's file changed event to
-            // have been raised more than once.
-            // The ConfigFileWatcher's job is to ensure it only raises its NewFileContentsDetected
-            // event when the new file's hash differs from the currently tracked file hash.
-            Assert.AreEqual(
-                expected: expectedInvocationCount,
-                actual: fileSystemWatcherMock.Invocations.Count - numberFileSystemWatcherMockInvocations,
-                message: FILECHANGE_EVENT_NOT_RAISED_ERR);
-            Assert.AreEqual(
-                expected: 1,
-                actual: fileChangeNotificationsReceived,
-                message: UNEXPECTED_INVOCATION_COUNT_ERR);
-        }
-
-        /// <summary>
-        /// This test validates that overwriting a file with the same contents does not
-        /// result in ConfigFileWatcher's NewFileContentsDetected event being raised.
-        /// Internally, ConfigFileWatcher.NewFileContentsDetected is raised when the hash
-        /// of the file contents differ from what was previously detected.
-        /// In this test, the file contents are the same: MyValue -> MyValue.
-        /// The config file name is specific to this test in order to avoid concurrently
-        /// running tests from stepping over eachother due to acquiring a handle(s) to the file.
-        /// </summary>
-        [TestMethod]
-        public void ConfigFileWatcher_NotifiedOfZeroNetNewChange()
+        // Act
+        // Manually induce two "file changed" events to simulate a file change
+        // which is detected by ConfigFileWatcher's OnConfigFileChange() method.
+        // The two events result in two filesystem reads returning "SecondValue".
+        // This test ensures the second instance of "SecondValue" results in a no-op
+        // as no file changes occurred and NewFileContentsDetected was already raised.
+        // Upon detecting a net-new config (due to differing hash),
+        // ConfigFileWatcher triggers its NewFileContentsDetected event.
+        int expectedInvocationCount = 2;
+        for (int invocations = 1; invocations <= expectedInvocationCount; invocations++)
         {
-            // Arrange
-            int fileChangeNotificationsReceived = 0;
-            string configName = "ConfigFileWatcher_NotifiedOfZeroNetNewChange.json";
-
-            // Mock filesystem calls for when FileUtilities.ComputeHash() utilizes the filesystem.
-            // For this test, we assume the file exists because we are validating the behavior
-            // of differing config file contents triggering a NewFileContentsDetected event.
-            IFileSystem fileSystem = Mock.Of<IFileSystem>();
-            Mock.Get(fileSystem).Setup(fs => fs.Directory.GetCurrentDirectory()).Returns(Directory.GetCurrentDirectory());
-            Mock.Get(fileSystem).Setup(fs => fs.File.Exists(It.IsAny<string>())).Returns(true);
-
-            // Mock file system to return different byte arrays for each read which occurs in
-            // FileUtilities.ComputeHash() called by ConfigFileWatcher.
-            // The first read occurs during ConfigFileWatcher's initialization
-            // The second read occurs during the manual invocation of a "file changed" event.
-            Mock.Get(fileSystem).SetupSequence(fs => fs.File.ReadAllBytes(It.IsAny<string>()))
-                .Returns(Encoding.UTF8.GetBytes("FirstValue"))
-                .Returns(Encoding.UTF8.GetBytes("FirstValue"));
-
-            Mock<IFileSystemWatcher> fileSystemWatcherMock = new();
-            fileSystemWatcherMock.Setup(mock => mock.FileSystem).Returns(fileSystem);
-
-            ConfigFileWatcher fileWatcher = new(fileSystemWatcherMock.Object, directoryName: Directory.GetCurrentDirectory(), configFileName: configName);
-            fileWatcher.NewFileContentsDetected += (sender, e) =>
-            {
-                // For testing, modification of fileChangeNotificationsRecieved
-                // should be atomic. 
-                Interlocked.Increment(ref fileChangeNotificationsReceived);
-            };
-
-            // Track the number of invocations so far so we can prove that
-            // fileSystemWatcherMock.Raise() actually triggers a "file changed" event.
-            int numberFileSystemWatcherMockInvocations = fileSystemWatcherMock.Invocations.Count;
-
-            // Act
-            // Manually induce two "file changed" events to simulate a file change
-            // which is detected by ConfigFileWatcher's OnConfigFileChange() method.
-            // Upon detecting the same config (due to same hash), ConfigFileWatcher
-            // skips triggering its NewFileContentsDetected event.
             fileSystemWatcherMock.Raise(mock => mock.Changed += null, this, new FileSystemEventArgs(
                 changeType: WatcherChangeTypes.Changed,
                 directory: fileSystem.Directory.GetCurrentDirectory(),
                 name: configName));
-
-            // Assert
-            // Even though the ConfigFileWatcher's NewFileContentsDetected is not raised,
-            // we still expected the underlying FileSystemWatcher's file changed event to be raised.
-            // The ConfigFileWatcher's job is to ensure it only raises its NewFileContentsDetected
-            // event when the new file's hash differs from the currently tracked file hash.
-            Assert.AreEqual(
-                expected: 1,
-                actual: fileSystemWatcherMock.Invocations.Count - numberFileSystemWatcherMockInvocations,
-                message: FILECHANGE_EVENT_NOT_RAISED_ERR);
-            Assert.AreEqual(
-                expected: 0,
-                actual: fileChangeNotificationsReceived,
-                message: UNEXPECTED_INVOCATION_COUNT_ERR);
         }
-        #endregion
+
+        // Assert
+        // Even though the ConfigFileWatcher's NewFileContentsDetected is raised,
+        // we still expect the underlying FileSystemWatcher's file changed event to
+        // have been raised more than once.
+        // The ConfigFileWatcher's job is to ensure it only raises its NewFileContentsDetected
+        // event when the new file's hash differs from the currently tracked file hash.
+        Assert.AreEqual(
+            expected: expectedInvocationCount,
+            actual: fileSystemWatcherMock.Invocations.Count - numberFileSystemWatcherMockInvocations,
+            message: FILECHANGE_EVENT_NOT_RAISED_ERR);
+        Assert.AreEqual(
+            expected: 1,
+            actual: fileChangeNotificationsReceived,
+            message: UNEXPECTED_INVOCATION_COUNT_ERR);
     }
+
+    /// <summary>
+    /// This test validates that overwriting a file with the same contents does not
+    /// result in ConfigFileWatcher's NewFileContentsDetected event being raised.
+    /// Internally, ConfigFileWatcher.NewFileContentsDetected is raised when the hash
+    /// of the file contents differ from what was previously detected.
+    /// In this test, the file contents are the same: MyValue -> MyValue.
+    /// The config file name is specific to this test in order to avoid concurrently
+    /// running tests from stepping over each other due to acquiring a handle(s) to the file.
+    /// </summary>
+    [TestMethod]
+    public void ConfigFileWatcher_NotifiedOfZeroNetNewChange()
+    {
+        // Arrange
+        int fileChangeNotificationsReceived = 0;
+        string configName = "ConfigFileWatcher_NotifiedOfZeroNetNewChange.json";
+
+        // Mock filesystem calls for when FileUtilities.ComputeHash() utilizes the filesystem.
+        // For this test, we assume the file exists because we are validating the behavior
+        // of differing config file contents triggering a NewFileContentsDetected event.
+        IFileSystem fileSystem = Mock.Of<IFileSystem>();
+        Mock.Get(fileSystem).Setup(fs => fs.Directory.GetCurrentDirectory()).Returns(Directory.GetCurrentDirectory());
+        Mock.Get(fileSystem).Setup(fs => fs.File.Exists(It.IsAny<string>())).Returns(true);
+
+        // Mock file system to return different byte arrays for each read which occurs in
+        // FileUtilities.ComputeHash() called by ConfigFileWatcher.
+        // The first read occurs during ConfigFileWatcher's initialization
+        // The second read occurs during the manual invocation of a "file changed" event.
+        Mock.Get(fileSystem).SetupSequence(fs => fs.File.ReadAllBytes(It.IsAny<string>()))
+            .Returns(Encoding.UTF8.GetBytes("FirstValue"))
+            .Returns(Encoding.UTF8.GetBytes("FirstValue"));
+
+        Mock<IFileSystemWatcher> fileSystemWatcherMock = new();
+        fileSystemWatcherMock.Setup(mock => mock.FileSystem).Returns(fileSystem);
+
+        ConfigFileWatcher fileWatcher = new(fileSystemWatcherMock.Object, directoryName: Directory.GetCurrentDirectory(), configFileName: configName);
+        fileWatcher.NewFileContentsDetected += (sender, e) =>
+        {
+            // For testing, modification of fileChangeNotificationsRecieved
+            // should be atomic. 
+            Interlocked.Increment(ref fileChangeNotificationsReceived);
+        };
+
+        // Track the number of invocations so far so we can prove that
+        // fileSystemWatcherMock.Raise() actually triggers a "file changed" event.
+        int numberFileSystemWatcherMockInvocations = fileSystemWatcherMock.Invocations.Count;
+
+        // Act
+        // Manually induce a "file changed" event to simulate a file change
+        // which is detected by ConfigFileWatcher's OnConfigFileChange() method.
+        // Upon detecting the same config (due to same hash), ConfigFileWatcher
+        // skips triggering its NewFileContentsDetected event.
+        fileSystemWatcherMock.Raise(mock => mock.Changed += null, this, new FileSystemEventArgs(
+            changeType: WatcherChangeTypes.Changed,
+            directory: fileSystem.Directory.GetCurrentDirectory(),
+            name: configName));
+
+        // Assert
+        // Even though the ConfigFileWatcher's NewFileContentsDetected is not raised,
+        // we still expected the underlying FileSystemWatcher's file changed event to be raised.
+        // The ConfigFileWatcher's job is to ensure it only raises its NewFileContentsDetected
+        // event when the new file's hash differs from the currently tracked file hash.
+        Assert.AreEqual(
+            expected: 1,
+            actual: fileSystemWatcherMock.Invocations.Count - numberFileSystemWatcherMockInvocations,
+            message: FILECHANGE_EVENT_NOT_RAISED_ERR);
+        Assert.AreEqual(
+            expected: 0,
+            actual: fileChangeNotificationsReceived,
+            message: UNEXPECTED_INVOCATION_COUNT_ERR);
+    }
+    #endregion
 }


### PR DESCRIPTION
## Why make this change?

- Closes #2423
  - Hot reloading reacts to >1 file change notification representing a single "Save File" action. DAB should only react to the first file change event which represents processing the changed file. DAB should only react to subsequent file change events when the file has actually changed.

## What is this change?

- Modifies `ConfigFileWatcher` class such that it no longer needs to have `FileSystemRuntimeConfigLoader` as a dependency/constructor parameter.  `ConfigFileWatcher` just called the passed in loader's methods which was a confusing layer of abstraction. 
- ConfigFileWatcher now (due to this PR's changes) has a hash persistence mechanism of runtimeconfig file contents and compares the currently tracked hash to a new hash calculated on the file after a "file change" event is emitted from the file watcher. One file change (e.g. clicking save in a text editor) causes multiple file change events to be detected by the file watcher (Added code comments to clarify). Dotnet docs describe the hashing mechanism included in this PR as a way to "ignore" subsequent file change events and only act on one event per file change.
    - Hash mechanism is SHA256 (32 bytes) as recommended by this [.NET documentation guidance](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.sha1?view=net-8.0) That's why my implementation of the hash mechanism differs from the [ChangeToken documentation referenced implementation ](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/change-tokens?view=aspnetcore-8.0#:~:text=exponential%20back%2Doff.-,Utilities/Utilities.cs%3A,-C%23) which uses SHA1. We are **not** using the hash for encryption.
    > Due to collision problems with SHA1, Microsoft recommends a security model based on SHA256 or better.
- ConfigFileWatcher now raises an event (**NewFileContentsDetected**) when the hash of the old versus new runtime config file is detected.  `FileSystemRuntimeConfigLoader` subscribes to `NewFileContentsDetected` and 
reacts by calling `HotReloadConfig(...)`
- Fixes how `FileSystemRuntimeConfigLoader` reads the config file to avoid issues where the disposable doesn't immediately close the file handle and we get occurrences of "IOException file being used by another process". Now using File.ReadAllText so that the file handle is closed immediately.
- Adds field `_isCliLoader` to FIleSystemRuntimeConfigLoader so DAB knows not to init filewatcher for CLI usage. This fixed a pipeline file IO bug due to CLI usage of filesystemruntimeconfigloader initializing the file watcher. 

## How was this tested?

The following two integration tests are added to validate the functionality of the modified `ConfigFileWatcher` class. These tests immitate a user change the runtime config file's contents (or not changing contents) and the test check that the `NewFileContentsDetected` is raised the expected number times. 

- [x] Integration Tests 
    1. `ConfigFileWatcher_NotifiedOfOneNetNewChanges`
    2. `ConfigFileWatcher_NotifiedOfZeroNetNewChange`

