### PR TITLE
Fix MetadataProvider initialization in Hot Reload and remove duplicate Query Executor reloading

### DIFF
--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -142,8 +142,7 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
         string path,
         [NotNullWhen(true)] out RuntimeConfig? config,
         bool replaceEnvVar = false,
-        ILogger? logger = null,
-        string defaultDataSourceName = "")
+        ILogger? logger = null)
     {
         if (_fileSystem.File.Exists(path))
         {
@@ -185,9 +184,9 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     /// <param name="replaceEnvVar">Whether to replace environment variable with its
     /// value or not while deserializing.</param>
     /// <returns>True if the config was loaded, otherwise false.</returns>
-    public override bool TryLoadKnownConfig([NotNullWhen(true)] out RuntimeConfig? config, bool replaceEnvVar = false, string defaultDataSourceName = "")
+    public override bool TryLoadKnownConfig([NotNullWhen(true)] out RuntimeConfig? config, bool replaceEnvVar = false)
     {
-        return TryLoadConfig(ConfigFilePath, out config, replaceEnvVar, defaultDataSourceName: defaultDataSourceName);
+        return TryLoadConfig(ConfigFilePath, out config, replaceEnvVar);
     }
 
     /// <summary>
@@ -197,7 +196,7 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     public void HotReloadConfig(string defaultDataSourceName, ILogger? logger = null)
     {
         logger?.LogInformation(message: "Starting hot-reload process for config: {ConfigFilePath}", ConfigFilePath);
-        TryLoadConfig(ConfigFilePath, out _, replaceEnvVar: true, defaultDataSourceName: defaultDataSourceName);
+        TryLoadConfig(ConfigFilePath, out _, replaceEnvVar: true);
         SendEventNotification();
     }
 

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -156,11 +156,6 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
                     logger?.LogInformation("Monitoring config: {ConfigFilePath} for hot-reloading.", ConfigFilePath);
                 }
 
-                if (!string.IsNullOrEmpty(defaultDataSourceName))
-                {
-                    RuntimeConfig.DefaultDataSourceName = defaultDataSourceName;
-                }
-
                 config = RuntimeConfig;
                 return true;
             }

--- a/src/Config/HotReloadEventHandler.cs
+++ b/src/Config/HotReloadEventHandler.cs
@@ -22,6 +22,9 @@ public class HotReloadEventHandler<TEventArgs> where TEventArgs : HotReloadEvent
     {
         _eventHandlers = new Dictionary<string, EventHandler<TEventArgs>?>
         {
+            // QueryManagerFactory will create a new set of QueryExecutors
+            // during Hot-Reload so it is not necessary to specifically reconfigure
+            // QueryExecutors as part of the Hot-Reload process.
             { QUERY_MANAGER_FACTORY_ON_CONFIG_CHANGED, null },
             { METADATA_PROVIDER_FACTORY_ON_CONFIG_CHANGED, null },
             { QUERY_ENGINE_FACTORY_ON_CONFIG_CHANGED,null },

--- a/src/Config/HotReloadEventHandler.cs
+++ b/src/Config/HotReloadEventHandler.cs
@@ -27,8 +27,8 @@ public class HotReloadEventHandler<TEventArgs> where TEventArgs : HotReloadEvent
             // QueryExecutors as part of the Hot-Reload process.
             { QUERY_MANAGER_FACTORY_ON_CONFIG_CHANGED, null },
             { METADATA_PROVIDER_FACTORY_ON_CONFIG_CHANGED, null },
-            { QUERY_ENGINE_FACTORY_ON_CONFIG_CHANGED,null },
-            { MUTATION_ENGINE_FACTORY_ON_CONFIG_CHANGED,null },
+            { QUERY_ENGINE_FACTORY_ON_CONFIG_CHANGED, null },
+            { MUTATION_ENGINE_FACTORY_ON_CONFIG_CHANGED, null },
             { DOCUMENTOR_ON_CONFIG_CHANGED, null }
         };
     }

--- a/src/Config/HotReloadEventHandler.cs
+++ b/src/Config/HotReloadEventHandler.cs
@@ -26,10 +26,6 @@ public class HotReloadEventHandler<TEventArgs> where TEventArgs : HotReloadEvent
             { METADATA_PROVIDER_FACTORY_ON_CONFIG_CHANGED, null },
             { QUERY_ENGINE_FACTORY_ON_CONFIG_CHANGED,null },
             { MUTATION_ENGINE_FACTORY_ON_CONFIG_CHANGED,null },
-            { QUERY_EXECUTOR_ON_CONFIG_CHANGED, null },
-            { MSSQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, null },
-            { MYSQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, null },
-            { POSTGRESQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, null },
             { DOCUMENTOR_ON_CONFIG_CHANGED, null }
         };
     }

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -178,24 +178,30 @@ public record RuntimeConfig
     /// <param name="Runtime">Runtime settings.</param>
     /// <param name="DataSourceFiles">List of datasource files for multiple db scenario. Null for single db scenario.</param>
     [JsonConstructor]
-    public RuntimeConfig(string? Schema, DataSource DataSource, RuntimeEntities Entities, RuntimeOptions? Runtime = null, DataSourceFiles? DataSourceFiles = null)
+    public RuntimeConfig(
+        string? Schema,
+        DataSource DataSource,
+        RuntimeEntities Entities,
+        RuntimeOptions? Runtime = null,
+        DataSourceFiles? DataSourceFiles = null,
+        string DefaultDataSourceName = "")
     {
         this.Schema = Schema ?? DEFAULT_CONFIG_SCHEMA_LINK;
         this.DataSource = DataSource;
         this.Runtime = Runtime;
         this.Entities = Entities;
-        this.DefaultDataSourceName = Guid.NewGuid().ToString();
+        this.DefaultDataSourceName = string.IsNullOrWhiteSpace(DefaultDataSourceName) ? Guid.NewGuid().ToString() : DefaultDataSourceName;
 
         // we will set them up with default values
         _dataSourceNameToDataSource = new Dictionary<string, DataSource>
         {
-            { DefaultDataSourceName, this.DataSource }
+            { this.DefaultDataSourceName, this.DataSource }
         };
 
         _entityNameToDataSourceName = new Dictionary<string, string>();
         foreach (KeyValuePair<string, Entity> entity in Entities)
         {
-            _entityNameToDataSourceName.TryAdd(entity.Key, DefaultDataSourceName);
+            _entityNameToDataSourceName.TryAdd(entity.Key, this.DefaultDataSourceName);
         }
 
         // Process data source and entities information for each database in multiple database scenario.

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -183,14 +183,13 @@ public record RuntimeConfig
         DataSource DataSource,
         RuntimeEntities Entities,
         RuntimeOptions? Runtime = null,
-        DataSourceFiles? DataSourceFiles = null,
-        string DefaultDataSourceName = "")
+        DataSourceFiles? DataSourceFiles = null)
     {
         this.Schema = Schema ?? DEFAULT_CONFIG_SCHEMA_LINK;
         this.DataSource = DataSource;
         this.Runtime = Runtime;
         this.Entities = Entities;
-        this.DefaultDataSourceName = string.IsNullOrWhiteSpace(DefaultDataSourceName) ? Guid.NewGuid().ToString() : DefaultDataSourceName;
+        this.DefaultDataSourceName = Guid.NewGuid().ToString();
 
         // we will set them up with default values
         _dataSourceNameToDataSource = new Dictionary<string, DataSource>

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -93,7 +93,6 @@ public abstract class RuntimeConfigLoader
         ILogger? logger = null,
         string? connectionString = null,
         bool replaceEnvVar = false,
-        string dataSourceName = "",
         Dictionary<string, string>? datasourceNameToConnectionString = null,
         EnvironmentVariableReplacementFailureMode replacementFailureMode = EnvironmentVariableReplacementFailureMode.Throw)
     {
@@ -109,7 +108,7 @@ public abstract class RuntimeConfigLoader
             }
 
             // retreive current connection string from config
-            string updatedConnectionString = config.DataSource.ConnectionString;
+            string updatedConnectionString = config.DataSource.ConnectionString;            
 
             if (!string.IsNullOrEmpty(connectionString))
             {
@@ -123,7 +122,7 @@ public abstract class RuntimeConfigLoader
             }
 
             // add to dictionary if datasourceName is present (will either be the default or the one provided)
-            datasourceNameToConnectionString.TryAdd(dataSourceName, updatedConnectionString);
+            datasourceNameToConnectionString.TryAdd(config.DefaultDataSourceName, updatedConnectionString);
 
             // iterate over dictionary and update runtime config with connection strings.
             foreach ((string dataSourceKey, string connectionValue) in datasourceNameToConnectionString)
@@ -143,7 +142,7 @@ public abstract class RuntimeConfigLoader
                 }
 
                 ds = ds with { ConnectionString = updatedConnection };
-                config.UpdateDataSourceNameToDataSource(dataSourceName, ds);
+                config.UpdateDataSourceNameToDataSource(config.DefaultDataSourceName, ds);
 
                 if (string.Equals(dataSourceKey, config.DefaultDataSourceName, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -108,7 +108,7 @@ public abstract class RuntimeConfigLoader
             }
 
             // retreive current connection string from config
-            string updatedConnectionString = config.DataSource.ConnectionString;            
+            string updatedConnectionString = config.DataSource.ConnectionString;       
 
             if (!string.IsNullOrEmpty(connectionString))
             {

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -56,10 +56,6 @@ public abstract class RuntimeConfigLoader
         OnConfigChangedEvent(new HotReloadEventArgs(METADATA_PROVIDER_FACTORY_ON_CONFIG_CHANGED, message));
         OnConfigChangedEvent(new HotReloadEventArgs(QUERY_ENGINE_FACTORY_ON_CONFIG_CHANGED, message));
         OnConfigChangedEvent(new HotReloadEventArgs(MUTATION_ENGINE_FACTORY_ON_CONFIG_CHANGED, message));
-        OnConfigChangedEvent(new HotReloadEventArgs(QUERY_EXECUTOR_ON_CONFIG_CHANGED, message));
-        OnConfigChangedEvent(new HotReloadEventArgs(MSSQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, message));
-        OnConfigChangedEvent(new HotReloadEventArgs(MYSQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, message));
-        OnConfigChangedEvent(new HotReloadEventArgs(POSTGRESQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, message));
         OnConfigChangedEvent(new HotReloadEventArgs(DOCUMENTOR_ON_CONFIG_CHANGED, message));
     }
 
@@ -105,34 +101,15 @@ public abstract class RuntimeConfigLoader
 
         try
         {
-            // Use an intermediate object to inject default data source name in the case of hot reload.
-            RuntimeConfig? tempConfig = JsonSerializer.Deserialize<RuntimeConfig>(json, options);
+            config = JsonSerializer.Deserialize<RuntimeConfig>(json, options);
 
-            if (tempConfig is null)
+            if (config is null)
             {
-                config = null;
                 return false;
             }
 
-            // If a dataSourceName was provided we use that, otherwise use the GUID generated from tempConfig construction.
-            dataSourceName = string.IsNullOrWhiteSpace(dataSourceName) ? tempConfig.DefaultDataSourceName : dataSourceName;
-
-            config = new RuntimeConfig(
-                tempConfig.Schema,
-                tempConfig.DataSource,
-                tempConfig.Entities,
-                tempConfig.Runtime,
-                tempConfig.DataSourceFiles,
-                dataSourceName);
-
             // retreive current connection string from config
             string updatedConnectionString = config.DataSource.ConnectionString;
-
-            // set dataSourceName to default if not provided
-            if (string.IsNullOrEmpty(dataSourceName))
-            {
-                dataSourceName = config.DefaultDataSourceName;
-            }
 
             if (!string.IsNullOrEmpty(connectionString))
             {

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -65,9 +65,8 @@ public abstract class RuntimeConfigLoader
     /// <param name="config">The loaded <c>RuntimeConfig</c>, or null if none was loaded.</param>
     /// <param name="replaceEnvVar">Whether to replace environment variable with its
     /// value or not while deserializing.</param>
-    /// <param name="dataSourceName">The data source name to be used in the loaded config.</param>
     /// <returns>True if the config was loaded, otherwise false.</returns>
-    public abstract bool TryLoadKnownConfig([NotNullWhen(true)] out RuntimeConfig? config, bool replaceEnvVar = false, string dataSourceName = "");
+    public abstract bool TryLoadKnownConfig([NotNullWhen(true)] out RuntimeConfig? config, bool replaceEnvVar = false);
 
     /// <summary>
     /// Returns the link to the published draft schema.
@@ -85,15 +84,12 @@ public abstract class RuntimeConfigLoader
     /// <param name="connectionString">connectionString to add to config if specified</param>
     /// <param name="replaceEnvVar">Whether to replace environment variable with its
     /// value or not while deserializing. By default, no replacement happens.</param>
-    /// <param name="dataSourceName"> datasource name for which to add connection string</param>
-    /// <param name="datasourceNameToConnectionString"> dictionary of datasource name to connection string</param>
     /// <param name="replacementFailureMode">Determines failure mode for env variable replacement.</param>
     public static bool TryParseConfig(string json,
         [NotNullWhen(true)] out RuntimeConfig? config,
         ILogger? logger = null,
         string? connectionString = null,
         bool replaceEnvVar = false,
-        Dictionary<string, string>? datasourceNameToConnectionString = null,
         EnvironmentVariableReplacementFailureMode replacementFailureMode = EnvironmentVariableReplacementFailureMode.Throw)
     {
         JsonSerializerOptions options = GetSerializationOptions(replaceEnvVar, replacementFailureMode);
@@ -116,12 +112,9 @@ public abstract class RuntimeConfigLoader
                 updatedConnectionString = connectionString;
             }
 
-            if (datasourceNameToConnectionString is null)
-            {
-                datasourceNameToConnectionString = new Dictionary<string, string>();
-            }
+            Dictionary<string, string> datasourceNameToConnectionString = new();
 
-            // add to dictionary if datasourceName is present (will either be the default or the one provided)
+            // add to dictionary if datasourceName is present
             datasourceNameToConnectionString.TryAdd(config.DefaultDataSourceName, updatedConnectionString);
 
             // iterate over dictionary and update runtime config with connection strings.

--- a/src/Config/RuntimeConfigLoader.cs
+++ b/src/Config/RuntimeConfigLoader.cs
@@ -108,7 +108,7 @@ public abstract class RuntimeConfigLoader
             }
 
             // retreive current connection string from config
-            string updatedConnectionString = config.DataSource.ConnectionString;       
+            string updatedConnectionString = config.DataSource.ConnectionString;
 
             if (!string.IsNullOrEmpty(connectionString))
             {

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -16,7 +16,6 @@ using Azure.Identity;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
-using static Azure.DataApiBuilder.Config.DabConfigEvents;
 
 namespace Azure.DataApiBuilder.Core.Resolvers
 {
@@ -77,7 +76,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                   httpContextAccessor,
                   handler)
         {
-            handler?.Subscribe(MSSQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, OnConfigChanged);
             _dataSourceAccessTokenUsage = new Dictionary<string, bool>();
             _dataSourceToSessionContextUsage = new Dictionary<string, bool>();
             _accessTokensFromConfiguration = runtimeConfigProvider.ManagedIdentityAccessToken;
@@ -107,19 +105,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 _dataSourceToSessionContextUsage[dataSourceName] = msSqlOptions is null ? false : msSqlOptions.SetSessionContext;
                 _dataSourceAccessTokenUsage[dataSourceName] = ShouldManagedIdentityAccessBeAttempted(builder);
             }
-        }
-
-        /// <summary>
-        /// Function registered for callback during a hot-reload scenario.
-        /// </summary>
-        /// <param name="sender">The calling object.</param>
-        /// <param name="args">Event arguments.</param>
-        public void MsSqlQueryExecutorOnConfigChanged(object? sender, HotReloadEventArgs args)
-        {
-            _dataSourceAccessTokenUsage = new Dictionary<string, bool>();
-            _dataSourceToSessionContextUsage = new Dictionary<string, bool>();
-            _accessTokensFromConfiguration = _runtimeConfigProvider.ManagedIdentityAccessToken;
-            ConfigureMsSqlQueryEecutor();
         }
 
         /// <summary>

--- a/src/Core/Resolvers/MySqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MySqlQueryExecutor.cs
@@ -11,7 +11,6 @@ using Azure.Identity;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using MySqlConnector;
-using static Azure.DataApiBuilder.Config.DabConfigEvents;
 
 namespace Azure.DataApiBuilder.Core.Resolvers
 {
@@ -67,7 +66,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                   httpContextAccessor,
                   handler)
         {
-            handler?.Subscribe(MYSQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, MySqlQueryExecutorOnConfigChanged);
             _dataSourceAccessTokenUsage = new Dictionary<string, bool>();
             _accessTokensFromConfiguration = runtimeConfigProvider.ManagedIdentityAccessToken;
             _runtimeConfigProvider = runtimeConfigProvider;
@@ -98,18 +96,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 ConnectionStringBuilders.TryAdd(dataSourceName, builder);
                 _dataSourceAccessTokenUsage[dataSourceName] = ShouldManagedIdentityAccessBeAttempted(builder);
             }
-        }
-
-        /// <summary>
-        /// Function registered for callback during a hot-reload scenario.
-        /// </summary>
-        /// <param name="sender">The calling object.</param>
-        /// <param name="args">Event arguments.</param>
-        public void MySqlQueryExecutorOnConfigChanged(object? sender, HotReloadEventArgs args)
-        {
-            _dataSourceAccessTokenUsage = new Dictionary<string, bool>();
-            _accessTokensFromConfiguration = _runtimeConfigProvider.ManagedIdentityAccessToken;
-            ConfigureMySqlQueryExecutor();
         }
 
         /// <summary>

--- a/src/Core/Resolvers/PostgreSqlExecutor.cs
+++ b/src/Core/Resolvers/PostgreSqlExecutor.cs
@@ -11,7 +11,6 @@ using Azure.Identity;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Npgsql;
-using static Azure.DataApiBuilder.Config.DabConfigEvents;
 
 namespace Azure.DataApiBuilder.Core.Resolvers
 {
@@ -68,7 +67,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                   httpContextAccessor,
                   handler)
         {
-            handler?.Subscribe(POSTGRESQL_QUERY_EXECUTOR_ON_CONFIG_CHANGED, PostgreSqlQueryExecutorOnConfigChanged);
             _dataSourceAccessTokenUsage = new Dictionary<string, bool>();
             _accessTokensFromConfiguration = runtimeConfigProvider.ManagedIdentityAccessToken;
             _runtimeConfigProvider = runtimeConfigProvider;
@@ -95,18 +93,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 MsSqlOptions? msSqlOptions = dataSource.GetTypedOptions<MsSqlOptions>();
                 _dataSourceAccessTokenUsage[dataSourceName] = ShouldManagedIdentityAccessBeAttempted(builder);
             }
-        }
-
-        /// <summary>
-        /// Function registered for callback during a hot-reload scenario.
-        /// </summary>
-        /// <param name="sender">The calling object.</param>
-        /// <param name="args">Event arguments.</param>
-        public void PostgreSqlQueryExecutorOnConfigChanged(object? sender, HotReloadEventArgs args)
-        {
-            _dataSourceAccessTokenUsage = new Dictionary<string, bool>();
-            _accessTokensFromConfiguration = _runtimeConfigProvider.ManagedIdentityAccessToken;
-            ConfigurePostgreSqlQueryExecutor();
         }
 
         /// <summary>

--- a/src/Core/Resolvers/QueryExecutor.cs
+++ b/src/Core/Resolvers/QueryExecutor.cs
@@ -16,7 +16,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Retry;
-using static Azure.DataApiBuilder.Config.DabConfigEvents;
 
 namespace Azure.DataApiBuilder.Core.Resolvers
 {
@@ -56,7 +55,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                              IHttpContextAccessor httpContextAccessor,
                              HotReloadEventHandler<HotReloadEventArgs>? handler)
         {
-            handler?.Subscribe(QUERY_EXECUTOR_ON_CONFIG_CHANGED, OnConfigChanged);
             DbExceptionParser = dbExceptionParser;
             QueryExecutorLogger = logger;
             ConnectionStringBuilders = new Dictionary<string, DbConnectionStringBuilder>();
@@ -84,18 +82,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     {
                         QueryExecutorLogger.LogError(exception: exception, message: "Error during query execution, retrying.");
                     });
-        }
-
-        /// <summary>
-        /// Function registered for callback during a hot-reload scenario.
-        /// </summary>
-        /// <param name="sender">The calling object.</param>
-        /// <param name="args">Event arguments.</param>
-        public void OnConfigChanged(object? sender, HotReloadEventArgs args)
-        {
-            ConnectionStringBuilders = new Dictionary<string, DbConnectionStringBuilder>();
-            _maxResponseSizeMB = ConfigProvider.GetConfig().MaxResponseSizeMB();
-            _maxResponseSizeBytes = _maxResponseSizeMB * 1024 * 1024;
         }
 
         /// <inheritdoc/>

--- a/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
+++ b/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
@@ -63,6 +63,9 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
         public void OnConfigChanged(object? sender, HotReloadEventArgs args)
         {
             ConfigureMetadataProviders();
+            // Creates a new task to run this initialization and blocks until it completes.
+            // Avoids making the entire hot-reload process async.
+            Task.Run(() => this.InitializeAsync().GetAwaiter().GetResult());
         }
 
         /// <inheritdoc />

--- a/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
+++ b/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
@@ -17,7 +17,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
     /// <inheritdoc />
     public class MetadataProviderFactory : IMetadataProviderFactory
     {
-        private readonly IDictionary<string, ISqlMetadataProvider> _metadataProviders;
+        private IDictionary<string, ISqlMetadataProvider> _metadataProviders;
         private readonly RuntimeConfigProvider _runtimeConfigProvider;
         private readonly IAbstractQueryManagerFactory _queryManagerFactory;
         private readonly ILogger<ISqlMetadataProvider> _logger;
@@ -62,10 +62,10 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
 
         public void OnConfigChanged(object? sender, HotReloadEventArgs args)
         {
+            _metadataProviders = new Dictionary<string, ISqlMetadataProvider>();
             ConfigureMetadataProviders();
-            // Creates a new task to run this initialization and blocks until it completes.
-            // Avoids making the entire hot-reload process async.
-            Task.Run(() => this.InitializeAsync().GetAwaiter().GetResult());
+            // Blocks the current thread until initialization is finished.
+            this.InitializeAsync().GetAwaiter().GetResult();
         }
 
         /// <inheritdoc />

--- a/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
+++ b/src/Core/Services/MetadataProviders/MetadataProviderFactory.cs
@@ -17,7 +17,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
     /// <inheritdoc />
     public class MetadataProviderFactory : IMetadataProviderFactory
     {
-        private IDictionary<string, ISqlMetadataProvider> _metadataProviders;
+        private readonly IDictionary<string, ISqlMetadataProvider> _metadataProviders;
         private readonly RuntimeConfigProvider _runtimeConfigProvider;
         private readonly IAbstractQueryManagerFactory _queryManagerFactory;
         private readonly ILogger<ISqlMetadataProvider> _logger;
@@ -62,7 +62,7 @@ namespace Azure.DataApiBuilder.Core.Services.MetadataProviders
 
         public void OnConfigChanged(object? sender, HotReloadEventArgs args)
         {
-            _metadataProviders = new Dictionary<string, ISqlMetadataProvider>();
+            _metadataProviders.Clear();
             ConfigureMetadataProviders();
             // Blocks the current thread until initialization is finished.
             this.InitializeAsync().GetAwaiter().GetResult();

--- a/src/Service.Tests/Caching/CachingConfigProcessingTests.cs
+++ b/src/Service.Tests/Caching/CachingConfigProcessingTests.cs
@@ -59,8 +59,6 @@ public class CachingConfigProcessingTests
             logger: null,
             connectionString: null,
             replaceEnvVar: false,
-            dataSourceName: string.Empty,
-            datasourceNameToConnectionString: null,
             replacementFailureMode: EnvironmentVariableReplacementFailureMode.Throw);
 
         // Assert
@@ -108,8 +106,6 @@ public class CachingConfigProcessingTests
             logger: null,
             connectionString: null,
             replaceEnvVar: false,
-            dataSourceName: string.Empty,
-            datasourceNameToConnectionString: null,
             replacementFailureMode: EnvironmentVariableReplacementFailureMode.Throw);
 
         // Assert
@@ -148,8 +144,6 @@ public class CachingConfigProcessingTests
             logger: null,
             connectionString: null,
             replaceEnvVar: false,
-            dataSourceName: string.Empty,
-            datasourceNameToConnectionString: null,
             replacementFailureMode: EnvironmentVariableReplacementFailureMode.Throw);
 
         // Assert
@@ -196,8 +190,6 @@ public class CachingConfigProcessingTests
             logger: null,
             connectionString: null,
             replaceEnvVar: false,
-            dataSourceName: string.Empty,
-            datasourceNameToConnectionString: null,
             replacementFailureMode: EnvironmentVariableReplacementFailureMode.Throw);
 
         // Assert
@@ -227,8 +219,6 @@ public class CachingConfigProcessingTests
                        logger: null,
                        connectionString: null,
                        replaceEnvVar: false,
-                       dataSourceName: string.Empty,
-                       datasourceNameToConnectionString: null,
                        replacementFailureMode: EnvironmentVariableReplacementFailureMode.Throw);
 
         // Assert
@@ -265,8 +255,6 @@ public class CachingConfigProcessingTests
                        logger: null,
                        connectionString: null,
                        replaceEnvVar: false,
-                       dataSourceName: string.Empty,
-                       datasourceNameToConnectionString: null,
                        replacementFailureMode: EnvironmentVariableReplacementFailureMode.Throw);
         Assert.IsNotNull(config, message: "Test setup failure. Config must not be null, runtime config JSON deserialization failed.");
 
@@ -315,8 +303,6 @@ public class CachingConfigProcessingTests
                        logger: null,
                        connectionString: null,
                        replaceEnvVar: false,
-                       dataSourceName: string.Empty,
-                       datasourceNameToConnectionString: null,
                        replacementFailureMode: EnvironmentVariableReplacementFailureMode.Throw);
         Assert.IsNotNull(config, message: "Test setup failure. Config must not be null, runtime config JSON deserialization failed.");
 
@@ -359,8 +345,6 @@ public class CachingConfigProcessingTests
                        logger: null,
                        connectionString: null,
                        replaceEnvVar: false,
-                       dataSourceName: string.Empty,
-                       datasourceNameToConnectionString: null,
                        replacementFailureMode: EnvironmentVariableReplacementFailureMode.Throw);
         Assert.IsNotNull(config, message: "Test setup failure. Config must not be null, runtime config JSON deserialization failed.");
 

--- a/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
+++ b/src/Service.Tests/Unittests/MultiSourceQueryExecutionUnitTests.cs
@@ -92,7 +92,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
             Mock<IMutationEngineFactory> mutationEngineFactory = new();
 
             Mock<RuntimeConfigLoader> mockLoader = new(null, null);
-            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig1, It.IsAny<bool>(), It.IsAny<string>())).Returns(true);
+            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig1, It.IsAny<bool>())).Returns(true);
 
             RuntimeConfigProvider provider = new(mockLoader.Object);
 
@@ -161,7 +161,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
             Mock<IMutationEngineFactory> mutationEngineFactory = new();
 
             Mock<RuntimeConfigLoader> mockLoader = new(null, null);
-            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig1, It.IsAny<bool>(), It.IsAny<string>())).Returns(true);
+            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig1, It.IsAny<bool>())).Returns(true);
 
             RuntimeConfigProvider provider = new(mockLoader.Object);
 
@@ -260,7 +260,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Unittests
                );
 
             Mock<RuntimeConfigLoader> mockLoader = new(null, null);
-            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig, It.IsAny<bool>(), It.IsAny<string>())).Returns(true);
+            mockLoader.Setup(x => x.TryLoadKnownConfig(out mockConfig, It.IsAny<bool>())).Returns(true);
             mockLoader.Object.RuntimeConfig = mockConfig;
 
             RuntimeConfigProvider provider = new(mockLoader.Object);


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/2426
Closes https://github.com/Azure/data-api-builder/issues/2427

## What is this change?

Properly create and initialize a new set of `SqlMetadataProviders` as part of the hot-reload process of the `SqlMetadataProviderFactory`, by utilizing the `initiaizeAsync()` function. This guarantees a correctly configured set of meta data providers for the factory.

Remove the event handling to hot-reload the `QueryExecutors` classes specifically, since this is already handled during the hot-reload process of the `QueryManagerFactory`. That process creates new and up to date `QueryExecutors` as part of a hot-reload.

With the correct initialization of the meta data providers, we can remove the code that saves the `DefaultDataSourceName` to be passed along the hot-reloaded configs. With all of the data structures we initialized on new meta data providers, we do not need to save the data source name and hot-reloading will be more resilient. This is because we will build all of the data structures which depend on this DefaultDataSourceName fresh from newly created or cleared objects, and we do not have to worry about maintaining previous configuration's DefaultDataSourceName, everything will simply use the new name generated during a hot-reload.

## How was this tested?

### Testing Scenario
Scenario A: Handling a change in entities in the config 
Objective: Verify that hot-reload correctly refreshes the MetadataProviders and QueryExecutors when we hot-reload the entities by making a REST request.

Steps:

Start with MSSQL with a valid config file that contains some valid entities.
Make a REST request that targets one of the entities and observe the results to compare against later.
Change the entities section by removing an entity and any entities that have a relationship with that entity.
Make a REST request for that entity and observe that the entity is not found.
Add the removed entities back to the config file.
Make a REST request for that same entity and observe the results match the original REST request.

## Sample Request(s)

For the "Book" entity with a rest path of "rest"

https://localhost:5001/rest/Book