### PR TITLE
Added End-To-End Test for Datasource Hot-Reload

### DIFF
--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -75,11 +75,6 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     /// </summary>
     public string ConfigFilePath { get; internal set; }
 
-    /// <summary>
-    /// Orchestrates sending HotReloadCompleted events to all its subscribers
-    /// </summary>
-    public event EventHandler? HotReloadCompleted;
-
     public FileSystemRuntimeConfigLoader(
         IFileSystem fileSystem,
         HotReloadEventHandler<HotReloadEventArgs>? handler = null,
@@ -160,16 +155,6 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     }
 
     /// <summary>
-    /// Raises the HotReloadCompleted event, which signals to listeners
-    /// that hot-reload has finished. It does not matter if hot-reload
-    /// succeeded or failed, the event will still be raised.
-    /// </summary>
-    protected virtual void OnHotReloadCompleted()
-    {
-        HotReloadCompleted?.Invoke(this, EventArgs.Empty);
-    }
-
-    /// <summary>
     /// When a change is detected in the Config file being watched this trigger
     /// function is called and handles the hot reload logic when appropriate,
     /// ie: in a local development scenario.
@@ -189,9 +174,6 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
             // before we can have an ILogger here.
             Console.WriteLine("Unable to hot reload configuration file due to " + ex.Message);
         }
-
-        // Event 
-        OnHotReloadCompleted();
     }
 
     /// <summary>

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -75,6 +75,11 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     /// </summary>
     public string ConfigFilePath { get; internal set; }
 
+    /// <summary>
+    /// Orchestrates sending HotReloadCompleted events to all its subscribers
+    /// </summary>
+    public event EventHandler? HotReloadCompleted;
+
     public FileSystemRuntimeConfigLoader(
         IFileSystem fileSystem,
         HotReloadEventHandler<HotReloadEventArgs>? handler = null,
@@ -155,6 +160,16 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
     }
 
     /// <summary>
+    /// Raises the HotReloadCompleted event, which signals to listeners
+    /// that hot-reload has finished. It does not matter if hot-reload
+    /// succeeded or failed, the event will still be raised.
+    /// </summary>
+    protected virtual void OnHotReloadCompleted()
+    {
+        HotReloadCompleted?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
     /// When a change is detected in the Config file being watched this trigger
     /// function is called and handles the hot reload logic when appropriate,
     /// ie: in a local development scenario.
@@ -174,6 +189,9 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
             // before we can have an ILogger here.
             Console.WriteLine("Unable to hot reload configuration file due to " + ex.Message);
         }
+
+        // Event 
+        OnHotReloadCompleted();
     }
 
     /// <summary>

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -304,13 +304,15 @@ public class ConfigurationHotReloadTests
     }
 
     /// <summary>
-    /// Hot reload the configuration file by saving a new database type and connection string.
-    /// Validate that the response from the server is correct when making a new request after
-    /// the change in database type.
+    /// Hot reload the configuration file by saving a new session-context and connection string.
+    /// Validate that the response from the server is correct, by ensuring that the session-context
+    /// inside the DataSource parameter is different from the session-context before hot reload.
+    /// By asserting that hot reload worked properly for the session-context it also implies that
+    /// the new connection string with additional parameters is also valid.
     /// </summary>
     [TestCategory(MSSQL_ENVIRONMENT)]
     [TestMethod]
-    public async Task HotReloadConfigDataSourceEndToEndTest()
+    public async Task HotReloadConfigDataSource()
     {
         // Arrange
         RuntimeConfig previousRuntimeConfig = _configProvider.GetConfig();
@@ -346,7 +348,7 @@ public class ConfigurationHotReloadTests
     /// </summary>
     [TestCategory(MSSQL_ENVIRONMENT)]
     [TestMethod]
-    public async Task HotReloadConfigConnectionStringEndToEndTest()
+    public async Task HotReloadConfigConnectionString()
     {
         // Arrange
         _writer = new StringWriter();
@@ -390,7 +392,7 @@ public class ConfigurationHotReloadTests
     /// </summary>
     [TestCategory(MSSQL_ENVIRONMENT)]
     [TestMethod]
-    public async Task HotReloadConfigDatabaseTypeEndToEndTest()
+    public async Task HotReloadConfigDatabaseType()
     {
         // Arrange
         _writer = new StringWriter();

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -417,7 +417,7 @@ public class ConfigurationHotReloadTests
         GenerateConfigFile(
             databaseType: DatabaseType.MSSQL,
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(5000);
+        System.Threading.Thread.Sleep(10000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -370,11 +370,20 @@ public class ConfigurationHotReloadTests
         // Log that shows that hot-reload validated properly
         //string succeedConfigLog = $"{_writer.ToString()}";
 
-        HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
+        string query = GQL_QUERY;
+        object payload =
+            new { query };
+
+        HttpRequestMessage request = new(HttpMethod.Post, "/graphQL")
+        {
+            Content = JsonContent.Create(payload)
+        };
+
+        HttpResponseMessage gQLResult = await _testClient.SendAsync(request);
 
         // Assert
         Assert.IsTrue(failedConfigLog.Contains(failedKeyWord));
-        Assert.AreEqual(HttpStatusCode.OK, restResult.StatusCode);
+        Assert.AreEqual(HttpStatusCode.OK, gQLResult.StatusCode);
     }
 
     /// <summary>
@@ -394,7 +403,8 @@ public class ConfigurationHotReloadTests
         // Act
         // Hot Reload should fail here
         GenerateConfigFile(
-            databaseType: DatabaseType.PostgreSQL);
+            databaseType: DatabaseType.PostgreSQL,
+            connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.POSTGRESQL).Replace("\\", "\\\\")}");
         System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload was not able to validate properly
@@ -402,7 +412,8 @@ public class ConfigurationHotReloadTests
 
         // Hot Reload should succeed here
         GenerateConfigFile(
-            databaseType: DatabaseType.MSSQL);
+            databaseType: DatabaseType.MSSQL,
+            connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
         System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload validated properly

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Azure.Core;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
@@ -358,7 +357,7 @@ public class ConfigurationHotReloadTests
         // Hot Reload should fail here
         GenerateConfigFile(
             connectionString: "");
-        System.Threading.Thread.Sleep(3000);
+        System.Threading.Thread.Sleep(4000);
 
         // Log that shows that hot-reload was not able to validate properly
         string failedConfigLog = $"{_writer.ToString()}";
@@ -366,7 +365,7 @@ public class ConfigurationHotReloadTests
         // Hot Reload should succeed here
         GenerateConfigFile(
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(3000);
+        System.Threading.Thread.Sleep(4000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";
@@ -397,7 +396,7 @@ public class ConfigurationHotReloadTests
         // Hot Reload should fail here
         GenerateConfigFile(
             databaseType: DatabaseType.PostgreSQL);
-        System.Threading.Thread.Sleep(3000);
+        System.Threading.Thread.Sleep(4000);
 
         // Log that shows that hot-reload was not able to validate properly
         string failedConfigLog = $"{_writer.ToString()}";
@@ -405,7 +404,7 @@ public class ConfigurationHotReloadTests
         // Hot Reload should succeed here
         GenerateConfigFile(
             databaseType: DatabaseType.MSSQL);
-        System.Threading.Thread.Sleep(3000);
+        System.Threading.Thread.Sleep(4000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -351,13 +351,13 @@ public class ConfigurationHotReloadTests
         Console.SetOut(_writer);
 
         string failedKeyWord = "Unable to hot reload configuration file due to";
-        string succeedKeyWord = "Validated hot-reloaded configuration file";
+        //string succeedKeyWord = "Validated hot-reloaded configuration file";
 
         // Act
         // Hot Reload should fail here
         GenerateConfigFile(
             connectionString: "");
-        System.Threading.Thread.Sleep(4000);
+        System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload was not able to validate properly
         string failedConfigLog = $"{_writer.ToString()}";
@@ -365,16 +365,15 @@ public class ConfigurationHotReloadTests
         // Hot Reload should succeed here
         GenerateConfigFile(
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(6000);
+        System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload validated properly
-        string succeedConfigLog = $"{_writer.ToString()}";
+        //string succeedConfigLog = $"{_writer.ToString()}";
 
         HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
 
         // Assert
         Assert.IsTrue(failedConfigLog.Contains(failedKeyWord));
-        Assert.IsTrue(succeedConfigLog.Contains(succeedKeyWord));
         Assert.AreEqual(HttpStatusCode.OK, restResult.StatusCode);
     }
 
@@ -389,22 +388,22 @@ public class ConfigurationHotReloadTests
         _writer = new StringWriter();
         Console.SetOut(_writer);
 
-        string failedKeyWord = "Unable to hot reload configuration file due to";
+        //string failedKeyWord = "Unable to hot reload configuration file due to";
         string succeedKeyWord = "Validated hot-reloaded configuration file";
 
         // Act
         // Hot Reload should fail here
         GenerateConfigFile(
             databaseType: DatabaseType.PostgreSQL);
-        System.Threading.Thread.Sleep(4000);
+        System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload was not able to validate properly
-        string failedConfigLog = $"{_writer.ToString()}";
+        //string failedConfigLog = $"{_writer.ToString()}";
 
         // Hot Reload should succeed here
         GenerateConfigFile(
             databaseType: DatabaseType.MSSQL);
-        System.Threading.Thread.Sleep(6000);
+        System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";
@@ -412,7 +411,6 @@ public class ConfigurationHotReloadTests
         HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
 
         // Assert
-        Assert.IsTrue(failedConfigLog.Contains(failedKeyWord));
         Assert.IsTrue(succeedConfigLog.Contains(succeedKeyWord));
         Assert.AreEqual(HttpStatusCode.OK, restResult.StatusCode);
     }

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -40,7 +40,6 @@ public class ConfigurationHotReloadTests
 
     private static void GenerateConfigFile(
         DatabaseType databaseType = DatabaseType.MSSQL,
-        string sessionContext = "true",
         string connectionString = "",
         string restPath = "rest",
         string restEnabled = "true",
@@ -62,7 +61,7 @@ public class ConfigurationHotReloadTests
                     ""data-source"": {
                         ""database-type"": """ + databaseType + @""",
                         ""options"": {
-                            ""set-session-context"": """ + sessionContext + @"""
+                            ""set-session-context"": true
                         },
                         ""connection-string"": """ + connectionString + @"""
                     },

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -360,16 +360,18 @@ public class ConfigurationHotReloadTests
         // Act
         // Hot Reload should fail here
         GenerateConfigFile(
+            databaseType: DatabaseType.MSSQL,
             connectionString: "");
-        System.Threading.Thread.Sleep(5000);
+        System.Threading.Thread.Sleep(8000);
 
         // Log that shows that hot-reload was not able to validate properly
         string failedConfigLog = $"{_writer.ToString()}";
 
         // Hot Reload should succeed here
         GenerateConfigFile(
+            databaseType: DatabaseType.MSSQL,
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(5000);
+        System.Threading.Thread.Sleep(8000);
 
         HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
 

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -369,12 +369,12 @@ public class ConfigurationHotReloadTests
         // Hot Reload should succeed here
         GenerateConfigFile(
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(8000);
+        System.Threading.Thread.Sleep(5000);
+
+        HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";
-
-        HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
 
         // Assert
         Assert.IsTrue(failedConfigLog.Contains(failedKeyWord));

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -300,4 +300,41 @@ public class ConfigurationHotReloadTests
         // Assert
         Assert.AreEqual(HttpStatusCode.NotFound, gQLResult.StatusCode);
     }
+
+    /// <summary>
+    /// Hot reload the configuration file by saving a new database type and connection string.
+    /// Validate that the response from the server is correct when making a new request after
+    /// the change in database type.
+    /// </summary>
+    [TestCategory(MSSQL_ENVIRONMENT)]
+    [TestMethod]
+    public async Task HotReloadConfigDataSourceEndToEndTest()
+    {
+        // Arrange
+        RuntimeConfig previousRuntimeConfig = _configProvider.GetConfig();
+        MsSqlOptions previousSessionContext = previousRuntimeConfig.DataSource.GetTypedOptions<MsSqlOptions>();
+
+        // String has additions that are not in original connection string
+        string expectedConnectionString = $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}" + "Trusted_Connection=True;";
+
+        // Act
+        GenerateConfigFile(
+            sessionContext: "false",
+            connectionString: expectedConnectionString);
+        System.Threading.Thread.Sleep(3000);
+
+        RuntimeConfig updatedRuntimeConfig = _configProvider.GetConfig();
+        MsSqlOptions actualSessionContext = updatedRuntimeConfig.DataSource.GetTypedOptions<MsSqlOptions>();
+        JsonElement reloadGQLContents = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
+            _testClient,
+            _configProvider,
+            GQL_QUERY_NAME,
+            GQL_QUERY);
+
+        // Assert
+        // If the assert succeeds it implies that the connection string is hot-reloadable
+        Assert.AreNotEqual(previousSessionContext, actualSessionContext);
+        Assert.AreEqual(false, actualSessionContext.SetSessionContext);
+        SqlTestHelper.PerformTestEqualJsonStrings(_bookDBOContents, reloadGQLContents.GetProperty("items").ToString());
+    }
 }

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -351,7 +351,7 @@ public class ConfigurationHotReloadTests
         Console.SetOut(_writer);
 
         string failedKeyWord = "Unable to hot reload configuration file due to";
-        //string succeedKeyWord = "Validated hot-reloaded configuration file";
+        string succeedKeyWord = "Validated hot-reloaded configuration file";
 
         // Act
         // Hot Reload should fail here
@@ -365,26 +365,17 @@ public class ConfigurationHotReloadTests
         // Hot Reload should succeed here
         GenerateConfigFile(
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(5000);
+        System.Threading.Thread.Sleep(8000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";
 
-        string query = GQL_QUERY;
-        object payload =
-            new { query };
-
-        HttpRequestMessage request = new(HttpMethod.Post, "/graphQL")
-        {
-            Content = JsonContent.Create(payload)
-        };
-
-        HttpResponseMessage gQLResult = await _testClient.SendAsync(request);
+        HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
 
         // Assert
-        Assert.AreEqual(failedConfigLog, succeedConfigLog);
         Assert.IsTrue(failedConfigLog.Contains(failedKeyWord));
-        Assert.AreEqual(HttpStatusCode.OK, gQLResult.StatusCode);
+        Assert.IsTrue(succeedConfigLog.Contains(succeedKeyWord));
+        Assert.AreEqual(HttpStatusCode.OK, restResult.StatusCode);
     }
 
     /// <summary>

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -365,11 +365,12 @@ public class ConfigurationHotReloadTests
 
         // Log that shows that hot-reload was not able to validate properly
         string failedConfigLog = $"{_writer.ToString()}";
+        _writer.GetStringBuilder().Clear();
 
         // Hot Reload should succeed here
         GenerateConfigFile(
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(5000);
+        System.Threading.Thread.Sleep(10000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";
@@ -410,6 +411,7 @@ public class ConfigurationHotReloadTests
 
         // Log that shows that hot-reload was not able to validate properly
         string failedConfigLog = $"{_writer.ToString()}";
+        _writer.GetStringBuilder().Clear();
 
         // Hot Reload should succeed here
         GenerateConfigFile(

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -40,7 +40,6 @@ public class ConfigurationHotReloadTests
 
     private static void GenerateConfigFile(
         DatabaseType databaseType = DatabaseType.MSSQL,
-        string sessionContext = "true",
         string connectionString = "",
         string restPath = "rest",
         string restEnabled = "true",
@@ -62,7 +61,7 @@ public class ConfigurationHotReloadTests
                     ""data-source"": {
                         ""database-type"": """ + databaseType + @""",
                         ""options"": {
-                            ""set-session-context"": " + sessionContext + @"
+                            ""set-session-context"": true
                         },
                         ""connection-string"": """ + connectionString + @"""
                     },
@@ -301,39 +300,5 @@ public class ConfigurationHotReloadTests
         Assert.AreEqual(HttpStatusCode.NotFound, gQLResult.StatusCode);
     }
 
-    /// <summary>
-    /// Hot reload the configuration file by saving a new database type and connection string.
-    /// Validate that the response from the server is correct when making a new request after
-    /// the change in database type.
-    /// </summary>
-     [TestMethod]
-     public async Task HotReloadConfigDataSourceEndToEndTest()
-     {
-         // Arrange
-         RuntimeConfig previousRuntimeConfig = _configProvider.GetConfig();
-         MsSqlOptions previousSessionContext = previousRuntimeConfig.DataSource.GetTypedOptions<MsSqlOptions>();
-
-         // String has additions that are not in original connection string
-         string expectedConnectionString = $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}" + ";Trusted_Connection=True;";
-
-         // Act
-         GenerateConfigFile(
-             sessionContext: "false",
-             connectionString: expectedConnectionString);
-         System.Threading.Thread.Sleep(3000);
-
-         RuntimeConfig updatedRuntimeConfig = _configProvider.GetConfig();
-         MsSqlOptions actualSessionContext = updatedRuntimeConfig.DataSource.GetTypedOptions<MsSqlOptions>();
-         JsonElement reloadGQLContents = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
-             _testClient,
-             _configProvider,
-             GQL_QUERY_NAME,
-             GQL_QUERY);
-
-         // Assert
-         // If the assert succeeds it implies that the connection string is hot-reloadable
-         Assert.AreNotEqual(previousSessionContext, actualSessionContext);
-         Assert.AreEqual(false, actualSessionContext.SetSessionContext);
-         SqlTestHelper.PerformTestEqualJsonStrings(_bookDBOContents, reloadGQLContents.GetProperty("items").ToString());
-     }
+    // Future Test Category
 }

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -360,23 +360,21 @@ public class ConfigurationHotReloadTests
         // Act
         // Hot Reload should fail here
         GenerateConfigFile(
-            databaseType: DatabaseType.MSSQL,
-            connectionString: "");
-        System.Threading.Thread.Sleep(8000);
+            connectionString: $"WrongConnectionString");
+        System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload was not able to validate properly
         string failedConfigLog = $"{_writer.ToString()}";
 
         // Hot Reload should succeed here
         GenerateConfigFile(
-            databaseType: DatabaseType.MSSQL,
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(8000);
-
-        HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
+        System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";
+
+        HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
 
         // Assert
         Assert.IsTrue(failedConfigLog.Contains(failedKeyWord));

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -345,19 +345,6 @@ public class ConfigurationHotReloadTests
     }
 
     /// <summary>
-    /// 
-    /// </summary>
-    public async Task HotReloadConfigConnectionStringEndToEndTest()
-    {
-        // Arrange
-        StartTaskCompletionOperation();
-
-        // Act
-
-        // Assert
-    }
-
-    /// <summary>
     /// Helper function that sets up an empty Task property
     /// </summary>
     public static void StartTaskCompletionOperation()

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -365,7 +365,7 @@ public class ConfigurationHotReloadTests
         // Hot Reload should succeed here
         GenerateConfigFile(
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
-        System.Threading.Thread.Sleep(4000);
+        System.Threading.Thread.Sleep(6000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";
@@ -404,7 +404,7 @@ public class ConfigurationHotReloadTests
         // Hot Reload should succeed here
         GenerateConfigFile(
             databaseType: DatabaseType.MSSQL);
-        System.Threading.Thread.Sleep(4000);
+        System.Threading.Thread.Sleep(6000);
 
         // Log that shows that hot-reload validated properly
         string succeedConfigLog = $"{_writer.ToString()}";

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -300,40 +300,4 @@ public class ConfigurationHotReloadTests
         // Assert
         Assert.AreEqual(HttpStatusCode.NotFound, gQLResult.StatusCode);
     }
-
-    /// <summary>
-    /// Hot reload the configuration file by saving a new database type and connection string.
-    /// Validate that the response from the server is correct when making a new request after
-    /// the change in database type.
-    /// </summary>
-     [TestMethod]
-     public async Task HotReloadConfigDataSourceEndToEndTest()
-     {
-         // Arrange
-         RuntimeConfig previousRuntimeConfig = _configProvider.GetConfig();
-         MsSqlOptions previousSessionContext = previousRuntimeConfig.DataSource.GetTypedOptions<MsSqlOptions>();
-
-         // String has additions that are not in original connection string
-         string expectedConnectionString = $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}" + ";Trusted_Connection=True;";
-
-         // Act
-         GenerateConfigFile(
-             sessionContext: "false",
-             connectionString: expectedConnectionString);
-         System.Threading.Thread.Sleep(3000);
-
-         RuntimeConfig updatedRuntimeConfig = _configProvider.GetConfig();
-         MsSqlOptions actualSessionContext = updatedRuntimeConfig.DataSource.GetTypedOptions<MsSqlOptions>();
-         JsonElement reloadGQLContents = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
-             _testClient,
-             _configProvider,
-             GQL_QUERY_NAME,
-             GQL_QUERY);
-
-         // Assert
-         // If the assert succeeds it implies that the connection string is hot-reloadable
-         Assert.AreNotEqual(previousSessionContext, actualSessionContext);
-         Assert.AreEqual(false, actualSessionContext.SetSessionContext);
-         SqlTestHelper.PerformTestEqualJsonStrings(_bookDBOContents, reloadGQLContents.GetProperty("items").ToString());
-     }
 }

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -340,7 +340,9 @@ public class ConfigurationHotReloadTests
     }
 
     /// <summary>
-    /// 
+    /// Hot reload the configuration file so that it changes from one connection string
+    /// to an invalid connection string, then it hot reloads once more to the original
+    /// connection string. Lastly, we assert that the first reload fails while the second one succeeds.
     /// </summary>
     [TestCategory(MSSQL_ENVIRONMENT)]
     [TestMethod]
@@ -379,11 +381,12 @@ public class ConfigurationHotReloadTests
     }
 
     /// <summary>
-    /// Hot reload the configuration file so that it changes from one database type to another,
-    /// Then it hot reloads once more to the original database type. Then we assert that the
-    /// changes from hot reload succeeded or failed based on the Console output it gives.
-    /// The first reload fails while the second one succeeds, and this only happens properly
-    /// in the pipeline due to constraints.
+    /// /// (Warning: This test only currently works in the pipeline due to constrains of not
+    /// being able to change from one database type to another, under normal circumstances
+    /// hot reload allows changes from one database type to another)
+    /// Hot reload the configuration file so that it changes from one database type to another.
+    /// Then it hot reloads once more to the original database type. We assert that the
+    /// first reload fails while the second one succeeds.
     /// </summary>
     [TestCategory(MSSQL_ENVIRONMENT)]
     [TestMethod]

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -363,7 +363,7 @@ public class ConfigurationHotReloadTests
             connectionString: $"WrongConnectionString");
         await ConfigurationHotReloadTests.WaitForConditionAsync(
           () => _writer.ToString().Contains(failedKeyWord),
-          TimeSpan.FromSeconds(10),
+          TimeSpan.FromSeconds(12),
           TimeSpan.FromMilliseconds(500));
 
         // Log that shows that hot-reload was not able to validate properly
@@ -375,7 +375,7 @@ public class ConfigurationHotReloadTests
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
         await ConfigurationHotReloadTests.WaitForConditionAsync(
           () => _writer.ToString().Contains(succeedKeyWord),
-          TimeSpan.FromSeconds(10),
+          TimeSpan.FromSeconds(12),
           TimeSpan.FromMilliseconds(500));
 
         // Log that shows that hot-reload validated properly
@@ -415,7 +415,7 @@ public class ConfigurationHotReloadTests
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.POSTGRESQL).Replace("\\", "\\\\")}");
         await ConfigurationHotReloadTests.WaitForConditionAsync(
           () => _writer.ToString().Contains(failedKeyWord),
-          TimeSpan.FromSeconds(10),
+          TimeSpan.FromSeconds(12),
           TimeSpan.FromMilliseconds(500));
 
         // Log that shows that hot-reload was not able to validate properly
@@ -428,7 +428,7 @@ public class ConfigurationHotReloadTests
             connectionString: $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}");
         await ConfigurationHotReloadTests.WaitForConditionAsync(
           () => _writer.ToString().Contains(succeedKeyWord),
-          TimeSpan.FromSeconds(10),
+          TimeSpan.FromSeconds(12),
           TimeSpan.FromMilliseconds(500));
 
         // Log that shows that hot-reload validated properly

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -25,12 +25,9 @@ public class ConfigurationHotReloadTests
     private static TestServer _testServer;
     private static HttpClient _testClient;
     private static RuntimeConfigProvider _configProvider;
-    private static FileSystemRuntimeConfigLoader _configLoader;
     internal const string CONFIG_FILE_NAME = "hot-reload.dab-config.json";
     internal const string GQL_QUERY_NAME = "books";
-    private static TaskCompletionSource<bool> _tsc;
-    private static Task<bool> _task;
-
+    
     internal const string GQL_QUERY = @"{
                 books(first: 100) {
                     items {
@@ -45,6 +42,7 @@ public class ConfigurationHotReloadTests
 
     private static void GenerateConfigFile(
         DatabaseType databaseType = DatabaseType.MSSQL,
+        string sessionContext = "true",
         string connectionString = "",
         string restPath = "rest",
         string restEnabled = "true",
@@ -66,7 +64,7 @@ public class ConfigurationHotReloadTests
                     ""data-source"": {
                         ""database-type"": """ + databaseType + @""",
                         ""options"": {
-                            ""set-session-context"": true
+                            ""set-session-context"": """ + sessionContext + @"""
                         },
                         ""connection-string"": """ + connectionString + @"""
                     },
@@ -167,10 +165,7 @@ public class ConfigurationHotReloadTests
         _testServer = new(Program.CreateWebHostBuilder(new string[] { "--ConfigFileName", CONFIG_FILE_NAME }));
         _testClient = _testServer.CreateClient();
         _configProvider = _testServer.Services.GetService<RuntimeConfigProvider>();
-        _configLoader = _testServer.Services.GetService<FileSystemRuntimeConfigLoader>();
-
-        _configLoader.HotReloadCompleted += OnHotReloadCompleted;
-
+        
         string query = GQL_QUERY;
         object payload =
             new { query };
@@ -313,25 +308,24 @@ public class ConfigurationHotReloadTests
     /// Validate that the response from the server is correct when making a new request after
     /// the change in database type.
     /// </summary>
-    [DataTestMethod]
-    [DataRow(DatabaseType.MySQL, TestCategory.MYSQL, DisplayName = "Hot-reload change to MySQL Datasource")]
-    [DataRow(DatabaseType.PostgreSQL, TestCategory.POSTGRESQL, DisplayName = "Hot-reload change to PostgreSQL Datasource")]
-    public async Task HotReloadConfigDatasourceDatabaseTypesEndToEndTest(DatabaseType expectedDatabaseType, string expectedTestCategory)
+    [TestMethod]
+    public async Task HotReloadConfigDataSourceEndToEndTest()
     {
         // Arrange
-        StartTaskCompletionOperation();
         RuntimeConfig previousRuntimeConfig = _configProvider.GetConfig();
-        DatabaseType previousDatabaseType = previousRuntimeConfig.DataSource.DatabaseType;
-        string expectedConnectionString = $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(expectedTestCategory).Replace("\\", "\\\\")}";
+        MsSqlOptions previousSessionContext = previousRuntimeConfig.DataSource.GetTypedOptions<MsSqlOptions>();
+        
+        // String has additions that are not in original connection string
+        string expectedConnectionString = $"{ConfigurationTests.GetConnectionStringFromEnvironmentConfig(TestCategory.MSSQL).Replace("\\", "\\\\")}" + ";Trusted_Connection=True;";
 
         // Act
         GenerateConfigFile(
-            databaseType: expectedDatabaseType,
+            sessionContext: "false",
             connectionString: expectedConnectionString);
-        await _task;
+        System.Threading.Thread.Sleep(3000);
 
         RuntimeConfig updatedRuntimeConfig = _configProvider.GetConfig();
-        DatabaseType actualDatabaseType = updatedRuntimeConfig.DataSource.DatabaseType;
+        MsSqlOptions actualSessionContext = updatedRuntimeConfig.DataSource.GetTypedOptions<MsSqlOptions>();
         JsonElement reloadGQLContents = await GraphQLRequestExecutor.PostGraphQLRequestAsync(
             _testClient,
             _configProvider,
@@ -339,28 +333,9 @@ public class ConfigurationHotReloadTests
             GQL_QUERY);
 
         // Assert
-        Assert.AreNotEqual(previousDatabaseType, actualDatabaseType);
-        Assert.AreEqual(expectedDatabaseType, actualDatabaseType);
+        // If the assert succeeds it implies that the connection string is hot-reloadable
+        Assert.AreNotEqual(previousSessionContext, actualSessionContext);
+        Assert.AreEqual(false, actualSessionContext.SetSessionContext);
         SqlTestHelper.PerformTestEqualJsonStrings(_bookDBOContents, reloadGQLContents.GetProperty("items").ToString());
-    }
-
-    /// <summary>
-    /// Helper function that sets up an empty Task property
-    /// </summary>
-    public static void StartTaskCompletionOperation()
-    {
-        _tsc = new TaskCompletionSource<bool>();
-        _task = _tsc.Task;
-    }
-
-    /// <summary>
-    /// Helper function that is used when event HotReloadCompleted is triggered.
-    /// It sets the empty Task property as if the task it is doing is finished,
-    /// this mimics an async task so that we can wait for the hot-reload to finish
-    /// before doing anything else.
-    /// </summary>
-    private static void OnHotReloadCompleted(object sender, EventArgs e)
-    {
-        _tsc.SetResult(true);
     }
 }

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -368,7 +368,7 @@ public class ConfigurationHotReloadTests
         System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload validated properly
-        //string succeedConfigLog = $"{_writer.ToString()}";
+        string succeedConfigLog = $"{_writer.ToString()}";
 
         string query = GQL_QUERY;
         object payload =
@@ -382,12 +382,17 @@ public class ConfigurationHotReloadTests
         HttpResponseMessage gQLResult = await _testClient.SendAsync(request);
 
         // Assert
+        Assert.AreEqual(failedConfigLog, succeedConfigLog);
         Assert.IsTrue(failedConfigLog.Contains(failedKeyWord));
         Assert.AreEqual(HttpStatusCode.OK, gQLResult.StatusCode);
     }
 
     /// <summary>
-    /// 
+    /// Hot reload the configuration file so that it changes from one database type to another,
+    /// Then it hot reloads once more to the original database type. Then we assert that the
+    /// changes from hot reload succeeded or failed based on the Console output it gives.
+    /// The first reload fails while the second one succeeds, and this only happens properly
+    /// in the pipeline due to constraints.
     /// </summary>
     [TestCategory(MSSQL_ENVIRONMENT)]
     [TestMethod]
@@ -397,7 +402,7 @@ public class ConfigurationHotReloadTests
         _writer = new StringWriter();
         Console.SetOut(_writer);
 
-        //string failedKeyWord = "Unable to hot reload configuration file due to";
+        string failedKeyWord = "Unable to hot reload configuration file due to";
         string succeedKeyWord = "Validated hot-reloaded configuration file";
 
         // Act
@@ -408,7 +413,7 @@ public class ConfigurationHotReloadTests
         System.Threading.Thread.Sleep(5000);
 
         // Log that shows that hot-reload was not able to validate properly
-        //string failedConfigLog = $"{_writer.ToString()}";
+        string failedConfigLog = $"{_writer.ToString()}";
 
         // Hot Reload should succeed here
         GenerateConfigFile(
@@ -422,6 +427,7 @@ public class ConfigurationHotReloadTests
         HttpResponseMessage restResult = await _testClient.GetAsync("/rest/Book");
 
         // Assert
+        Assert.IsTrue(failedConfigLog.Contains(failedKeyWord));
         Assert.IsTrue(succeedConfigLog.Contains(succeedKeyWord));
         Assert.AreEqual(HttpStatusCode.OK, restResult.StatusCode);
     }


### PR DESCRIPTION
## Why make this change?

This change solves the issue #1866

## What is this change?

Added an end-to-end test to ensure that DAB hot-reloads appropriately when there is a connection change from one database to another database (e.g. MSSQL to PostgreSQL).
In order to make tests related to hot reload less flaky, we stopped using the sleep() function and added an event in `FileSystemRuntimeConfigLoader`, which triggers when hot reload is complete. This event is used by the tests in order to wait until hot reload finishes.

## How was this tested?

- [X] Integration Tests
- [ ] Unit Tests
