### PR TITLE
Add exponential backoff to reading config file

### DIFF
--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -9,7 +9,6 @@ using System.Text.Json;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Config.Utilities;
 using Azure.DataApiBuilder.Service.Exceptions;
-using Humanizer;
 using Microsoft.Extensions.Logging;
 
 namespace Azure.DataApiBuilder.Config;

--- a/src/Config/FileSystemRuntimeConfigLoader.cs
+++ b/src/Config/FileSystemRuntimeConfigLoader.cs
@@ -209,6 +209,7 @@ public class FileSystemRuntimeConfigLoader : RuntimeConfigLoader
                 try
                 {
                     json = _fileSystem.File.ReadAllText(path);
+                    break;
                 }
                 catch (IOException ex)
                 {

--- a/src/Config/Utilities/FileUtilities.cs
+++ b/src/Config/Utilities/FileUtilities.cs
@@ -11,14 +11,14 @@ internal class FileUtilities
     /// <summary>
     /// Limit the number of retries when failures occur.
     /// </summary>
-    private static readonly int _runLimit = 3;
+    public static readonly int RunLimit = 3;
 
     /// <summary>
     /// Base of the exponential retry back-off.
     /// -> base ^ runCount
     /// e.g. 2^1 , 2^2, 2^3, etc.
     /// </summary>
-    private static readonly int _exponentialRetryBase = 2;
+    public static readonly int ExponentialRetryBase = 2;
 
     /// <summary>
     /// Computes the SHA256 hash for the input data (file contents) at the given path.
@@ -42,7 +42,7 @@ internal class FileUtilities
         int runCount = 1;
 
         // Maximum 2^_runLimit seconds of wait time due to retries.
-        while (runCount <= _runLimit)
+        while (runCount <= RunLimit)
         {
             try
             {
@@ -73,7 +73,7 @@ internal class FileUtilities
                     throw;
                 }
 
-                Thread.Sleep(TimeSpan.FromSeconds(Math.Pow(_exponentialRetryBase, runCount)));
+                Thread.Sleep(TimeSpan.FromSeconds(Math.Pow(ExponentialRetryBase, runCount)));
                 runCount++;
             }
         }

--- a/src/Config/Utilities/FileUtilities.cs
+++ b/src/Config/Utilities/FileUtilities.cs
@@ -41,7 +41,7 @@ internal class FileUtilities
         // Exponential back-off retry mechanism.
         int runCount = 1;
 
-        // Maximum 2^_runLimit seconds of wait time due to retries.
+        // Maximum 2^RunLimit seconds of wait time due to retries.
         while (runCount <= RunLimit)
         {
             try

--- a/src/Config/Utilities/FileUtilities.cs
+++ b/src/Config/Utilities/FileUtilities.cs
@@ -68,7 +68,7 @@ internal class FileUtilities
             catch (IOException ex)
             {
                 Console.WriteLine($"IO Exception, retrying due to {ex.Message}");
-                if (runCount == 3)
+                if (runCount == RunLimit)
                 {
                     throw;
                 }


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/2119

## What is this change?

We add a try catch around the file reading in the `FileSystemRuntimeConfigLoader` class, and implement an exponential backoff for reading said file.

## How was this tested?

Manually tested and ran against the test suite. A manual test can be run by having an editor with the file in question open and then closing the editor during the reading process.

## Sample Request(s)

N/A
