### PR TITLE
Adding numeric type support for data api builder

### DIFF
--- a/src/Core/Models/SqlTypeConstants.cs
+++ b/src/Core/Models/SqlTypeConstants.cs
@@ -48,5 +48,6 @@ public static class SqlTypeConstants
         { "datetime2", true },            // SqlDbType.DateTime2
         { "datetimeoffset", true },       // SqlDbType.DateTimeOffset
         { "", false },                    // SqlDbType.Udt and SqlDbType.Structured provided by SQL as empty strings (unsupported)
+        { "numeric", true}                // Not present in SqlDbType, however can be returned by sql functions like LAG and should map to decimal.
     };
 }

--- a/src/Core/Services/TypeHelper.cs
+++ b/src/Core/Services/TypeHelper.cs
@@ -111,7 +111,7 @@ namespace Azure.DataApiBuilder.Core.Services
             [SqlDbType.TinyInt] = typeof(byte),
             [SqlDbType.UniqueIdentifier] = typeof(Guid),
             [SqlDbType.VarBinary] = typeof(byte[]),
-            [SqlDbType.VarChar] = typeof(string)
+            [SqlDbType.VarChar] = typeof(string),
         };
 
         private static Dictionary<SqlDbType, DbType> _sqlDbDateTimeTypeToDbType = new()
@@ -276,6 +276,10 @@ namespace Azure.DataApiBuilder.Core.Services
                 {
                     return value;
                 }
+            }
+            else if (baseType.Equals("numeric", StringComparison.OrdinalIgnoreCase))
+            {
+                return typeof(decimal);
             }
 
             throw new DataApiBuilderException(


### PR DESCRIPTION
## Why make this change?
Addresses bug #2059 

## What is this change?
adds support for the numeric data type.

## How was this tested?
Unit test added.
