### PR TITLE
Use most recent version of Microsoft.Extensions.Configuration

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -31,7 +31,7 @@
         <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
         <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.4" />
         <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
         <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />
         <PackageVersion Include="Microsoft.IdentityModel.OpenIdConnect" Version="8.1.2" />


### PR DESCRIPTION
## Why make this change?

We need to use the most up to date version Microsoft.Extensions.Configuration

## What is this change?

By removing the explicit version from the Directory.Packages.Props file we will automatically get the most up to date version. This can be validated in the project.assets.json generated for each project that uses the above package, in particular the Core and Services projects.

## How was this tested?

Run against our normal test suite.

## Sample Request(s)

N/A
