### PR TITLE
Update Dockerfile with correct string format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS runtime
 
 COPY --from=build /out /App
 WORKDIR /App
-ENV ASPNETCORE_URLS="http://localhost:5000"
+ENV ASPNETCORE_URLS="http://0.0.0.0:5000"
 ENTRYPOINT ["dotnet", "Azure.DataApiBuilder.Service.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS runtime
 
 COPY --from=build /out /App
 WORKDIR /App
-ENV ASPNETCORE_URLS="http://+:5000"
+ENV ASPNETCORE_URLS=http://+:5000
 ENTRYPOINT ["dotnet", "Azure.DataApiBuilder.Service.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS runtime
 
 COPY --from=build /out /App
 WORKDIR /App
-ENV ASPNETCORE_URLS=http://+:5000
+ENV ASPNETCORE_URLS="http://localhost:5000"
 ENTRYPOINT ["dotnet", "Azure.DataApiBuilder.Service.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS runtime
 
 COPY --from=build /out /App
 WORKDIR /App
-ENV ASPNETCORE_URLS="http://0.0.0.0:5000"
+ENV ASPNETCORE_URLS="http://+:5000"
 ENTRYPOINT ["dotnet", "Azure.DataApiBuilder.Service.dll"]

--- a/src/Service.Tests/Unittests/EnvironmentTests.cs
+++ b/src/Service.Tests/Unittests/EnvironmentTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Azure.DataApiBuilder.Service.Tests.UnitTests;
@@ -13,6 +14,8 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests;
 [TestClass]
 public class EnvironmentTests
 {
+    private const string ASPNETCORE_URLS_NAME = "ASPNETCORE_URLS";
+
     /// <summary>
     /// Tests the behavior of the <c>Main</c> method when the <c>ASPNETCORE_URLS</c> environment variable is set to an invalid value.
     /// </summary>
@@ -24,7 +27,6 @@ public class EnvironmentTests
     [TestMethod]
     public void Main_WhenAspNetCoreUrlsInvalid_ShouldExitWithError()
     {
-        const string ASPNETCORE_URLS_NAME = "ASPNETCORE_URLS";
         const string ASPNETCORE_URLS_INVALID_VALUE = nameof(Main_WhenAspNetCoreUrlsInvalid_ShouldExitWithError);
         string originalEnvValue = Environment.GetEnvironmentVariable(ASPNETCORE_URLS_NAME);
 
@@ -39,6 +41,57 @@ public class EnvironmentTests
         // Assert
         Assert.AreEqual(-1, Environment.ExitCode);
         StringAssert.Contains(consoleOutput.ToString(), ASPNETCORE_URLS_NAME, StringComparison.Ordinal);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable(ASPNETCORE_URLS_NAME, originalEnvValue);
+    }
+
+    /// <summary>
+    /// Tests the `ValidateAspNetCoreUrls` method with various inputs to ensure it correctly validates URLs.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow(null, true, DisplayName = "null input")]
+    [DataRow("", true, DisplayName = "empty string")]
+    [DataRow(" ", false, DisplayName = "whitespace only")]
+    [DataRow("http://localhost", true, DisplayName = "valid URL")]
+    [DataRow("https://localhost", true, DisplayName = "valid secure URL")]
+    [DataRow("http://127.0.0.1:5000", true, DisplayName = "valid IP URL")]
+    [DataRow("https://127.0.0.1:5001", true, DisplayName = "valid secure IP URL")]
+    [DataRow("http://[::1]:80", true, DisplayName = "valid IPv6 URL")]
+    [DataRow("https://[::1]:443", true, DisplayName = "valid secure IPv6 URL")]
+    [DataRow("http://+:80/", true, DisplayName = "wildcard '+' host")]
+    [DataRow("https://+:443/", true, DisplayName = "secure wildcard '+' host")]
+    [DataRow("http://*:80/", true, DisplayName = "wildcard '*' host")]
+    [DataRow("https://*:443/", true, DisplayName = "secure wildcard '*' host")]
+    [DataRow("http://localhost:80/;https://localhost:443/", true, DisplayName = "semicolon-separated URLs")]
+    [DataRow("http://localhost:80/ https://localhost:443/", true, DisplayName = "space-separated URLs")]
+    [DataRow("http://localhost:80/,https://localhost:443/", true, DisplayName = "comma-separated URLs")]
+    [DataRow("ftp://localhost:21", false, DisplayName = "invalid scheme (ftp)")]
+    [DataRow("localhost:80", false, DisplayName = "missing scheme")]
+    [DataRow("http://", false, DisplayName = "incomplete URL")]
+    [DataRow("http://unix:/var/run/app.sock", true, DisplayName = "unix socket (Linux)")]
+    [DataRow("https://unix:/var/run/app.sock", true, DisplayName = "secure unix socket (Linux)")]
+    [DataRow("http://unix:var/run/app.sock", false, DisplayName = "unix socket missing slash")]
+    [DataRow("http://unix:", false, DisplayName = "unix socket missing path")]
+    [DataRow("http://unix:/var/run/app.sock;https://unix:/var/run/app2.sock", true, DisplayName = "multiple unix sockets (Linux)")]
+    [DataRow("http://localhost:80/;ftp://localhost:21", false, DisplayName = "mixed valid/invalid schemes")]
+    [DataRow("  http://localhost:80/  ", true, DisplayName = "trimmed whitespace")]
+    public void ValidateAspNetCoreUrls_Test(string input, bool expected)
+    {
+        // Arrange
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+            input is not null &&
+            (input.StartsWith("http://unix:", StringComparison.OrdinalIgnoreCase) ||
+            input.StartsWith("https://unix:", StringComparison.OrdinalIgnoreCase)))
+        {
+            expected = false;
+        }
+
+        string originalEnvValue = Environment.GetEnvironmentVariable(ASPNETCORE_URLS_NAME);
+        Environment.SetEnvironmentVariable(ASPNETCORE_URLS_NAME, input);
+        
+        // Act
+        Assert.AreEqual(expected, Program.ValidateAspNetCoreUrls());
 
         // Cleanup
         Environment.SetEnvironmentVariable(ASPNETCORE_URLS_NAME, originalEnvValue);

--- a/src/Service.Tests/Unittests/EnvironmentTests.cs
+++ b/src/Service.Tests/Unittests/EnvironmentTests.cs
@@ -89,7 +89,7 @@ public class EnvironmentTests
 
         string originalEnvValue = Environment.GetEnvironmentVariable(ASPNETCORE_URLS_NAME);
         Environment.SetEnvironmentVariable(ASPNETCORE_URLS_NAME, input);
-        
+
         // Act
         Assert.AreEqual(expected, Program.ValidateAspNetCoreUrls());
 


### PR DESCRIPTION
## Why make this change?

- Closes #2546
  - Due to new validations intorduced in https://github.com/Azure/data-api-builder/pull/2466 , old Dockerfile was failing to start the engine.

## What is this change?
As highlighted in #2466 
![image](https://github.com/user-attachments/assets/33bc790a-57d3-4df1-bd32-eeb40b7de4fa)

We have to update our Docker file 
from:
![image](https://github.com/user-attachments/assets/f33bca5b-1411-455c-926f-2e0a0e27e01d)

to:
![image](https://github.com/user-attachments/assets/0a3189ed-97a5-46e5-9d01-a1f605b832bd)





## How was this tested?

- Created a work item to update the release checklist to verify docker image is running as expected to avoid such regressions in future.
- Validated locally and was able to start the engine successfully.

![image](https://github.com/user-attachments/assets/d4dfea55-1079-4f14-9056-a3e7e25c11a2)




