### PR TITLE
Cosmos DB: Improve Error message During Schema Generation

### DIFF
--- a/src/Cli/Exporter.cs
+++ b/src/Cli/Exporter.cs
@@ -119,7 +119,7 @@ namespace Cli
 
             if (string.IsNullOrEmpty(schemaText))
             {
-                logger.LogError("Generated GraphQL schema is empty. Please check if you have data to generate the schema out of it.");
+                logger.LogError("Generated GraphQL schema is empty. Please ensure data is available to generate the schema.");
                 return;
             }
 

--- a/src/Cli/Exporter.cs
+++ b/src/Cli/Exporter.cs
@@ -80,6 +80,10 @@ namespace Cli
                     logger.LogError("Failed to export GraphQL schema.");
                 }
             }
+            else
+            {
+                logger.LogError("Exporting GraphQL schema is not enabled. You need to pass --graphql.");
+            }
 
             _cancellationTokenSource.Cancel();
             return isSuccess;
@@ -115,7 +119,7 @@ namespace Cli
 
             if (string.IsNullOrEmpty(schemaText))
             {
-                logger.LogError("Failed to export the GraphQL schema.");
+                logger.LogError("Generated GraphQL schema is empty. Please check if you have data to generate the schema out of it.");
                 return;
             }
 

--- a/src/Core/Generator/SchemaGenerator.cs
+++ b/src/Core/Generator/SchemaGenerator.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Humanizer;
+using Microsoft.Extensions.Logging;
 using static System.Text.Json.JsonElement;
 
 namespace Azure.DataApiBuilder.Core.Generator
@@ -18,6 +19,8 @@ namespace Azure.DataApiBuilder.Core.Generator
     {
         // Azure Cosmos DB reserved properties, these properties will be ignored in the schema generation as they are not user-defined properties.
         private readonly List<string> _cosmosDbReservedProperties = new() { "_ts", "_etag", "_rid", "_self", "_attachments" };
+
+        private readonly ILogger? _logger;
 
         // Maps GraphQL entities to their corresponding attributes.
         private Dictionary<string, HashSet<AttributeObject>> _attrMapping = new();
@@ -35,19 +38,25 @@ namespace Azure.DataApiBuilder.Core.Generator
         /// <param name="data">A list of JSON documents to be used to generate the schema.</param>
         /// <param name="containerName">The name of the Azure Cosmos DB container which is used to generate the GraphQL schema.</param>
         /// <param name="config">Optional configuration that maps GraphQL entity names to their singular forms.</param>
-        private SchemaGenerator(List<JsonDocument> data, string containerName, RuntimeConfig? config)
+        /// <param name="logger">Optional Logger</param>
+        private SchemaGenerator(List<JsonDocument> data, string containerName, RuntimeConfig? config, ILogger? logger)
         {
+            this._logger = logger;
+
             this._data = data;
             this._containerName = containerName;
             if (config != null)
             {
+                if (config.Entities == null || config.Entities.Count() == 0)
+                {
+                    throw new Exception("Define one or more entities to generate the schema in the config file. ");
+                }
                 // Populate entity and singular name mapping if configuration is provided.
                 foreach (KeyValuePair<string, Entity> item in config.Entities)
                 {
                     _entityAndSingularNameMapping.Add(item.Value.GraphQL.Singular.Pascalize(), item.Key);
                 }
             }
-
         }
 
         /// <summary>
@@ -56,19 +65,29 @@ namespace Azure.DataApiBuilder.Core.Generator
         /// <param name="jsonData">A list of JSON documents to generate the schema from.</param>
         /// <param name="containerName">The name of the Azure Cosmos DB container.</param>
         /// <param name="config">Optional configuration that maps GraphQL entity names to their singular forms.</param>
+        /// <param name="logger">Optional Logger</param>
         /// <returns>A string representing the generated GraphQL schema.</returns>
         /// <exception cref="InvalidOperationException">Thrown if the JSON data is empty or the container name is null or empty.</exception>
-        public static string Generate(List<JsonDocument> jsonData, string containerName, RuntimeConfig? config = null)
+        public static string Generate(List<JsonDocument> jsonData, string containerName, RuntimeConfig? config = null, ILogger? logger = null)
         {
             // Validate input parameters.
-            if (jsonData == null || jsonData.Count == 0 || string.IsNullOrEmpty(containerName))
+            if (string.IsNullOrEmpty(containerName))
             {
-                throw new InvalidOperationException("There must be at least one JSON object and Container Name can not be blank");
+                throw new InvalidOperationException("Container Name can not be blank");
+            }
+
+            if(jsonData == null || jsonData.Count == 0)
+            {
+                logger?.LogWarning($"No JSON data found to generate schema, from Container: {containerName}");
+                return string.Empty;
             }
 
             // Create an instance of SchemaGenerator and generate the schema.
-            return new SchemaGenerator(jsonData, containerName.Singularize(), config)
-                        .ConvertJsonToGQLSchema();
+            return new SchemaGenerator(jsonData,
+                        containerName.Singularize(),
+                        config,
+                        logger)
+                  .ConvertJsonToGQLSchema();
         }
 
         /// <summary>
@@ -144,6 +163,11 @@ namespace Azure.DataApiBuilder.Core.Generator
                 sb.AppendLine("}");
             }
 
+            if (sb.Length == 0)
+            {
+                _logger?.LogWarning("Generated Schema is empty.");
+            }
+
             return sb.ToString();
         }
 
@@ -165,6 +189,7 @@ namespace Azure.DataApiBuilder.Core.Generator
                 // Check if the parent type is not in the entity mapping.
                 if (_entityAndSingularNameMapping.Count != 0 && !_entityAndSingularNameMapping.ContainsKey(parentType.Pascalize()))
                 {
+                    _logger?.LogWarning($"{parentType.Pascalize()} is not available, If it is unexpected, add an entry of it, in the config file.");
                     continue;
                 }
 

--- a/src/Core/Generator/SchemaGenerator.cs
+++ b/src/Core/Generator/SchemaGenerator.cs
@@ -189,7 +189,7 @@ namespace Azure.DataApiBuilder.Core.Generator
                 // Check if the parent type is not in the entity mapping.
                 if (_entityAndSingularNameMapping.Count != 0 && !_entityAndSingularNameMapping.ContainsKey(parentType.Pascalize()))
                 {
-                    _logger?.LogWarning($"{parentType.Pascalize()} is not available, If it is unexpected, add an entry of it, in the config file.");
+                    _logger?.LogWarning($"{parentType.Pascalize()} is not available, If it is unexpected, add an entity of it, in the config file.");
                     continue;
                 }
 

--- a/src/Core/Generator/SchemaGenerator.cs
+++ b/src/Core/Generator/SchemaGenerator.cs
@@ -76,7 +76,7 @@ namespace Azure.DataApiBuilder.Core.Generator
                 throw new InvalidOperationException("Container Name can not be blank");
             }
 
-            if(jsonData == null || jsonData.Count == 0)
+            if (jsonData == null || jsonData.Count == 0)
             {
                 logger?.LogWarning($"No JSON data found to generate schema, from Container: {containerName}");
                 return string.Empty;

--- a/src/Core/Generator/SchemaGenerator.cs
+++ b/src/Core/Generator/SchemaGenerator.cs
@@ -73,7 +73,7 @@ namespace Azure.DataApiBuilder.Core.Generator
             // Validate input parameters.
             if (string.IsNullOrEmpty(containerName))
             {
-                throw new InvalidOperationException("Container Name can not be blank");
+                throw new InvalidOperationException("Container name cannot be blank");
             }
 
             if (jsonData == null || jsonData.Count == 0)

--- a/src/Core/Generator/SchemaGenerator.cs
+++ b/src/Core/Generator/SchemaGenerator.cs
@@ -165,7 +165,7 @@ namespace Azure.DataApiBuilder.Core.Generator
 
             if (sb.Length == 0)
             {
-                _logger?.LogWarning("Generated Schema is empty.");
+                _logger?.LogWarning("Generated schema is empty.");
             }
 
             return sb.ToString();

--- a/src/Core/Generator/SchemaGenerator.cs
+++ b/src/Core/Generator/SchemaGenerator.cs
@@ -20,6 +20,7 @@ namespace Azure.DataApiBuilder.Core.Generator
         // Azure Cosmos DB reserved properties, these properties will be ignored in the schema generation as they are not user-defined properties.
         private readonly List<string> _cosmosDbReservedProperties = new() { "_ts", "_etag", "_rid", "_self", "_attachments" };
 
+        // Logger instance for logging messages.
         private readonly ILogger? _logger;
 
         // Maps GraphQL entities to their corresponding attributes.
@@ -165,7 +166,7 @@ namespace Azure.DataApiBuilder.Core.Generator
 
             if (sb.Length == 0)
             {
-                _logger?.LogWarning("Generated schema is empty.");
+                _logger?.LogWarning("Generated GraphQL schema is empty.");
             }
 
             return sb.ToString();

--- a/src/Core/Generator/SchemaGenerator.cs
+++ b/src/Core/Generator/SchemaGenerator.cs
@@ -49,7 +49,7 @@ namespace Azure.DataApiBuilder.Core.Generator
             {
                 if (config.Entities == null || config.Entities.Count() == 0)
                 {
-                    throw new Exception("Define one or more entities to generate the schema in the config file. ");
+                    throw new Exception("Define one or more entities in the config file to generate the GraphQL schema.");
                 }
                 // Populate entity and singular name mapping if configuration is provided.
                 foreach (KeyValuePair<string, Entity> item in config.Entities)

--- a/src/Core/Generator/SchemaGeneratorFactory.cs
+++ b/src/Core/Generator/SchemaGeneratorFactory.cs
@@ -122,15 +122,13 @@ namespace Azure.DataApiBuilder.Core.Generator
                 List<JsonDocument> dataArray = await schemaGeneratorSampler.GetSampleAsync();
 
                 logger.LogInformation("{0} records collected as Sample", dataArray.Count);
-                if (dataArray.Count == 0)
-                {
-                    logger.LogError($"No data was sampled from Database: {dbContainer[0]} Container: {dbContainer[1]}. Please try a different sampling mode or provide different sampling options.");
-                    throw new ArgumentException($"No data was sampled from Database: {dbContainer[0]} Container: {dbContainer[1]}. Please try a different sampling mode or provide different sampling options.");
-                }
-
                 logger.LogInformation("GraphQL schema generation started.");
 
-                schema.AppendLine(SchemaGenerator.Generate(dataArray, dbContainer[1], config));
+                string generatedSchema = SchemaGenerator.Generate(dataArray, dbContainer[1], config, logger);
+                if (!string.IsNullOrEmpty(generatedSchema))
+                {
+                    schema.AppendLine(generatedSchema);
+                }
             }
 
             // Generate and return the GraphQL schema based on the sampled data.

--- a/src/Service.Tests/CosmosTests/SamplerTests.cs
+++ b/src/Service.Tests/CosmosTests/SamplerTests.cs
@@ -90,7 +90,7 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
         [TestMethod(displayName: "TopNExtractor Scenarios")]
         [DataRow(1, 0, 1, DisplayName = "Retrieve 1 record when max days are not specified as count is set as 1.")]
         [DataRow(5, null, 5, DisplayName = "Retrieve 5 records when max days are null as count is set as 5")]
-        [DataRow(5, 2, 3, DisplayName = "Retrieve 3 records with max days configured as 2 as we should get 2 records from last 2 days and 1 record from today. Hence 3 records")]
+        [DataRow(5, 2, 3, DisplayName = "Retrieve 3 records when max days configured as 2 as we should get 2 records from last 2 days and 1 record from today. Hence 3 records")]
         public async Task TestTopNExtractor(int count, int? maxDays, int expectedCount)
         {
             Mock<TopNExtractor> topNExtractor = new(_containerWithIdPk, count, maxDays, _mockLogger.Object);
@@ -109,7 +109,7 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
             // We're relying on a delay to create records with different timestamps.
             // However, this can cause the actual result to intermittently vary by one record in some cases, particularly in pipelines.
             // To prevent these tests from becoming flaky, the assertion has been adjusted.
-            Assert.IsTrue(expectedCount == result.Count || (expectedCount + 1) == result.Count, $"Expected result count is {expectedCount} and Actual result count is {result.Count}");
+            Assert.IsTrue(expectedCount == result.Count || (expectedCount - 1) == result.Count, $"Expected result count is {expectedCount} and Actual result count is {result.Count}");
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace Azure.DataApiBuilder.Service.Tests.CosmosTests
             // We're relying on a delay to create records with different timestamps.
             // However, this can cause the actual result to intermittently vary by one record in some cases, particularly in pipelines.
             // To prevent these tests from becoming flaky, the assertion has been adjusted.
-            Assert.IsTrue(expectedResultCount == result.Count || (expectedResultCount + 1) == result.Count, $"Expected result count is {expectedResultCount} and Actual result count is {result.Count}");
+            Assert.IsTrue(expectedResultCount == result.Count || (expectedResultCount - 1) == result.Count, $"Expected result count is {expectedResultCount} and Actual result count is {result.Count}");
         }
 
         /// <summary>

--- a/src/Service.Tests/CosmosTests/SchemaGeneratorTest.cs
+++ b/src/Service.Tests/CosmosTests/SchemaGeneratorTest.cs
@@ -227,13 +227,12 @@ type PhoneNumber {
 
         /// <summary>
         /// Tests the <see cref="SchemaGenerator.Generate"/> method with an empty JSON array.
-        /// Ensures that the method correctly handles an empty input by throwing an appropriate exception.
         /// </summary>
         [TestMethod]
         public void TestEmptyJsonArray()
         {
             List<JsonDocument> jsonArray = new();
-            Assert.ThrowsException<InvalidOperationException>(() => SchemaGenerator.Generate(jsonArray, "containerName"));
+            Assert.AreEqual(string.Empty, SchemaGenerator.Generate(jsonArray, "containerName"));
         }
 
         /// <summary>


### PR DESCRIPTION
## Why make this change?

This PR enhances user experience by providing more informative error and warning messages in case of misconfigurations.

**Changes:**
1. **Improved Missing Flag Handling-** Added an ERROR log when `--graphql` is not passed, preventing a generic failure message and clearly informing users that `--graphql` is required.
2. **Better Schema Validation-** If the generated schema is empty, an ERROR log now states: _"Generated GraphQL schema is empty. Please check if you have data to generate the schema."_ This provides clearer guidance instead of a vague failure message.
3. **Handling Missing Entities in Config-** An exception is now thrown when no entities are configured in the config file, ensuring this is logged for better debugging.
4. **Logging for Empty Data-** Added an ERROR log if data is missing and an empty array is received for schema generation.
5. **Warnings for Skipped Entities-** Introduced a WARNING log if a specific entity is missing from the config while processing. This helps users understand why an entity was skipped in schema generation.
6. **Test Fixes-** Updated and fixed tests to align with the new error-handling improvements.

## What is this change?

Added more error message.

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests
