### PR TITLE
Adding version check to startup

### DIFF
--- a/src/Product/VersionChecker.cs
+++ b/src/Product/VersionChecker.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.Json.Serialization;
+
+namespace Azure.DataApiBuilder.Product;
+
+public static class VersionChecker
+{
+    private const string PackageName = "Microsoft.DataApiBuilder";
+    private const string NuGetApiUrl = "https://api.nuget.org/v3-flatcontainer/{0}/index.json";
+
+    public static (string? LatestVersion, string? CurrentVersion) GetVersions()
+    {
+        var latestVersion = FetchLatestNuGetVersion();
+        var currentVersion = GetCurrentVersionFromAssembly(Assembly.GetExecutingAssembly());
+        return (latestVersion, currentVersion);
+    }
+
+    private static string? FetchLatestNuGetVersion()
+    {
+        try
+        {
+            using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(2) }; 
+            var url = string.Format(NuGetApiUrl, PackageName.ToLower());
+            var versionData = httpClient.GetFromJsonAsync<NuGetVersionResponse>(url).GetAwaiter().GetResult();
+
+            return versionData?.Versions
+                ?.Where(v => !v.Contains("-rc"))
+                .Max(); // Get the latest stable version
+        }
+        catch
+        {
+            return null; // Assume no update available on failure
+        }
+    }
+
+    private static string? GetCurrentVersionFromAssembly(Assembly assembly)
+    {
+        var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        return !string.IsNullOrEmpty(version) ? version.Split('+')[0] : assembly.GetName().Version?.ToString();
+    }
+
+    private class NuGetVersionResponse
+    {
+        [JsonPropertyName("versions")]
+        public string[]? Versions { get; set; }
+    }
+}

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -27,6 +27,13 @@ namespace Azure.DataApiBuilder.Service
 
         public static void Main(string[] args)
         {
+            // Compare current version of DAB with latest (non-rc) version in NuGet. 
+            var (latestVersion, currentVersion) = await Azure.DataApiBuilder.Product.VersionChecker.GetVersionsAsync();
+            if (!string.IsNullOrEmpty(latestVersion) && latestVersion != currentVersion)
+            {
+                Console.Error.WriteLine("A newer version of Data API builder is available. {currentVersion} -> {latestVersion}");
+            }
+
             if (!ValidateAspNetCoreUrls())
             {
                 Console.Error.WriteLine("Invalid ASPNETCORE_URLS format. e.g.: ASPNETCORE_URLS=\"http://localhost:5000;https://localhost:5001\"");


### PR DESCRIPTION
Closes #3292

## Why make this change?

It is easy to continue running an outdated version of Data API builder after a newer version has been released to NuGet. This PR updates the startup process, checking the current version against the latest version available on NuGet.

## What is this change?

1. Introducing `Azure.DataApiBuilder.Product.VersionChecker`.
2. Validating the versions during `Program.Main()`.
3. Write out a log message only; this does NOT exit the engine. 

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

## Sample Request(s)

- Example REST and/or GraphQL request to demonstrate modifications
- Example of CLI usage to demonstrate modifications
