### PR TITLE
Remove caseInsensitive filter operator from schema generated

### DIFF
--- a/src/Service.GraphQLBuilder/Queries/StandardQueryInputs.cs
+++ b/src/Service.GraphQLBuilder/Queries/StandardQueryInputs.cs
@@ -169,7 +169,6 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Queries
                     new(null, new NameNode("startsWith"), new StringValueNode("Starts With"), new StringType().ToTypeNode(), null, new List<DirectiveNode>()),
                     new(null, new NameNode("endsWith"), new StringValueNode("Ends With"), new StringType().ToTypeNode(), null, new List<DirectiveNode>()),
                     new(null, new NameNode("neq"), new StringValueNode("Not Equals"), new StringType().ToTypeNode(), null, new List<DirectiveNode>()),
-                    new(null, new NameNode("caseInsensitive"), new StringValueNode("Case Insensitive"), new BooleanType().ToTypeNode(), new BooleanValueNode(false), new List<DirectiveNode>()),
                     new(null, new NameNode("isNull"), new StringValueNode("Is null test"), new BooleanType().ToTypeNode(), null, new List<DirectiveNode>())
                 }
             );
@@ -232,7 +231,6 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Queries
                     new(null, new NameNode("startsWith"), new StringValueNode("Starts With"), new UuidType().ToTypeNode(), null, new List<DirectiveNode>()),
                     new(null, new NameNode("endsWith"), new StringValueNode("Ends With"), new UuidType().ToTypeNode(), null, new List<DirectiveNode>()),
                     new(null, new NameNode("neq"), new StringValueNode("Not Equals"), new UuidType().ToTypeNode(), null, new List<DirectiveNode>()),
-                    new(null, new NameNode("caseInsensitive"), new StringValueNode("Case Insensitive"), new BooleanType().ToTypeNode(), new BooleanValueNode(false), new List<DirectiveNode>()),
                     new(null, new NameNode("isNull"), new StringValueNode("Is null test"), new BooleanType().ToTypeNode(), null, new List<DirectiveNode>())
                 }
             );

--- a/src/Service.Tests/MultiSourceTestSchema.gql
+++ b/src/Service.Tests/MultiSourceTestSchema.gql
@@ -77,8 +77,6 @@ input StringFilterInput {
   endsWith: String
   "Not Equals"
   neq: String
-  "Case Insensitive"
-  caseInsensitive: Boolean = false
   "Is null test"
   isNull: Boolean
 }


### PR DESCRIPTION
## Why make this change?
caseInsensitive filter operator is not implemented in the resolvers leading to runtime error when used. Including it in schema seems to be an oversight. Removing it for schema generated until we have an approach defined for case insensitive comparisons with different source types

Relevant issue #2280 
![image5](https://github.com/user-attachments/assets/2876c306-0041-4137-a36a-74b691841434)

## What is this change?
Remove caseInsensitive filter operator from schema generated


## How was this tested?

- [x] Integration Tests
- [x] Unit Tests

