### PR TITLE
Enhance error handling with innerException in DataApiBuilderException

### DIFF
--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1468,7 +1468,8 @@ namespace Azure.DataApiBuilder.Core.Services
                     throw new DataApiBuilderException(
                         message,
                         statusCode: HttpStatusCode.ServiceUnavailable,
-                        subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
+                        subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization,
+                        innerException: ex);
                 }
             }
 


### PR DESCRIPTION

## Why make this change?
Having the inner exception makes root causing and debugging easier for downstream consumers of data-api-builder.

## What is this change?

Added an innerException parameter to the DataApiBuilderException constructor, passing the original exception (ex). This provides better context and aids in debugging by preserving the root cause of the error.
