### PR TITLE
Make parameter length based on underlying column length except for complex ops

### DIFF
--- a/src/Config/DatabasePrimitives/DatabaseObject.cs
+++ b/src/Config/DatabasePrimitives/DatabaseObject.cs
@@ -229,6 +229,17 @@ public class SourceDefinition
 
         return null;
     }
+
+    public virtual int? GetLengthForParam(string paramName)
+    {
+        if (Columns.TryGetValue(paramName, out ColumnDefinition? columnDefinition))
+        {
+            return columnDefinition.Length
+            ;
+        }
+
+        return null;
+    }
 }
 
 /// <summary>
@@ -264,6 +275,7 @@ public class ColumnDefinition
     public bool IsNullable { get; set; }
     public bool IsReadOnly { get; set; }
     public object? DefaultValue { get; set; }
+    public int? Length { get; set; }
 
     public ColumnDefinition() { }
 

--- a/src/Core/Models/DbConnectionParam.cs
+++ b/src/Core/Models/DbConnectionParam.cs
@@ -10,11 +10,12 @@ namespace Azure.DataApiBuilder.Core.Models;
 /// </summary>
 public class DbConnectionParam
 {
-    public DbConnectionParam(object? value, DbType? dbType = null, SqlDbType? sqlDbType = null)
+    public DbConnectionParam(object? value, DbType? dbType = null, SqlDbType? sqlDbType = null, int? length = null)
     {
         Value = value;
         DbType = dbType;
         SqlDbType = sqlDbType;
+        Length = length;
     }
 
     /// <summary>
@@ -31,4 +32,7 @@ public class DbConnectionParam
     // This is being made nullable
     // because it's not populated for DB's other than MSSQL.
     public SqlDbType? SqlDbType { get; set; }
+
+    // Nullable integer parameter representing length. nullable for back compatibility and for where its not needed
+    public int? Length { get; set; }
 }

--- a/src/Core/Resolvers/BaseQueryStructure.cs
+++ b/src/Core/Resolvers/BaseQueryStructure.cs
@@ -125,7 +125,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 Parameters.Add(encodedParamName,
                     new(value,
                         dbType: GetUnderlyingSourceDefinition().GetDbTypeForParam(paramName),
-                        sqlDbType: GetUnderlyingSourceDefinition().GetSqlDbTypeForParam(paramName)));
+                        sqlDbType: GetUnderlyingSourceDefinition().GetSqlDbTypeForParam(paramName),
+                        length: GetUnderlyingSourceDefinition().GetLengthForParam(paramName)));
             }
             else
             {

--- a/src/Core/Resolvers/BaseQueryStructure.cs
+++ b/src/Core/Resolvers/BaseQueryStructure.cs
@@ -117,7 +117,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         /// <param name="value">Value to be assigned to parameter, which can be null for nullable columns.</param>
         /// <param name="paramName"> The name of the parameter - backing column name for table/views or parameter name for stored procedures.</param>
-        public virtual string MakeDbConnectionParam(object? value, string? paramName = null)
+        public virtual string MakeDbConnectionParam(object? value, string? paramName = null, bool lengthOverride=false)
         {
             string encodedParamName = GetEncodedParamName(Counter.Next());
             if (!string.IsNullOrEmpty(paramName))
@@ -126,7 +126,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     new(value,
                         dbType: GetUnderlyingSourceDefinition().GetDbTypeForParam(paramName),
                         sqlDbType: GetUnderlyingSourceDefinition().GetSqlDbTypeForParam(paramName),
-                        length: GetUnderlyingSourceDefinition().GetLengthForParam(paramName)));
+                        length: lengthOverride ? -1:GetUnderlyingSourceDefinition().GetLengthForParam(paramName) ));
             }
             else
             {

--- a/src/Core/Resolvers/CosmosQueryStructure.cs
+++ b/src/Core/Resolvers/CosmosQueryStructure.cs
@@ -67,7 +67,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         }
 
         /// <inheritdoc/>
-        public override string MakeDbConnectionParam(object? value, string? columnName = null)
+        public override string MakeDbConnectionParam(object? value, string? columnName = null, bool lengthOverride=false)
         {
             string encodedParamName = $"{PARAM_NAME_PREFIX}param{Counter.Next()}";
             Parameters.Add(encodedParamName, new(value));

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -392,8 +392,16 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 {
                     SqlParameter parameter = cmd.CreateParameter();
                     parameter.ParameterName = parameterEntry.Key;
-                    parameter.Value = parameterEntry.Value.Value ?? DBNull.Value;
+                    parameter.Value = parameterEntry.Value?.Value?? DBNull.Value;
+
                     PopulateDbTypeForParameter(parameterEntry, parameter);
+
+                    //if sqldbtype is varchar, nvarchar then set the length
+                    if (parameter.SqlDbType is SqlDbType.VarChar or SqlDbType.NVarChar or SqlDbType.Char or SqlDbType.NChar)
+                    {
+                        parameter.Size = parameterEntry.Value?.Length??-1;
+                    }
+
                     cmd.Parameters.Add(parameter);
                 }
             }

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1321,7 +1321,8 @@ namespace Azure.DataApiBuilder.Core.Services
                     SystemType = (Type)columnInfoFromAdapter["DataType"],
                     // An auto-increment column is also considered as a read-only column. For other types of read-only columns,
                     // the flag is populated later via PopulateColumnDefinitionsWithReadOnlyFlag() method.
-                    IsReadOnly = (bool)columnInfoFromAdapter["IsAutoIncrement"]
+                    IsReadOnly = (bool)columnInfoFromAdapter["IsAutoIncrement"],
+                    Length = (int)columnInfoFromAdapter["ColumnSize"]
                 };
 
                 // Tests may try to add the same column simultaneously

--- a/src/Service.Tests/DatabaseSchema-MsSql.sql
+++ b/src/Service.Tests/DatabaseSchema-MsSql.sql
@@ -82,7 +82,7 @@ CREATE TABLE publishers_mm(
 
 CREATE TABLE books(
     id int IDENTITY(5001, 1) PRIMARY KEY,
-    title varchar(max) NOT NULL,
+    title varchar(30) NOT NULL,
     publisher_id int NOT NULL
 );
 
@@ -514,7 +514,7 @@ SET IDENTITY_INSERT books ON
 INSERT INTO books(id, title, publisher_id)
 VALUES (1, 'Awesome book', 1234),
 (2, 'Also Awesome book', 1234),
-(3, 'Great wall of china explained', 2345),
+(3, 'Great wall of china explained]', 2345),
 (4, 'US history in a nutshell', 2345),
 (5, 'Chernobyl Diaries', 2323),
 (6, 'The Palace Door', 2324),

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
@@ -165,6 +165,34 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
             await QueryWithMultipleColumnPrimaryKey(msSqlQuery);
         }
 
+        /// <sumary>
+        /// Test if filter param successfully filters when string filter
+        /// </summary>
+        [TestMethod]
+        public virtual async Task TestFilterParamForStringFilter()
+        {
+            string graphQLQueryName = "books";
+            string graphQLQuery = @"{
+                books( " + Service.GraphQLBuilder.Queries.QueryBuilder.FILTER_FIELD_NAME + @":{ title: {eq:""Awesome book""}}) {
+                    items {
+                        id
+                        title
+                    }
+                }
+            }";
+
+            string expected = @"
+[
+  {
+    ""id"": 1,
+    ""title"": ""Awesome book""
+  }
+]";
+
+            JsonElement actual = await ExecuteGraphQLRequestAsync(graphQLQuery, graphQLQueryName, isAuthenticated: false);
+
+            SqlTestHelper.PerformTestEqualJsonStrings(expected, actual.GetProperty("items").ToString());
+        }
         [TestMethod]
         public async Task QueryWithNullableForeignKey()
         {
@@ -421,8 +449,8 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
         public async Task TestSupportForAggregationsWithAliases()
         {
             string msSqlQuery = @"
-                SELECT 
-                    MAX(categoryid) AS max, 
+                SELECT
+                    MAX(categoryid) AS max,
                     MAX(price) AS max_price,
                     MIN(price) AS min_price,
                     AVG(price) AS avg_price,

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
@@ -193,6 +193,65 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
 
             SqlTestHelper.PerformTestEqualJsonStrings(expected, actual.GetProperty("items").ToString());
         }
+
+        /// <sumary>
+        /// Test if filter param successfully filters when string filter results in a value longer than the column
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("contains")]
+        [DataRow("startsWith")]
+        [DataRow("endsWith")]
+        public virtual async Task TestFilterParamForStringFilterWorkWithComplexOp(string op)
+        {
+            string graphQLQueryName = "books";
+            string graphQLQuery = @"{
+                books( " + Service.GraphQLBuilder.Queries.QueryBuilder.FILTER_FIELD_NAME + @":{ title: {" + op + @":""Great wall of china explained]""}}) {
+                    items {
+                        id
+                        title
+                    }
+                }
+            }";
+
+            string expected = @"
+[
+  {
+    ""id"": 3,
+    ""title"": ""Great wall of china explained]""
+  }
+]";
+
+            JsonElement actual = await ExecuteGraphQLRequestAsync(graphQLQuery, graphQLQueryName, isAuthenticated: false);
+
+            SqlTestHelper.PerformTestEqualJsonStrings(expected, actual.GetProperty("items").ToString());
+        }
+
+        /// <sumary>
+        /// Test if filter param successfully filters when string filter results in a value longer than the column
+        /// </summary>
+        [TestMethod]
+        public virtual async Task TestFilterParamForStringFilterWorkWithNotContains(string op)
+        {
+            string graphQLQueryName = "books";
+            string graphQLQuery = @"{
+                books( " + Service.GraphQLBuilder.Queries.QueryBuilder.FILTER_FIELD_NAME + @":{ title: { notContains:""Great wall of china explained]""},id:{eq:3} }) {
+                    items {
+                        id
+                        title
+                    }
+                }
+            }";
+
+            string expected = @"
+[
+]";
+
+            JsonElement actual = await ExecuteGraphQLRequestAsync(graphQLQuery, graphQLQueryName, isAuthenticated: false);
+
+            SqlTestHelper.PerformTestEqualJsonStrings(expected, actual.GetProperty("items").ToString());
+        }
+
+
         [TestMethod]
         public async Task QueryWithNullableForeignKey()
         {


### PR DESCRIPTION
## Why make this change?

Fixes issue #2619 

## What is this change?

Where a parameter is linked to an underlying column in the data model the length is stored
When the query is executed the length is used to ensure parameters have consistent lengths

For certain operations the value is padded with escape characters or %s, these need to be allowed for.  In those cases the length is  set to -1 (max) in order that the extra characters are allowed for AND consistent lengths are maintained

## How was this tested?

- [x] Integration Tests

Checking the resultant query is using the right length was done using trace. Not sure with the architecture whether it would be possible to mock at that level.

## Sample Request(s)

See new tests TestFilterParamForStringFilterWorkWithComplexOp and TestFilterParamForStringFilterWorkWithNotContains