### PR TITLE
Fixing Pipelines due to Ubuntu 24.04 update removing Mono

### DIFF
--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -51,12 +51,12 @@ steps:
 - task: NuGetToolInstaller@1
 
 - task: DotNetCoreCLI@2
-    displayName: Restore NuGet packages
-    inputs:
-      command: restore
-      projects: '$(solution)'
-      feedsToUse: config
-      nugetConfigPath: Nuget.config
+  displayName: Restore NuGet packages
+  inputs:
+    command: restore
+    projects: '$(solution)'
+    feedsToUse: config
+    nugetConfigPath: Nuget.config
 
 - task: DotNetCoreCLI@2
   displayName: Build

--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -50,12 +50,13 @@ steps:
 
 - task: NuGetToolInstaller@1
 
-- task: NuGetCommand@2
-  displayName: Restore NuGet packages
-  inputs:
-    restoreSolution: '$(solution)'
-    feedsToUse: config
-    nugetConfigPath: Nuget.config
+- task: DotNetCoreCLI@2
+    displayName: Restore NuGet packages
+    inputs:
+      command: restore
+      projects: '$(solution)'
+      feedsToUse: config
+      nugetConfigPath: Nuget.config
 
 - task: DotNetCoreCLI@2
   displayName: Build

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -42,10 +42,11 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     displayName: Restore NuGet packages
     inputs:
-      restoreSolution: '$(solution)'
+      command: restore
+      projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
 

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -43,10 +43,11 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     displayName: Restore NuGet packages
     inputs:
-      restoreSolution: '$(solution)'
+      command: restore
+      projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
 

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -41,10 +41,11 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     displayName: Restore NuGet packages
     inputs:
-      restoreSolution: '$(solution)'
+      command: restore
+      projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
 

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -36,10 +36,11 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     displayName: Restore NuGet packages
     inputs:
-      restoreSolution: '$(solution)'
+      command: restore
+      projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
 

--- a/.pipelines/templates/build-pipelines.yml
+++ b/.pipelines/templates/build-pipelines.yml
@@ -62,9 +62,11 @@ steps:
 
 - task: NuGetToolInstaller@1
 
-- task: NuGetCommand@2
+- task: DotNetCoreCLI@2
+  displayName: Restore NuGet packages
   inputs:
-    restoreSolution: '$(solution)'
+    command: restore
+    projects: '$(solution)'
     feedsToUse: config
     nugetConfigPath: Nuget.config
 


### PR DESCRIPTION
## Why make this change?
Resolves #2649

## What is this change?
The pipelines are failing due to udpate from ubutu 24.04. 
We are using the latest version in our yamls hence, this change needs to be handled. 
<img width="527" alt="image" src="https://github.com/user-attachments/assets/b1f14841-ea20-4b18-8b17-b9f1c43b4022" />

The error message we are seeing is due to the fact that default Ubuntu 24.04+ image on Microsoft-hosted agents does not include Mono, which is required for the NuGet client that powers NuGetCommand@2 in our pipeline. Microsoft recommends migrating to using the NuGetAuthenticate@1 task and .NET CLI commands instead of the older NuGetCommand@2 task, which relies on Mono.

Steps to Fix the Issue:
- Remove NuGetCommand@2 task: Since this task requires Mono (which is no longer available by default on Ubuntu 24.04+), we should remove it and replace it with .NET CLI commands for restoring the NuGet packages.
- Add .NET CLI restore command: Instead of using the NuGetCommand@2 task, use the DotNetCoreCLI@2 task to restore NuGet packages.
- Update NuGet authentication: Ensure that you're using NuGetAuthenticate@1 before the restore task to handle authentication.

## How was this tested?
The pipelines are running as expected.
