### PR TITLE
Add header support for caching

### DIFF
--- a/src/Core/Models/RestRequestContexts/RestRequestContext.cs
+++ b/src/Core/Models/RestRequestContexts/RestRequestContext.cs
@@ -42,6 +42,12 @@ public abstract class RestRequestContext
     public List<string> FieldsToBeReturned { get; set; } = new();
 
     /// <summary>
+    /// Defines the cache control option from the request header.
+    /// 
+    /// </summary>
+    public string? HeaderCacheControlOption { get; set; }
+
+    /// <summary>
     /// Dictionary of primary key and their values specified in the request.
     /// When there are multiple values, that means its a composite primary key.
     /// Based on the operation type, this property may or may not be populated.

--- a/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -17,7 +17,6 @@ using Azure.DataApiBuilder.Service.Services;
 using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using Microsoft.AspNetCore.Http;
-using Polly;
 using static Azure.DataApiBuilder.Service.GraphQLBuilder.Sql.SchemaConverter;
 namespace Azure.DataApiBuilder.Core.Resolvers
 {
@@ -94,6 +93,14 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         public GroupByMetadata GroupByMetadata { get; private set; }
 
         public string? CacheControlOption { get; set; }
+
+        public const string CACHE_CONTROL = "Cache-Control";
+
+        public const string CACHE_CONTROL_NO_STORE = "no-store";
+
+        public const string CACHE_CONTROL_NO_CACHE = "no-cache";
+
+        public const string CACHE_CONTROL_ONLY_IF_CACHED = "only-if-cached";
 
         /// <summary>
         /// Generate the structure for a SQL query based on GraphQL query
@@ -222,7 +229,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
             HttpContext httpContext = GraphQLFilterParser.GetHttpContextFromMiddlewareContext(ctx);
             // Set the cache control based on the header if it exists.
-            if (httpContext.Request.Headers.TryGetValue("Cache-Control", out Microsoft.Extensions.Primitives.StringValues cacheControlOption))
+            if (httpContext.Request.Headers.TryGetValue(CACHE_CONTROL, out Microsoft.Extensions.Primitives.StringValues cacheControlOption))
             {
                 CacheControlOption = cacheControlOption;
             }
@@ -576,15 +583,15 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         private void AddCacheControlOptions(HttpContext httpContext)
         {
             // Set the cache control based on the request header if it exists.
-            if (httpContext.Request.Headers.TryGetValue("Cache-Control", out Microsoft.Extensions.Primitives.StringValues cacheControlOption))
+            if (httpContext.Request.Headers.TryGetValue(CACHE_CONTROL, out Microsoft.Extensions.Primitives.StringValues cacheControlOption))
             {
                 CacheControlOption = cacheControlOption;
             }
 
             if (!string.IsNullOrEmpty(CacheControlOption) &&
-                !string.Equals(CacheControlOption, "no-cache") &&
-                !string.Equals(CacheControlOption, "no-store") &&
-                !string.Equals(CacheControlOption, "only-if-cached"))
+                !string.Equals(CacheControlOption, CACHE_CONTROL_NO_CACHE) &&
+                !string.Equals(CacheControlOption, CACHE_CONTROL_NO_STORE) &&
+                !string.Equals(CacheControlOption, CACHE_CONTROL_ONLY_IF_CACHED))
             {
                 throw new DataApiBuilderException(
                     message: "Request Header Cache-Control is invalid: " + CacheControlOption,


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/2604

## What is this change?

Inside of the `SqlQueryStructure`, there is a private constructor, that all of the public constructors will call. This private constructor offers a single point where all of the queries will bottleneck, and therefore we add the cache control information to the query structure at this point. Then when we are in the `SqlQueryEngine`, we can check for this cache control information and handle the query appropriately.

The cache control options can be found 

here: https://github.com/Azure/data-api-builder/issues/2253 

and here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#request_directives

But for reference, they are `no-cache`, `no-store`, `only-if-cached`, which will mean we do not get from the cache, we do not store in the cache, and if there is a cache miss we return gateway timeout, respectively.

## How was this tested?

Run against test suite.

## Sample Request(s)

To test you need to include the relevant cache headers in the request, "no-cache", "no-store", or "only-if-cached"
