### PR TITLE
[Bug] Fix Health request for GraphQL endpoint 

### DIFF
--- a/src/Service/HealthCheck/HealthCheckHelper.cs
+++ b/src/Service/HealthCheck/HealthCheckHelper.cs
@@ -221,7 +221,12 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 if (runtimeOptions.IsRestEnabled && entityValue.IsRestEnabled)
                 {
                     ComprehensiveHealthCheckReport.Checks ??= new List<HealthCheckResultEntry>();
+
+                    // In case of REST API, use the path specified in [entity.path] (if present).
+                    // The path is trimmed to remove the leading '/' character.
+                    // If the path is not present, use the entity key name as the path.
                     string entityPath = entityValue.Rest.Path != null ? entityValue.Rest.Path.TrimStart('/') : entityKeyName;
+
                     (int, string?) response = ExecuteRestEntityQuery(runtimeConfig.RestPath, entityPath, entityValue.EntityFirst);
                     bool isResponseTimeWithinThreshold = response.Item1 >= 0 && response.Item1 < entityValue.EntityThresholdMs;
 

--- a/src/Service/HealthCheck/HttpUtilities.cs
+++ b/src/Service/HealthCheck/HttpUtilities.cs
@@ -13,6 +13,7 @@ using Azure.DataApiBuilder.Core.Authorization;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Core.Services.MetadataProviders;
+using Humanizer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
@@ -157,14 +158,17 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 ISqlMetadataProvider sqlMetadataProvider = _metadataProviderFactory.GetMetadataProvider(dataSourceName);
                 DatabaseObject dbObject = sqlMetadataProvider.EntityToDatabaseObject[entityName];
                 List<string> columnNames = dbObject.SourceDefinition.Columns.Keys.ToList();
-                string databaseObjectName = entity.Source.Object;
-
+                
+                // In case of GraphQL API, use the plural value specified in [entity.graphql.type.plural].
+                // Further, we need to camel case this plural value to match the GraphQL object name.                  
+                string graphqlObjectName = LowerFirstLetter(entity.GraphQL.Plural.Pascalize());
+                
                 // In case any primitive column names are present, execute the query
                 if (columnNames.Any())
                 {
                     using (HttpClient client = CreateClient(apiRoute))
                     {
-                        string jsonPayload = Utilities.CreateHttpGraphQLQuery(databaseObjectName, columnNames, entity.EntityFirst);
+                        string jsonPayload = Utilities.CreateHttpGraphQLQuery(graphqlObjectName, columnNames, entity.EntityFirst);
                         HttpContent content = new StringContent(jsonPayload, Encoding.UTF8, Utilities.JSON_CONTENT_TYPE);
 
                         HttpRequestMessage message = new(method: HttpMethod.Post, requestUri: apiRoute)
@@ -219,6 +223,18 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 },
                 Timeout = TimeSpan.FromSeconds(200),
             };
+        }
+
+        // Updates the entity key name to camel case for the health check report.
+        public static string LowerFirstLetter(string input)
+        {
+            if (string.IsNullOrEmpty(input) || char.IsLower(input[0]))
+            {
+                // If the input is null or empty, or if the first character is already lowercase, return the input as is.
+                return input;
+            }
+
+            return char.ToLower(input[0]) + input.Substring(1);
         }
 
         // <summary>

--- a/src/Service/HealthCheck/Utilities.cs
+++ b/src/Service/HealthCheck/Utilities.cs
@@ -37,7 +37,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
             var payload = new
             {
                 //{"query":"{publishers(first:4) {items {id name} }}"}
-                query = $"{{{entityName.ToLowerInvariant()} (first: {first}) {{items {{ {string.Join(" ", columnNames)} }}}}}}"
+                query = $"{{{entityName} (first: {first}) {{items {{ {string.Join(" ", columnNames)} }}}}}}"
             };
 
             // Serialize the payload to a JSON string


### PR DESCRIPTION
## Why make this change?
Resolved #2645

## What is this change?
We need to take the plural value for the creating the http payload for the graphql request. Further we need to camel case this value instead of using the objects value which I was currently using

## How was this tested?
Local Testing
1. Type.Plural not provided and entity name is not the same as table name
2. Type.Plural not provided and entity name is caps
3. Type.Plural not provided and entity name is all small
4. source.objects is provided as `dbo.books`
5. Type.Plural provided but in all small case
6. Type.Plural provided in all caps


## Sample Request(s)
<img width="310" alt="image" src="https://github.com/user-attachments/assets/26c35c70-34a0-40d9-b344-90d7c31d117f" />
<img width="234" alt="image" src="https://github.com/user-attachments/assets/b3385e59-c9ee-4ad7-8fdb-2555bfaf16ed" />
