### PR TITLE
Add doc for how to push to external contributor's PR

### DIFF
--- a/docs/PushToExtContributorPR.md
+++ b/docs/PushToExtContributorPR.md
@@ -3,7 +3,7 @@
 In case it is not possible to either git switch or git fetch
 
 1. Add the contributor's repo `.git` as a remote, you can find the `.git` by clicking on their branch which should bring you to their fork and then clicking on the Green Code button, the .git address will be listed under the option to clone using web URL. Copy this `.git` address for future steps.
-2. git remote add <name> <.git address>
+2. `git remote add <name> <.git address>`
 
 For example:
 `git remote add thomasfroehle https://github.com/thomasfroehle/data-api-builder.git`

--- a/docs/PushToExtContributorPR.md
+++ b/docs/PushToExtContributorPR.md
@@ -15,14 +15,14 @@ For example:
 
 4. You now have the ability to either rebase their branch onto a working branch you've already made changes to, or you can start your changes fresh on their branch.
 
-If you are trying to add changes youve already made you can use the following example, note that `thomasfroehle` is the name of the remote we added, so you would use whatever remote name is relevant. Suppose I have a branch locally with the fix named `dev/aaronburtle/CompleteQuotedTableSupport`
+If you are trying to add changes you've already made you can use the following example, note that `thomasfroehle` is the name of the remote we added, so you would use whatever remote name is relevant. Suppose I have a branch locally with the fix named `dev/aaronburtle/CompleteQuotedTableSupport`
 
 `git checkout -b fix-case-sensitive-table-names thomasfroehle/fix-case-sensitive-table-names`
 `git rebase dev/aaronburtle/CompleteQuotedTableSupport` 
 `git push thomasfroehle fix-case-sensitive-table-names`
 
 If you just want to start fresh from their branch you can do
-`git switch <branchname>` without the need to include the name of the remote you added since youve fetched it already in step 3.
+`git switch <branchname>` without the need to include the name of the remote you added since you've fetched it already in step 3.
 
 5. You can now commit and push but make sure you use
 `git push <name of remote> <name of branch>`

--- a/docs/PushToExtContributorPR.md
+++ b/docs/PushToExtContributorPR.md
@@ -2,8 +2,7 @@
 
 In case it is not possible to either git switch or git fetch
 
-1. Add the contributor's repo `.git` as a remote, you can find the `.git` by clicking on their branch which should bring you to their fork and then clicking on the Green Code button, the .git address will be listed under the option to clone using web URL. Copy this `.get` address for future steps.
-
+1. Add the contributor's repo `.git` as a remote, you can find the `.git` by clicking on their branch which should bring you to their fork and then clicking on the Green Code button, the .git address will be listed under the option to clone using web URL. Copy this `.git` address for future steps.
 2. git remote add <name> <.git address>
 
 For example:

--- a/docs/PushToExtContributorPR.md
+++ b/docs/PushToExtContributorPR.md
@@ -1,0 +1,32 @@
+## How to Complete an External Contributor PR from their fork
+
+In case it is not possible to either git switch or git fetch
+
+1. Add the contributor's repo `.git` as a remote, you can find the `.git` by clicking on their branch which should bring you to their fork and then clicking on the Green Code button, the .git address will be listed under the option to clone using web URL. Copy this `.get` address for future steps.
+
+2. git remote add <name> <.git address>
+
+For example:
+`git remote add thomasfroehle https://github.com/thomasfroehle/data-api-builder.git`
+
+3. Run `git fetch <name>` for the remote you just added
+
+For example:
+`git fetch thomasfroehle`
+
+4. You now have the ability to either rebase their branch onto a working branch you've already made changes to, or you can start your changes fresh on their branch.
+
+If you are trying to add changes youve already made you can use the following example, note that `thomasfroehle` is the name of the remote we added, so you would use whatever remote name is relevant. Suppose I have a branch locally with the fix named `dev/aaronburtle/CompleteQuotedTableSupport`
+
+`git checkout -b fix-case-sensitive-table-names thomasfroehle/fix-case-sensitive-table-names`
+`git rebase dev/aaronburtle/CompleteQuotedTableSupport` 
+`git push thomasfroehle fix-case-sensitive-table-names`
+
+If you just want to start fresh from their branch you can do
+`git switch <branchname>` without the need to include the name of the remote you added since youve fetched it already in step 3.
+
+5. You can now commit and push but make sure you use
+`git push <name of remote> <name of branch>`
+
+For example:
+`git push --set-upstream thomasfroehle fix-case-sensitive-table-names`


### PR DESCRIPTION
## Why make this change?

We are an open source project, and as such we have external contributors pushing changes to our repo. But sometimes we may need to make some adjustments to their PR in order to fix format, bugs, help get tests passing, etc. This doc helps to make that easier by expanding on one way to handle this scenario.

## What is this change?

This is a doc that explains how to add a remote that represents the external contributor's fork of our repo, and then how to make changes and push to that remote.

## How was this tested?

N/A

## Sample Request(s)

N/A