### PR TITLE
Bug fix for GraphQL endpoint with DateTimeFilterInput

### DIFF
--- a/src/Core/Services/ExecutionHelper.cs
+++ b/src/Core/Services/ExecutionHelper.cs
@@ -328,7 +328,8 @@ namespace Azure.DataApiBuilder.Service.Services
                 SupportedHotChocolateTypes.SINGLE_TYPE => value is IntValueNode intValueNode ? intValueNode.ToSingle() : ((FloatValueNode)value).ToSingle(),
                 SupportedHotChocolateTypes.FLOAT_TYPE => value is IntValueNode intValueNode ? intValueNode.ToDouble() : ((FloatValueNode)value).ToDouble(),
                 SupportedHotChocolateTypes.DECIMAL_TYPE => value is IntValueNode intValueNode ? intValueNode.ToDecimal() : ((FloatValueNode)value).ToDecimal(),
-                SupportedHotChocolateTypes.UUID_TYPE => Guid.TryParse(value.Value!.ToString(), out Guid guidValue) ? guidValue : value.Value,
+                SupportedHotChocolateTypes.UUID_TYPE => Guid.TryParse(value.Value!.ToString(), out Guid guidValue) ? guidValue : value.Value,    
+                SupportedHotChocolateTypes.DATETIME_TYPE => DateTime.TryParse(value.Value!.ToString(), out DateTime dtValue) ? dtValue : value.Value,
                 _ => value.Value
             };
         }


### PR DESCRIPTION
Bug fix for GraphQL endpoint with DateTimeFilterInput

## Why make this change?

While testing a table with a DateTime filter condition using a GraphQL endpoint, I encountered an error: 'DatabaseOperationFailed - 42883: operator does not exist: date > text.'

## What is this change?

It's a straightforward adjustment to incorporate DateTime parsing conditions alongside other types.
