### PR TITLE
Cherry-Picking Commits for 1.5

### DIFF
--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -50,10 +50,11 @@ steps:
 
 - task: NuGetToolInstaller@1
 
-- task: NuGetCommand@2
+- task: DotNetCoreCLI@2
   displayName: Restore NuGet packages
   inputs:
-    restoreSolution: '$(solution)'
+    command: restore
+    projects: '$(solution)'
     feedsToUse: config
     nugetConfigPath: Nuget.config
 

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -42,10 +42,11 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     displayName: Restore NuGet packages
     inputs:
-      restoreSolution: '$(solution)'
+      command: restore
+      projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
 

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -43,10 +43,11 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     displayName: Restore NuGet packages
     inputs:
-      restoreSolution: '$(solution)'
+      command: restore
+      projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
 

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -41,10 +41,11 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     displayName: Restore NuGet packages
     inputs:
-      restoreSolution: '$(solution)'
+      command: restore
+      projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
 

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -36,10 +36,11 @@ jobs:
 
   - task: NuGetToolInstaller@1
 
-  - task: NuGetCommand@2
+  - task: DotNetCoreCLI@2
     displayName: Restore NuGet packages
     inputs:
-      restoreSolution: '$(solution)'
+      command: restore
+      projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
 

--- a/.pipelines/templates/build-pipelines.yml
+++ b/.pipelines/templates/build-pipelines.yml
@@ -62,9 +62,11 @@ steps:
 
 - task: NuGetToolInstaller@1
 
-- task: NuGetCommand@2
+- task: DotNetCoreCLI@2
+  displayName: Restore NuGet packages
   inputs:
-    restoreSolution: '$(solution)'
+    command: restore
+    projects: '$(solution)'
     feedsToUse: config
     nugetConfigPath: Nuget.config
 

--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -407,6 +407,11 @@
                 "type": "string"
               },
               "default": null
+            },
+            "cache-ttl-seconds": {
+              "type": "integer",
+              "description": "Time to live in seconds for the Comprehensive Health Check Report cache entry.",
+              "default": 5
             }
           }
         }

--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -14,7 +14,7 @@ Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Out-File $chiliCreamLicenseSavePath
 
 # Define the path to the license file in your repository and Read the content of the license file
-$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.0.License.txt"
+$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.3.License.txt"
 $sqlClientSNILicense = Get-Content -Path $sqlClientSNILicenseFilePath -Raw
 
 # Path of notice file generated in CI/CD pipeline.

--- a/src/Cli.Tests/AddEntityTests.cs
+++ b/src/Cli.Tests/AddEntityTests.cs
@@ -40,6 +40,8 @@ namespace Cli.Tests
                 fieldsToExclude: new string[] { },
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: null,
                 graphQLOperationForStoredProcedure: null
@@ -67,6 +69,8 @@ namespace Cli.Tests
                 fieldsToExclude: new string[] { },
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: null,
                 graphQLOperationForStoredProcedure: null
@@ -96,10 +100,12 @@ namespace Cli.Tests
                 fieldsToExclude: null,
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: null,
                 graphQLOperationForStoredProcedure: null
-                );
+            );
 
             string initialConfiguration = AddPropertiesToJson(INITIAL_CONFIG, GetFirstEntityConfiguration());
             Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(initialConfiguration, out RuntimeConfig? runtimeConfig), "Loaded config");
@@ -117,8 +123,8 @@ namespace Cli.Tests
         public Task AddEntityWithAnExistingNameButWithDifferentCase()
         {
             AddOptions options = new(
-               source: "MyTable",
-               permissions: new string[] { "anonymous", "*" },
+                source: "MyTable",
+                permissions: new string[] { "anonymous", "*" },
                 entity: "FIRSTEntity",
                 sourceType: null,
                 sourceParameters: null,
@@ -129,6 +135,8 @@ namespace Cli.Tests
                 fieldsToExclude: new string[] { },
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: null,
                 graphQLOperationForStoredProcedure: null
@@ -136,6 +144,35 @@ namespace Cli.Tests
 
             string initialConfiguration = AddPropertiesToJson(INITIAL_CONFIG, GetFirstEntityConfiguration());
             return ExecuteVerifyTest(options, initialConfiguration);
+        }
+
+        /// <summary>
+        /// Simple test to verify success on adding a new entity with caching enabled.
+        /// </summary>
+        [TestMethod]
+        public Task AddEntityWithCachingEnabled()
+        {
+            AddOptions options = new(
+                source: "MyTable",
+                permissions: new string[] { "anonymous", "*" },
+                entity: "CachingEntity",
+                sourceType: null,
+                sourceParameters: null,
+                sourceKeyFields: null,
+                restRoute: null,
+                graphQLType: null,
+                fieldsToInclude: null,
+                fieldsToExclude: null,
+                policyRequest: null,
+                policyDatabase: null,
+                cacheEnabled: "true",
+                cacheTtl: "1",
+                config: TEST_RUNTIME_CONFIG_FILE,
+                restMethodsForStoredProcedure: null,
+                graphQLOperationForStoredProcedure: null
+            );
+
+            return ExecuteVerifyTest(options);
         }
 
         /// <summary>
@@ -165,6 +202,8 @@ namespace Cli.Tests
                 policyRequest: policyRequest,
                 policyDatabase: policyDatabase,
                 config: TEST_RUNTIME_CONFIG_FILE,
+                cacheEnabled: null,
+                cacheTtl: null,
                 restMethodsForStoredProcedure: null,
                 graphQLOperationForStoredProcedure: null
             );
@@ -195,6 +234,8 @@ namespace Cli.Tests
                 policyRequest: null,
                 policyDatabase: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
+                cacheEnabled: null,
+                cacheTtl: null,
                 restMethodsForStoredProcedure: null,
                 graphQLOperationForStoredProcedure: null
                 );
@@ -223,6 +264,8 @@ namespace Cli.Tests
                 fieldsToExclude: new string[] { },
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: new string[] { "Post", "Put", "Patch" },
                 graphQLOperationForStoredProcedure: "Query"
@@ -271,6 +314,8 @@ namespace Cli.Tests
                 fieldsToExclude: new string[] { },
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: null,
                 graphQLOperationForStoredProcedure: null
@@ -328,6 +373,8 @@ namespace Cli.Tests
                 fieldsToExclude: new string[] { },
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: restMethods,
                 graphQLOperationForStoredProcedure: graphQLOperation
@@ -361,6 +408,8 @@ namespace Cli.Tests
                 fieldsToExclude: new string[] { },
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: restMethods,
                 graphQLOperationForStoredProcedure: graphQLOperation
@@ -397,6 +446,8 @@ namespace Cli.Tests
                 fieldsToExclude: new string[] { "level" },
                 policyRequest: null,
                 policyDatabase: null,
+                cacheEnabled: null,
+                cacheTtl: null,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: null,
                 graphQLOperationForStoredProcedure: null

--- a/src/Cli.Tests/ModuleInitializer.cs
+++ b/src/Cli.Tests/ModuleInitializer.cs
@@ -79,6 +79,8 @@ static class ModuleInitializer
         VerifierSettings.IgnoreMember<RuntimeConfig>(options => options.EnableAggregation);
         // Ignore the AllowedRolesForHealth as that's unimportant from a test standpoint.
         VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.AllowedRolesForHealth);
+        // Ignore the CacheTtlSeconds as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.CacheTtlSecondsForHealthReport);
         // Ignore the EnableAggregation as that's unimportant from a test standpoint.
         VerifierSettings.IgnoreMember<GraphQLRuntimeOptions>(options => options.EnableAggregation);
         // Ignore the EnableDwNto1JoinOpt as that's unimportant from a test standpoint.

--- a/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithCachingEnabled.verified.txt
+++ b/src/Cli.Tests/Snapshots/AddEntityTests.AddEntityWithCachingEnabled.verified.txt
@@ -1,0 +1,57 @@
+﻿{
+  DataSource: {
+    DatabaseType: MSSQL
+  },
+  Runtime: {
+    Rest: {
+      Enabled: true,
+      Path: /api,
+      RequestBodyStrict: true
+    },
+    GraphQL: {
+      Enabled: true,
+      Path: /graphql,
+      AllowIntrospection: true
+    },
+    Host: {
+      Cors: {
+        AllowCredentials: false
+      },
+      Authentication: {
+        Provider: StaticWebApps
+      }
+    }
+  },
+  Entities: [
+    {
+      CachingEntity: {
+        Source: {
+          Object: MyTable,
+          Type: Table
+        },
+        GraphQL: {
+          Singular: CachingEntity,
+          Plural: CachingEntities,
+          Enabled: true
+        },
+        Rest: {
+          Enabled: true
+        },
+        Permissions: [
+          {
+            Role: anonymous,
+            Actions: [
+              {
+                Action: *
+              }
+            ]
+          }
+        ],
+        Cache: {
+          Enabled: true,
+          TtlSeconds: 1
+        }
+      }
+    }
+  ]
+}

--- a/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityCaching.verified.txt
+++ b/src/Cli.Tests/Snapshots/UpdateEntityTests.TestUpdateEntityCaching.verified.txt
@@ -1,0 +1,51 @@
+﻿{
+  DataSource: {
+    DatabaseType: MSSQL
+  },
+  Runtime: {
+    Rest: {
+      Enabled: true,
+      Path: /,
+      RequestBodyStrict: true
+    },
+    GraphQL: {
+      Enabled: true,
+      Path: /graphql,
+      AllowIntrospection: true
+    },
+    Host: {
+      Cors: {
+        AllowCredentials: false
+      },
+      Authentication: {
+        Provider: StaticWebApps,
+        Jwt: {
+          Audience: ,
+          Issuer: 
+        }
+      }
+    }
+  },
+  Entities: [
+    {
+      MyEntity: {
+        Source: {
+          Object: MyTable,
+          Type: Table
+        },
+        GraphQL: {
+          Singular: MyEntity,
+          Plural: MyEntities,
+          Enabled: true
+        },
+        Rest: {
+          Enabled: true
+        },
+        Cache: {
+          Enabled: true,
+          TtlSeconds: 1
+        }
+      }
+    }
+  ]
+}

--- a/src/Cli.Tests/UpdateEntityTests.cs
+++ b/src/Cli.Tests/UpdateEntityTests.cs
@@ -293,6 +293,33 @@ namespace Cli.Tests
         }
 
         /// <summary>
+        /// Simple test to update an entity cache.
+        /// </summary>
+        [TestMethod, Description("It should update the cache into true.")]
+        public Task TestUpdateEntityCaching()
+        {
+            UpdateOptions options = GenerateBaseUpdateOptions(
+                source: "MyTable",
+                cacheEnabled: "true",
+                cacheTtl: "1"
+            );
+
+            string initialConfig = GetInitialConfigString() + "," + @"
+                    ""entities"": {
+                            ""MyEntity"": {
+                                ""source"": ""MyTable"",
+                                ""cache"": {
+                                    ""enabled"": false,
+                                    ""ttlseconds"": 0
+                                }
+                            }
+                        }
+                    }";
+
+            return ExecuteVerifyTest(initialConfig, options);
+        }
+
+        /// <summary>
         /// Test to check creation of a new relationship
         /// </summary>
         [TestMethod]
@@ -1093,7 +1120,9 @@ namespace Cli.Tests
             IEnumerable<string>? relationshipFields = null,
             IEnumerable<string>? map = null,
             IEnumerable<string>? restMethodsForStoredProcedure = null,
-            string? graphQLOperationForStoredProcedure = null
+            string? graphQLOperationForStoredProcedure = null,
+            string? cacheEnabled = null,
+            string? cacheTtl = null
             )
         {
             return new(
@@ -1117,6 +1146,8 @@ namespace Cli.Tests
                 linkingTargetFields: linkingTargetFields,
                 relationshipFields: relationshipFields,
                 map: map,
+                cacheEnabled: cacheEnabled,
+                cacheTtl: cacheTtl,
                 config: TEST_RUNTIME_CONFIG_FILE,
                 restMethodsForStoredProcedure: restMethodsForStoredProcedure,
                 graphQLOperationForStoredProcedure: graphQLOperationForStoredProcedure

--- a/src/Cli/Commands/AddOptions.cs
+++ b/src/Cli/Commands/AddOptions.cs
@@ -32,6 +32,8 @@ namespace Cli.Commands
             IEnumerable<string>? fieldsToExclude,
             string? policyRequest,
             string? policyDatabase,
+            string? cacheEnabled,
+            string? cacheTtl,
             string? config)
             : base(entity,
                   sourceType,
@@ -45,6 +47,8 @@ namespace Cli.Commands
                   fieldsToExclude,
                   policyRequest,
                   policyDatabase,
+                  cacheEnabled,
+                  cacheTtl,
                   config)
         {
             Source = source;

--- a/src/Cli/Commands/EntityOptions.cs
+++ b/src/Cli/Commands/EntityOptions.cs
@@ -23,6 +23,8 @@ namespace Cli.Commands
             IEnumerable<string>? fieldsToExclude,
             string? policyRequest,
             string? policyDatabase,
+            string? cacheEnabled,
+            string? cacheTtl,
             string? config)
             : base(config)
         {
@@ -38,6 +40,8 @@ namespace Cli.Commands
             FieldsToExclude = fieldsToExclude;
             PolicyRequest = policyRequest;
             PolicyDatabase = policyDatabase;
+            CacheEnabled = cacheEnabled;
+            CacheTtl = cacheTtl;
         }
 
         // Entity is required but we have made required as false to have custom error message (more user friendly), if not provided.
@@ -76,5 +80,11 @@ namespace Cli.Commands
 
         [Option("policy-database", Required = false, HelpText = "Specify an OData style filter rule that will be injected in the query sent to the database.")]
         public string? PolicyDatabase { get; }
+
+        [Option("cache.enabled", Required = false, HelpText = "Specify if caching is enabled for Entity, default value is false.")]
+        public string? CacheEnabled { get; }
+
+        [Option("cache.ttl", Required = false, HelpText = "Specify time to live in seconds for cache entries for Entity.")]
+        public string? CacheTtl { get; }
     }
 }

--- a/src/Cli/Commands/UpdateOptions.cs
+++ b/src/Cli/Commands/UpdateOptions.cs
@@ -40,6 +40,8 @@ namespace Cli.Commands
             IEnumerable<string>? fieldsToExclude,
             string? policyRequest,
             string? policyDatabase,
+            string? cacheEnabled,
+            string? cacheTtl,
             string config)
             : base(entity,
                   sourceType,
@@ -53,6 +55,8 @@ namespace Cli.Commands
                   fieldsToExclude,
                   policyRequest,
                   policyDatabase,
+                  cacheEnabled,
+                  cacheTtl,
                   config)
         {
             Source = source;

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -433,6 +433,7 @@ namespace Cli
 
             EntityRestOptions restOptions = ConstructRestOptions(options.RestRoute, SupportedRestMethods, initialRuntimeConfig.DataSource.DatabaseType == DatabaseType.CosmosDB_NoSQL);
             EntityGraphQLOptions graphqlOptions = ConstructGraphQLTypeDetails(options.GraphQLType, graphQLOperationsForStoredProcedures);
+            EntityCacheOptions? cacheOptions = ConstructCacheOptions(options.CacheEnabled, options.CacheTtl);
 
             // Create new entity.
             Entity entity = new(
@@ -441,7 +442,8 @@ namespace Cli
                 GraphQL: graphqlOptions,
                 Permissions: permissionSettings,
                 Relationships: null,
-                Mappings: null);
+                Mappings: null,
+                Cache: cacheOptions);
 
             // Add entity to existing runtime config.
             IDictionary<string, Entity> entities = new Dictionary<string, Entity>(initialRuntimeConfig.Entities.Entities)
@@ -1215,6 +1217,7 @@ namespace Cli
             Dictionary<string, string>? updatedMappings = entity.Mappings;
             EntityActionPolicy? updatedPolicy = GetPolicyForOperation(options.PolicyRequest, options.PolicyDatabase);
             EntityActionFields? updatedFields = GetFieldsForOperation(options.FieldsToInclude, options.FieldsToExclude);
+            EntityCacheOptions? updatedCacheOptions = ConstructCacheOptions(options.CacheEnabled, options.CacheTtl);
 
             if (!updatedGraphQLDetails.Enabled)
             {
@@ -1293,7 +1296,8 @@ namespace Cli
                 GraphQL: updatedGraphQLDetails,
                 Permissions: updatedPermissions,
                 Relationships: updatedRelationships,
-                Mappings: updatedMappings);
+                Mappings: updatedMappings,
+                Cache: updatedCacheOptions);
             IDictionary<string, Entity> entities = new Dictionary<string, Entity>(initialConfig.Entities.Entities)
             {
                 [options.Entity] = updatedEntity

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -829,6 +829,49 @@ namespace Cli
         }
 
         /// <summary>
+        /// Constructs the EntityCacheOption for Add/Update.
+        /// </summary>
+        /// <param name="cacheEnabled">String value that defines if the cache is enabled.</param>
+        /// <param name="cacheTtl">Int that gives time to live in seconds for cache.</param>
+        /// <returns>EntityCacheOption if values are provided for cacheEnabled or cacheTtl, null otherwise.</returns>
+        public static EntityCacheOptions? ConstructCacheOptions(string? cacheEnabled, string? cacheTtl)
+        {
+            if (cacheEnabled is null && cacheTtl is null)
+            {
+                return null;
+            }
+
+            EntityCacheOptions cacheOptions = new();
+            bool isEnabled = false;
+            int ttl = EntityCacheOptions.DEFAULT_TTL_SECONDS;
+
+            if (cacheEnabled is not null && !bool.TryParse(cacheEnabled, out isEnabled))
+            {
+                _logger.LogError("Invalid format for --cache.enabled. Accepted values are true/false.");
+            }
+
+            if ((cacheTtl is not null && !int.TryParse(cacheTtl, out ttl)) || ttl < 0)
+            {
+                _logger.LogError("Invalid format for --cache.ttl. Accepted values are any non-negative integer.");
+            }
+
+            // Both cacheEnabled and cacheTtl can not be null here, so if either one
+            // is, the other is not, and we return the cacheOptions with just that other
+            // value.
+            if (cacheEnabled is null)
+            {
+                return cacheOptions with { TtlSeconds = ttl };
+            }
+
+            if (cacheTtl is null)
+            {
+                return cacheOptions with { Enabled = isEnabled };
+            }
+
+            return cacheOptions with { Enabled = isEnabled, TtlSeconds = ttl };
+        }
+
+        /// <summary>
         /// Check if add/update command has Entity provided. Return false otherwise.
         /// </summary>
         public static bool IsEntityProvided(string? entity, ILogger cliLogger, string command)

--- a/src/Config/DatabasePrimitives/DatabaseObject.cs
+++ b/src/Config/DatabasePrimitives/DatabaseObject.cs
@@ -55,7 +55,7 @@ public abstract class DatabaseObject
     /// <summary>
     /// Get the underlying SourceDefinition based on database object source type
     /// </summary>
-    public SourceDefinition SourceDefinition
+    public virtual SourceDefinition SourceDefinition
     {
         get
         {

--- a/src/Config/HealthCheck/DatasourceHealthCheckConfig.cs
+++ b/src/Config/HealthCheck/DatasourceHealthCheckConfig.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Azure.DataApiBuilder.Config.Converters;
 using Azure.DataApiBuilder.Config.HealthCheck;
@@ -22,7 +21,6 @@ public record DatasourceHealthCheckConfig : HealthCheckConfig
     public int ThresholdMs { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    [MemberNotNullWhen(true, nameof(ThresholdMs))]
     public bool UserProvidedThresholdMs { get; set; } = false;
 
     public DatasourceHealthCheckConfig() : base()
@@ -30,13 +28,13 @@ public record DatasourceHealthCheckConfig : HealthCheckConfig
         ThresholdMs = HealthCheckConstants.DEFAULT_THRESHOLD_RESPONSE_TIME_MS;
     }
 
-    public DatasourceHealthCheckConfig(bool? Enabled, string? Name = null, int? ThresholdMs = null) : base(Enabled)
+    public DatasourceHealthCheckConfig(bool? enabled, string? name = null, int? thresholdMs = null) : base(enabled)
     {
-        this.Name = Name;
+        this.Name = name;
 
-        if (ThresholdMs is not null)
+        if (thresholdMs is not null)
         {
-            this.ThresholdMs = (int)ThresholdMs;
+            this.ThresholdMs = (int)thresholdMs;
             UserProvidedThresholdMs = true;
         }
         else

--- a/src/Config/HealthCheck/EntityHealthCheckConfig.cs
+++ b/src/Config/HealthCheck/EntityHealthCheckConfig.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Azure.DataApiBuilder.Config.Converters;
 using Azure.DataApiBuilder.Config.HealthCheck;
@@ -23,11 +22,9 @@ public record EntityHealthCheckConfig : HealthCheckConfig
     public int ThresholdMs { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    [MemberNotNullWhen(true, nameof(First))]
     public bool UserProvidedFirst { get; set; } = false;
 
     [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    [MemberNotNullWhen(true, nameof(ThresholdMs))]
     public bool UserProvidedThresholdMs { get; set; } = false;
 
     public EntityHealthCheckConfig() : base()
@@ -36,11 +33,11 @@ public record EntityHealthCheckConfig : HealthCheckConfig
         ThresholdMs = HealthCheckConstants.DEFAULT_THRESHOLD_RESPONSE_TIME_MS;
     }
 
-    public EntityHealthCheckConfig(bool? Enabled, int? First = null, int? ThresholdMs = null) : base(Enabled)
+    public EntityHealthCheckConfig(bool? enabled, int? first = null, int? thresholdMs = null) : base(enabled)
     {
-        if (First is not null)
+        if (first is not null)
         {
-            this.First = (int)First;
+            this.First = (int)first;
             UserProvidedFirst = true;
         }
         else
@@ -48,9 +45,9 @@ public record EntityHealthCheckConfig : HealthCheckConfig
             this.First = HealthCheckConstants.DEFAULT_FIRST_VALUE;
         }
 
-        if (ThresholdMs is not null)
+        if (thresholdMs is not null)
         {
-            this.ThresholdMs = (int)ThresholdMs;
+            this.ThresholdMs = (int)thresholdMs;
             UserProvidedThresholdMs = true;
         }
         else

--- a/src/Config/HealthCheck/HealthCheckConfig.cs
+++ b/src/Config/HealthCheck/HealthCheckConfig.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Azure.DataApiBuilder.Config.ObjectModel;
@@ -11,7 +10,6 @@ public record HealthCheckConfig
     public bool Enabled { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
-    [MemberNotNullWhen(true, nameof(Enabled))]
     public bool UserProvidedEnabled { get; init; } = false;
 
     public HealthCheckConfig()
@@ -19,11 +17,11 @@ public record HealthCheckConfig
         Enabled = true;
     }
 
-    public HealthCheckConfig(bool? Enabled)
+    public HealthCheckConfig(bool? enabled)
     {
-        if (Enabled is not null)
+        if (enabled is not null)
         {
-            this.Enabled = (bool)Enabled;
+            this.Enabled = (bool)enabled;
             UserProvidedEnabled = true;
         }
         else

--- a/src/Config/HealthCheck/RuntimeHealthCheckConfig.cs
+++ b/src/Config/HealthCheck/RuntimeHealthCheckConfig.cs
@@ -1,24 +1,39 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Text.Json.Serialization;
+
 namespace Azure.DataApiBuilder.Config.ObjectModel;
 
 public record RuntimeHealthCheckConfig : HealthCheckConfig
 {
-    // TODO: Add support for caching in upcoming PRs
-    // public int cache-ttl-seconds { get; set; };
+    [JsonPropertyName("cache-ttl-seconds")]
+    public int CacheTtlSeconds { get; set; }
 
     public HashSet<string>? Roles { get; set; }
 
     // TODO: Add support for parallel stream to run the health check query in upcoming PRs
     // public int MaxDop { get; set; } = 1; // Parallelized streams to run Health Check (Default: 1)
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    public bool UserProvidedTtlOptions { get; init; } = false;
+
     public RuntimeHealthCheckConfig() : base()
     {
     }
 
-    public RuntimeHealthCheckConfig(bool? Enabled, HashSet<string>? Roles = null) : base(Enabled)
+    public RuntimeHealthCheckConfig(bool? enabled, HashSet<string>? roles = null, int? cacheTtlSeconds = null) : base(enabled)
     {
-        this.Roles = Roles;
+        this.Roles = roles;
+
+        if (cacheTtlSeconds is not null)
+        {
+            this.CacheTtlSeconds = (int)cacheTtlSeconds;
+            UserProvidedTtlOptions = true;
+        }
+        else
+        {
+            this.CacheTtlSeconds = EntityCacheOptions.DEFAULT_TTL_SECONDS;
+        }
     }
 }

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -22,7 +22,7 @@ public record RuntimeConfig
 
     public RuntimeOptions? Runtime { get; init; }
 
-    public RuntimeEntities Entities { get; init; }
+    public virtual RuntimeEntities Entities { get; init; }
 
     public DataSourceFiles? DataSourceFiles { get; init; }
 
@@ -325,7 +325,7 @@ public record RuntimeConfig
     /// <param name="dataSourceName">Name of datasource.</param>
     /// <returns>DataSource object.</returns>
     /// <exception cref="DataApiBuilderException">Not found exception if key is not found.</exception>
-    public DataSource GetDataSourceFromDataSourceName(string dataSourceName)
+    public virtual DataSource GetDataSourceFromDataSourceName(string dataSourceName)
     {
         CheckDataSourceNamePresent(dataSourceName);
         return _dataSourceNameToDataSource[dataSourceName];
@@ -430,7 +430,7 @@ public record RuntimeConfig
     /// <param name="entityName">Name of the entity to check cache configuration.</param>
     /// <returns>Number of seconds (ttl) that a cache entry should be valid before cache eviction.</returns>
     /// <exception cref="DataApiBuilderException">Raised when an invalid entity name is provided or if the entity has caching disabled.</exception>
-    public int GetEntityCacheEntryTtl(string entityName)
+    public virtual int GetEntityCacheEntryTtl(string entityName)
     {
         if (!Entities.TryGetValue(entityName, out Entity? entityConfig))
         {
@@ -464,7 +464,7 @@ public record RuntimeConfig
     /// - whether the datasource is SQL and session context is disabled.
     /// </summary>
     /// <returns>Whether cache operations should proceed.</returns>
-    public bool CanUseCache()
+    public virtual bool CanUseCache()
     {
         bool setSessionContextEnabled = DataSource.GetTypedOptions<MsSqlOptions>()?.SetSessionContext ?? true;
         return IsCachingEnabled && !setSessionContextEnabled;

--- a/src/Config/ObjectModel/RuntimeConfig.cs
+++ b/src/Config/ObjectModel/RuntimeConfig.cs
@@ -154,6 +154,10 @@ public record RuntimeConfig
     public HashSet<string> AllowedRolesForHealth =>
         Runtime?.Health?.Roles ?? new HashSet<string>();
 
+    [JsonIgnore]
+    public int CacheTtlSecondsForHealthReport =>
+        Runtime?.Health?.CacheTtlSeconds ?? EntityCacheOptions.DEFAULT_TTL_SECONDS;
+
     /// <summary>
     /// Retrieves the value of runtime.graphql.dwnto1joinopt.enabled property if present, default is false.
     /// </summary>

--- a/src/Core/Configurations/RuntimeConfigProvider.cs
+++ b/src/Core/Configurations/RuntimeConfigProvider.cs
@@ -117,7 +117,7 @@ public class RuntimeConfigProvider
     /// <returns>The RuntimeConfig instance.</returns>
     /// <remark>Dont use this method if environment variable references need to be retained.</remark>
     /// <exception cref="DataApiBuilderException">Thrown when the loader is unable to load an instance of the config from its known location.</exception>
-    public RuntimeConfig GetConfig()
+    public virtual RuntimeConfig GetConfig()
     {
         if (_configLoader.RuntimeConfig is not null)
         {

--- a/src/Core/Resolvers/BaseQueryStructure.cs
+++ b/src/Core/Resolvers/BaseQueryStructure.cs
@@ -19,7 +19,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <summary>
         /// The Entity name associated with this query as appears in the config file.
         /// </summary>
-        public string EntityName { get; set; }
+        public virtual string EntityName { get; set; }
 
         /// <summary>
         /// The alias of the entity as used in the generated query.
@@ -74,7 +74,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// DbPolicyPredicates is a string that represents the filter portion of our query
         /// in the WHERE Clause added by virtue of the database policy.
         /// </summary>
-        public Dictionary<EntityActionOperation, string?> DbPolicyPredicatesForOperations { get; set; } = new();
+        public virtual Dictionary<EntityActionOperation, string?> DbPolicyPredicatesForOperations { get; set; } = new();
 
         public const string PARAM_NAME_PREFIX = "@";
 
@@ -156,7 +156,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// <summary>
         /// Returns the SourceDefinitionDefinition for the entity(table/view) of this query.
         /// </summary>
-        public SourceDefinition GetUnderlyingSourceDefinition()
+        public virtual SourceDefinition GetUnderlyingSourceDefinition()
         {
             return MetadataProvider.GetSourceDefinition(EntityName);
         }

--- a/src/Core/Resolvers/SqlQueryEngine.cs
+++ b/src/Core/Resolvers/SqlQueryEngine.cs
@@ -12,12 +12,14 @@ using Azure.DataApiBuilder.Core.Resolvers.Factories;
 using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Core.Services.Cache;
 using Azure.DataApiBuilder.Core.Services.MetadataProviders;
+using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.GraphQLBuilder;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Queries;
 using HotChocolate.Resolvers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using ZiggyCreatures.Caching.Fusion;
 using static Azure.DataApiBuilder.Service.GraphQLBuilder.GraphQLStoredProcedureBuilder;
 
 namespace Azure.DataApiBuilder.Core.Resolvers
@@ -328,12 +330,13 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 // We want to avoid caching token metadata because token metadata can change frequently and we want to avoid caching it.
                 if (!dbPolicyConfigured && entityCacheEnabled)
                 {
-                    DatabaseQueryMetadata queryMetadata = new(queryText: queryString, dataSource: dataSourceName, queryParameters: structure.Parameters);
-                    JsonElement result = await _cache.GetOrSetAsync<JsonElement>(queryExecutor, queryMetadata, cacheEntryTtl: runtimeConfig.GetEntityCacheEntryTtl(entityName: structure.EntityName));
-                    byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(result);
-                    JsonDocument cacheServiceResponse = JsonDocument.Parse(jsonBytes);
-
-                    return cacheServiceResponse;
+                    return await GetResultInCacheScenario(
+                    runtimeConfig,
+                    structure,
+                    queryString,
+                    dataSourceName,
+                    queryExecutor
+                    );
                 }
             }
 
@@ -351,6 +354,82 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 dataSourceName: dataSourceName);
 
             return response;
+        }
+
+        private async Task<JsonDocument?> GetResultInCacheScenario(RuntimeConfig runtimeConfig, SqlQueryStructure structure, string queryString, string dataSourceName, IQueryExecutor queryExecutor)
+        {
+            DatabaseQueryMetadata queryMetadata = new(queryText: queryString, dataSource: dataSourceName, queryParameters: structure.Parameters);
+            JsonElement? result;
+            MaybeValue<JsonElement?>? maybeResult;
+            switch (structure.CacheControlOption?.ToLowerInvariant())
+            {
+                // Do not get result from cache even if it exists, still cache result.
+                case SqlQueryStructure.CACHE_CONTROL_NO_CACHE:
+                    result = await queryExecutor.ExecuteQueryAsync(
+                        sqltext: queryMetadata.QueryText,
+                        parameters: queryMetadata.QueryParameters,
+                        dataReaderHandler: queryExecutor.GetJsonResultAsync<JsonElement>,
+                        httpContext: _httpContextAccessor.HttpContext!,
+                        args: null,
+                        dataSourceName: queryMetadata.DataSource);
+                    _cache.Set<JsonElement?>(
+                        queryMetadata,
+                        cacheEntryTtl: runtimeConfig.GetEntityCacheEntryTtl(entityName: structure.EntityName),
+                        result);
+                    return ParseResultIntoJsonDocument(result);
+
+                // Do not store result even if valid, still get from cache if available.
+                case SqlQueryStructure.CACHE_CONTROL_NO_STORE:
+                    maybeResult = _cache.TryGet<JsonElement?>(queryMetadata);
+                    // maybeResult is a nullable wrapper so we must check hasValue at outer and inner layer.
+                    if (maybeResult.HasValue && maybeResult.Value.HasValue)
+                    {
+                        result = maybeResult.Value.Value;
+                    }
+                    else
+                    {
+                        result = await queryExecutor.ExecuteQueryAsync(
+                            sqltext: queryMetadata.QueryText,
+                            parameters: queryMetadata.QueryParameters,
+                            dataReaderHandler: queryExecutor.GetJsonResultAsync<JsonElement>,
+                            httpContext: _httpContextAccessor.HttpContext!,
+                            args: null,
+                            dataSourceName: queryMetadata.DataSource);
+                    }
+
+                    return ParseResultIntoJsonDocument(result);
+
+                // Only return query response if it exists in cache, return gateway timeout otherwise.
+                case SqlQueryStructure.CACHE_CONTROL_ONLY_IF_CACHED:
+                    maybeResult = _cache.TryGet<JsonElement?>(queryMetadata);
+                    // maybeResult is a nullable wrapper so we must check hasValue at outer and inner layer.
+                    if (maybeResult.HasValue && maybeResult.Value.HasValue)
+                    {
+                        result = maybeResult.Value.Value;
+                    }
+                    else
+                    {
+                        throw new DataApiBuilderException(
+                            message: "Header 'only-if-cached' was used but item was not found in cache.",
+                            statusCode: System.Net.HttpStatusCode.GatewayTimeout,
+                            subStatusCode: DataApiBuilderException.SubStatusCodes.ItemNotFound);
+                    }
+
+                    return ParseResultIntoJsonDocument(result);
+
+                default:
+                    result = await _cache.GetOrSetAsync<JsonElement>(
+                        queryExecutor,
+                        queryMetadata,
+                        cacheEntryTtl: runtimeConfig.GetEntityCacheEntryTtl(entityName: structure.EntityName));
+                    return ParseResultIntoJsonDocument(result);
+            }
+        }
+
+        private static JsonDocument? ParseResultIntoJsonDocument(JsonElement? result)
+        {
+            byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(result);
+            return JsonDocument.Parse(jsonBytes);
         }
 
         // <summary>

--- a/src/Core/Resolvers/SqlQueryEngine.cs
+++ b/src/Core/Resolvers/SqlQueryEngine.cs
@@ -332,6 +332,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     JsonElement result = await _cache.GetOrSetAsync<JsonElement>(queryExecutor, queryMetadata, cacheEntryTtl: runtimeConfig.GetEntityCacheEntryTtl(entityName: structure.EntityName));
                     byte[] jsonBytes = JsonSerializer.SerializeToUtf8Bytes(result);
                     JsonDocument cacheServiceResponse = JsonDocument.Parse(jsonBytes);
+
                     return cacheServiceResponse;
                 }
             }
@@ -348,6 +349,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 httpContext: _httpContextAccessor.HttpContext!,
                 args: null,
                 dataSourceName: dataSourceName);
+
             return response;
         }
 

--- a/src/Core/Services/BuildRequestStateMiddleware.cs
+++ b/src/Core/Services/BuildRequestStateMiddleware.cs
@@ -1,10 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
+using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Core.Telemetry;
 using HotChocolate.Execution;
+using HotChocolate.Language;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
+using Kestral = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
 using RequestDelegate = HotChocolate.Execution.RequestDelegate;
 
 /// <summary>
@@ -13,10 +20,12 @@ using RequestDelegate = HotChocolate.Execution.RequestDelegate;
 public sealed class BuildRequestStateMiddleware
 {
     private readonly RequestDelegate _next;
+    private readonly RuntimeConfigProvider _runtimeConfigProvider;
 
-    public BuildRequestStateMiddleware(RequestDelegate next)
+    public BuildRequestStateMiddleware(RequestDelegate next, RuntimeConfigProvider runtimeConfigProvider)
     {
         _next = next;
+        _runtimeConfigProvider = runtimeConfigProvider;
     }
 
     /// <summary>
@@ -26,14 +35,97 @@ public sealed class BuildRequestStateMiddleware
     /// <param name="context">HotChocolate execution request context.</param>
     public async ValueTask InvokeAsync(IRequestContext context)
     {
-        if (context.ContextData.TryGetValue(nameof(HttpContext), out object? value) &&
-            value is HttpContext httpContext)
+        bool isIntrospectionQuery = context.Request.OperationName == "IntrospectionQuery";
+        ApiType apiType = ApiType.GraphQL;
+        Kestral method = Kestral.Post;
+        string route = _runtimeConfigProvider.GetConfig().GraphQLPath.Trim('/');
+        DefaultHttpContext httpContext = (DefaultHttpContext)context.ContextData.First(x => x.Key == "HttpContext").Value!;
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        using Activity? activity = !isIntrospectionQuery ?
+            TelemetryTracesHelper.DABActivitySource.StartActivity($"{method} /{route}") : null;
+
+        try
         {
-            // Because Request.Headers is a NameValueCollection type, key not found will return StringValues.Empty and not an exception.
-            StringValues clientRoleHeader = httpContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER];
-            context.ContextData.TryAdd(key: AuthorizationResolver.CLIENT_ROLE_HEADER, value: clientRoleHeader);
+            // We want to ignore introspection queries DAB uses to check access to GraphQL since they are not sent by the user.
+            if (!isIntrospectionQuery)
+            {
+                TelemetryMetricsHelper.IncrementActiveRequests(apiType);
+                if (activity is not null)
+                {
+                    activity.TrackMainControllerActivityStarted(
+                        httpMethod: method,
+                        userAgent: httpContext.Request.Headers["User-Agent"].ToString(),
+                        actionType: (context.Request.Query!.ToString().Contains("mutation") ? OperationType.Mutation : OperationType.Query).ToString(),
+                        httpURL: string.Empty, // GraphQL has no route
+                        queryString: null, // GraphQL has no query-string
+                        userRole: httpContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER].FirstOrDefault() ?? httpContext.User.FindFirst("role")?.Value,
+                        apiType: apiType);
+                }
+            }
+
+            await InvokeAsync();
+        }
+        finally
+        {
+            stopwatch.Stop();
+
+            HttpStatusCode statusCode;
+
+            // We want to ignore introspection queries DAB uses to check access to GraphQL since they are not sent by the user.
+            if (!isIntrospectionQuery)
+            {
+                // There is an error in GraphQL when ContextData is not null
+                if (context.Result!.ContextData is not null)
+                {
+                    if (context.Result.ContextData.ContainsKey(WellKnownContextData.ValidationErrors))
+                    {
+                        statusCode = HttpStatusCode.BadRequest;
+                    }
+                    else if (context.Result.ContextData.ContainsKey(WellKnownContextData.OperationNotAllowed))
+                    {
+                        statusCode = HttpStatusCode.MethodNotAllowed;
+                    }
+                    else
+                    {
+                        statusCode = HttpStatusCode.InternalServerError;
+                    }
+
+                    Exception ex = new();
+                    if (context.Result.Errors is not null)
+                    {
+                        string errorMessage = context.Result.Errors[0].Message;
+                        ex = new(errorMessage);
+                    }
+
+                    // Activity will track error
+                    activity?.TrackMainControllerActivityFinishedWithException(ex, statusCode);
+                    TelemetryMetricsHelper.TrackError(method, statusCode, route, apiType, ex);
+                }
+                else
+                {
+                    statusCode = HttpStatusCode.OK;
+                    activity?.TrackMainControllerActivityFinished(statusCode);
+                }
+
+                TelemetryMetricsHelper.TrackRequest(method, statusCode, route, apiType);
+                TelemetryMetricsHelper.TrackRequestDuration(method, statusCode, route, apiType, stopwatch.Elapsed);
+                TelemetryMetricsHelper.DecrementActiveRequests(apiType);
+            }
         }
 
-        await _next(context).ConfigureAwait(false);
+        async Task InvokeAsync()
+        {
+            if (context.ContextData.TryGetValue(nameof(HttpContext), out object? value) &&
+                value is HttpContext httpContext)
+            {
+                // Because Request.Headers is a NameValueCollection type, key not found will return StringValues.Empty and not an exception.
+                StringValues clientRoleHeader = httpContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER];
+                context.ContextData.TryAdd(key: AuthorizationResolver.CLIENT_ROLE_HEADER, value: clientRoleHeader);
+            }
+
+            await _next(context).ConfigureAwait(false);
+        }
     }
 }
+

--- a/src/Core/Services/Cache/DabCacheService.cs
+++ b/src/Core/Services/Cache/DabCacheService.cs
@@ -82,6 +82,41 @@ public class DabCacheService
     }
 
     /// <summary>
+    /// Try to get cacheValue from the cache with the derived cache key.
+    /// </summary>
+    /// <typeparam name="JsonElement">The type of value in the cache</typeparam>
+    /// <param name="queryMetadata">Metadata used to create a cache key or fetch a response from the database.</param>
+    /// <returns>JSON Response</returns>
+    public MaybeValue<JsonElement>? TryGet<JsonElement>(DatabaseQueryMetadata queryMetadata)
+    {
+        string cacheKey = CreateCacheKey(queryMetadata);
+        return _cache.TryGet<JsonElement>(key: cacheKey);
+    }
+
+    /// <summary>
+    /// Store cacheValue into the cache with the derived cache key.
+    /// </summary>
+    /// <typeparam name="JsonElement">The type of value in the cache</typeparam>
+    /// <param name="queryMetadata">Metadata used to create a cache key or fetch a response from the database.</param>
+    /// <param name="cacheEntryTtl">Number of seconds the cache entry should be valid before eviction.</param>
+    /// <param name="cacheValue"">The value to store in the cache.</param>
+    public void Set<JsonElement>(
+        DatabaseQueryMetadata queryMetadata,
+        int cacheEntryTtl,
+        JsonElement? cacheValue)
+    {
+        string cacheKey = CreateCacheKey(queryMetadata);
+        _cache.Set(
+            key: cacheKey,
+            value: cacheValue,
+            (FusionCacheEntryOptions options) =>
+            {
+                options.SetSize(EstimateCacheEntrySize(cacheKey: cacheKey, cacheValue: cacheValue?.ToString()));
+                options.SetDuration(duration: TimeSpan.FromSeconds(cacheEntryTtl));
+            });
+    }
+
+    /// <summary>
     /// Attempts to fetch response from cache. If there is a cache miss, invoke executeQueryAsync Func to get a response
     /// </summary>
     /// <typeparam name="TResult">Response payload Type</typeparam>

--- a/src/Core/Services/ExecutionHelper.cs
+++ b/src/Core/Services/ExecutionHelper.cs
@@ -10,7 +10,6 @@ using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Resolvers;
 using Azure.DataApiBuilder.Core.Resolvers.Factories;
 using Azure.DataApiBuilder.Core.Telemetry;
-using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.GraphQLBuilder;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.CustomScalars;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.GraphQLTypes;

--- a/src/Core/Services/ExecutionHelper.cs
+++ b/src/Core/Services/ExecutionHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using Azure.DataApiBuilder.Config.ObjectModel;
@@ -8,6 +9,8 @@ using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Resolvers;
 using Azure.DataApiBuilder.Core.Resolvers.Factories;
+using Azure.DataApiBuilder.Core.Telemetry;
+using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.GraphQLBuilder;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.CustomScalars;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.GraphQLTypes;
@@ -17,6 +20,7 @@ using HotChocolate.Language;
 using HotChocolate.Resolvers;
 using HotChocolate.Types.NodaTime;
 using NodaTime.Text;
+using Kestral = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
 
 namespace Azure.DataApiBuilder.Service.Services
 {
@@ -50,6 +54,8 @@ namespace Azure.DataApiBuilder.Service.Services
         /// </param>
         public async ValueTask ExecuteQueryAsync(IMiddlewareContext context)
         {
+            using Activity? activity = StartQueryActivity(context);
+
             string dataSourceName = GraphQLUtils.GetDataSourceNameFromGraphQLContext(context, _runtimeConfigProvider.GetConfig());
             DataSource ds = _runtimeConfigProvider.GetConfig().GetDataSourceFromDataSourceName(dataSourceName);
             IQueryEngine queryEngine = _queryEngineFactory.GetQueryEngine(ds.DatabaseType);
@@ -91,6 +97,8 @@ namespace Azure.DataApiBuilder.Service.Services
         /// </param>
         public async ValueTask ExecuteMutateAsync(IMiddlewareContext context)
         {
+            using Activity? activity = StartQueryActivity(context);
+
             string dataSourceName = GraphQLUtils.GetDataSourceNameFromGraphQLContext(context, _runtimeConfigProvider.GetConfig());
             DataSource ds = _runtimeConfigProvider.GetConfig().GetDataSourceFromDataSourceName(dataSourceName);
             IQueryEngine queryEngine = _queryEngineFactory.GetQueryEngine(ds.DatabaseType);
@@ -125,6 +133,31 @@ namespace Azure.DataApiBuilder.Service.Services
                 SetContextResult(context, result.Item1);
                 SetNewMetadata(context, result.Item2);
             }
+        }
+
+        /// <summary>
+        /// Starts the activity for the query
+        /// </summary>
+        /// <param name="context">
+        /// The middleware context.
+        /// </param>
+        private Activity? StartQueryActivity(IMiddlewareContext context)
+        {
+            string route = _runtimeConfigProvider.GetConfig().GraphQLPath.Trim('/');
+            Kestral method = Kestral.Post;
+
+            Activity? activity = TelemetryTracesHelper.DABActivitySource.StartActivity($"{method} /{route}");
+
+            if (activity is not null)
+            {
+                string dataSourceName = GraphQLUtils.GetDataSourceNameFromGraphQLContext(context, _runtimeConfigProvider.GetConfig());
+                DataSource ds = _runtimeConfigProvider.GetConfig().GetDataSourceFromDataSourceName(dataSourceName);
+                activity.TrackQueryActivityStarted(
+                    databaseType: ds.DatabaseType,
+                    dataSourceName: dataSourceName);
+            }
+
+            return activity;
         }
 
         /// <summary>
@@ -425,7 +458,7 @@ namespace Azure.DataApiBuilder.Service.Services
 
         public static InputObjectType InputObjectTypeFromIInputField(IInputField field)
         {
-            return (InputObjectType)(InnerMostType(field.Type));
+            return (InputObjectType)InnerMostType(field.Type);
         }
 
         /// <summary>

--- a/src/Core/Services/MetadataProviders/ISqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/ISqlMetadataProvider.cs
@@ -121,7 +121,7 @@ namespace Azure.DataApiBuilder.Core.Services
         /// </summary>
         /// <param name="entityName">The entity whose mapping we lookup.</param>
         /// <param name="field">The field used for the lookup in the mapping.</param>
-        /// <param name="name"/>Out parameter in which we will save backing column name.<param>
+        /// <param name="name"/>Out parameter in which we will save backing column name.</param>
         /// <returns>True if exists, false otherwise.</returns>
         /// <throws>KeyNotFoundException if entity name not found.</throws>
         bool TryGetBackingColumn(string entityName, string field, [NotNullWhen(true)] out string? name);
@@ -131,6 +131,16 @@ namespace Azure.DataApiBuilder.Core.Services
         /// </summary>
         /// <returns></returns>
         DatabaseType GetDatabaseType();
+
+        /// <summary>
+        /// Method to access the dictionary since DatabaseObject is abstract class
+        /// </summary>
+        /// <param name="key">Key.</param>
+        /// <returns>DatabaseObject.</returns>
+        public virtual DatabaseObject GetDatabaseObjectByKey(string key)
+        {
+            return EntityToDatabaseObject[key];
+        }
 
         IQueryBuilder GetQueryBuilder();
 

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -81,7 +81,7 @@ namespace Azure.DataApiBuilder.Core.Services
         /// <summary>
         /// Maps an entity name to a DatabaseObject.
         /// </summary>
-        public Dictionary<string, DatabaseObject> EntityToDatabaseObject { get; set; } =
+        public virtual Dictionary<string, DatabaseObject> EntityToDatabaseObject { get; set; } =
             new(StringComparer.InvariantCulture);
 
         protected readonly ILogger<ISqlMetadataProvider> _logger;

--- a/src/Core/Telemetry/TelemetryMetricsHelper.cs
+++ b/src/Core/Telemetry/TelemetryMetricsHelper.cs
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Net;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Kestral = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
 
-namespace Azure.DataApiBuilder.Service.Telemetry
+namespace Azure.DataApiBuilder.Core.Telemetry
 {
     /// <summary>
     /// Helper class for tracking telemetry metrics such as active requests, errors, total requests,

--- a/src/Core/Telemetry/TelemetryTracesHelper.cs
+++ b/src/Core/Telemetry/TelemetryTracesHelper.cs
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Diagnostics;
 using System.Net;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using OpenTelemetry.Trace;
 using Kestral = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
 
-namespace Azure.DataApiBuilder.Service.Telemetry
+namespace Azure.DataApiBuilder.Core.Telemetry
 {
     public static class TelemetryTracesHelper
     {
@@ -18,7 +17,7 @@ namespace Azure.DataApiBuilder.Service.Telemetry
         public static readonly ActivitySource DABActivitySource = new("DataApiBuilder");
 
         /// <summary>
-        /// Tracks the start of a REST controller activity.
+        /// Tracks the start of the main controller activity.
         /// </summary>
         /// <param name="activity">The activity instance.</param>
         /// <param name="httpMethod">The HTTP method of the request (e.g., GET, POST).</param>
@@ -28,11 +27,11 @@ namespace Azure.DataApiBuilder.Service.Telemetry
         /// <param name="queryString">The query string of the request, if any.</param>
         /// <param name="userRole">The role of the user making the request.</param>
         /// <param name="apiType">The type of API being used (e.g., REST, GraphQL).</param>
-        public static void TrackRestControllerActivityStarted(
+        public static void TrackMainControllerActivityStarted(
             this Activity activity,
             Kestral httpMethod,
             string userAgent,
-            string actionType,
+            string actionType, // CRUD(EntityActionOperation) for REST, Query|Mutation(OperationType) for GraphQL
             string httpURL,
             string? queryString,
             string? userRole,
@@ -78,11 +77,11 @@ namespace Azure.DataApiBuilder.Service.Telemetry
         }
 
         /// <summary>
-        /// Tracks the completion of a REST controller activity.
+        /// Tracks the completion of the main controller activity without any exceptions.
         /// </summary>
         /// <param name="activity">The activity instance.</param>
         /// <param name="statusCode">The HTTP status code of the response.</param>
-        public static void TrackRestControllerActivityFinished(
+        public static void TrackMainControllerActivityFinished(
             this Activity activity,
             HttpStatusCode statusCode)
         {
@@ -93,12 +92,12 @@ namespace Azure.DataApiBuilder.Service.Telemetry
         }
 
         /// <summary>
-        /// Tracks the completion of a REST controller activity with an exception.
+        /// Tracks the completion of the main controller activity with an exception.
         /// </summary>
         /// <param name="activity">The activity instance.</param>
         /// <param name="ex">The exception that occurred.</param>
         /// <param name="statusCode">The HTTP status code of the response.</param>
-        public static void TrackRestControllerActivityFinishedWithException(
+        public static void TrackMainControllerActivityFinishedWithException(
             this Activity activity,
             Exception ex,
             HttpStatusCode statusCode)

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -29,7 +29,7 @@
         <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
         <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
         <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
-        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+        <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.3" />
         <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
         <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />

--- a/src/Service.Tests/Caching/HealthEndpointCachingTests.cs
+++ b/src/Service.Tests/Caching/HealthEndpointCachingTests.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Service.Tests.Configuration;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Azure.DataApiBuilder.Service.Tests.Caching;
+
+/// <summary>
+/// Validates that the caching of health endpoint behaves as expected.
+/// </summary>
+[TestClass]
+public class HealthEndpointCachingTests
+{
+    private const string CUSTOM_CONFIG_FILENAME = "custom-config.json";
+
+    [TestCleanup]
+    public void CleanupAfterEachTest()
+    {
+        if (File.Exists(CUSTOM_CONFIG_FILENAME))
+        {
+            File.Delete(CUSTOM_CONFIG_FILENAME);
+        }
+
+        TestHelper.UnsetAllDABEnvironmentVariables();
+    }
+
+    /// <summary>
+    /// Simulates GET requests to DAB's comprehensive health check endpoint ('/health') and validates the contents of the response.
+    /// The expected behavior is that these responses should be different as we supply delay in between them.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(TestCategory.MSSQL)]
+    [DataRow(null, DisplayName = "Validation of default cache TTL and delay.")]
+    [DataRow(0, DisplayName = "Validation of cache TTL set to 0 and delay.")]
+    [DataRow(10, DisplayName = "Validation of cache TTL set to 10 and delay.")]
+    public async Task ComprehensiveHealthEndpointCachingValidateWithDelay(int? cacheTtlSeconds)
+    {
+        SetupCachingTest(cacheTtlSeconds);
+        string[] args = new[]
+        {
+            $"--ConfigFileName={CUSTOM_CONFIG_FILENAME}"
+        };
+
+        using (TestServer server = new(Program.CreateWebHostBuilder(args)))
+        using (HttpClient client = server.CreateClient())
+        {
+            HttpRequestMessage healthRequest1 = new(HttpMethod.Get, "/health");
+            HttpResponseMessage response = await client.SendAsync(healthRequest1);
+            string responseContent1 = await response.Content.ReadAsStringAsync();
+            Assert.AreEqual(expected: HttpStatusCode.OK, actual: response.StatusCode, message: "Received unexpected HTTP code from health check endpoint.");
+
+            // Simulate a "delay" to allow the cache to expire (in case available)
+            // and send a new request to the health endpoint.
+            Task.Delay((cacheTtlSeconds ?? EntityCacheOptions.DEFAULT_TTL_SECONDS) * 1000 + 1000).Wait();
+
+            HttpRequestMessage healthRequest2 = new(HttpMethod.Get, "/health");
+            response = await client.SendAsync(healthRequest2);
+            string responseContent2 = await response.Content.ReadAsStringAsync();
+
+            // Responses are not the same as a new request was made to the DB (change in responseTimeMs for DB health check)
+            Assert.AreNotEqual(responseContent2, responseContent1);
+        }
+    }
+
+    /// <summary>
+    /// Simulates GET request to DAB's comprehensive health check endpoint ('/health') and validates the contents of the response.
+    /// The expected behavior is that both these responses should be same in case cache is enabled with no delay between the two requests.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(TestCategory.MSSQL)]
+    [DataRow(null, DisplayName = "Validation of default cache TTL and no delay.")]
+    [DataRow(0, DisplayName = "Validation of cache TTL set to 0 and no delay.")]
+    [DataRow(10, DisplayName = "Validation of cache TTL set to 10 and no delay.")]
+    public async Task ComprehensiveHealthEndpointCachingValidateNoDelay(int? cacheTtlSeconds)
+    {
+        SetupCachingTest(cacheTtlSeconds);
+        string[] args = new[]
+        {
+            $"--ConfigFileName={CUSTOM_CONFIG_FILENAME}"
+        };
+
+        using (TestServer server = new(Program.CreateWebHostBuilder(args)))
+        using (HttpClient client = server.CreateClient())
+        {
+            HttpRequestMessage healthRequest1 = new(HttpMethod.Get, "/health");
+            HttpResponseMessage response = await client.SendAsync(healthRequest1);
+            string responseContent1 = await response.Content.ReadAsStringAsync();
+            Assert.AreEqual(expected: HttpStatusCode.OK, actual: response.StatusCode, message: "Received unexpected HTTP code from health check endpoint.");
+
+            // Simulate a "no delay" scenario to make sure that the cache is not expired (in case available)
+            // and send a new request to the health endpoint.
+            HttpRequestMessage healthRequest2 = new(HttpMethod.Get, "/health");
+            response = await client.SendAsync(healthRequest2);
+            string responseContent2 = await response.Content.ReadAsStringAsync();
+
+            if (cacheTtlSeconds == 0)
+            {
+                // Responses are not the same as a new request was made to the DB (change in responseTimeMs for DB health check)
+                Assert.AreNotEqual(responseContent2, responseContent1);
+            }
+            else
+            {
+                // Response are the same as its coming from Cache (Timestamp would also be the same)
+                Assert.AreEqual(responseContent2, responseContent1);
+            }
+        }
+    }
+
+    private static void SetupCachingTest(int? cacheTtlSeconds)
+    {
+        Entity requiredEntity = new(
+            Health: new(enabled: true),
+            Source: new("books", EntitySourceType.Table, null, null),
+            Rest: new(Enabled: true),
+            GraphQL: new("book", "books", true),
+            Permissions: new[] { ConfigurationTests.GetMinimalPermissionConfig(AuthorizationResolver.ROLE_ANONYMOUS) },
+            Relationships: null,
+            Mappings: null);
+
+        Dictionary<string, Entity> entityMap = new()
+        {
+            { "Book", requiredEntity }
+        };
+
+        CreateCustomConfigFile(entityMap, cacheTtlSeconds);
+    }
+
+    /// <summary>
+    /// Helper function to write custom configuration file. with minimal REST/GraphQL global settings
+    /// using the supplied entities.
+    /// </summary>
+    /// <param name="entityMap">Collection of entityName -> Entity object.</param>
+    /// <param name="cacheTtlSeconds">flag to enable or disabled REST globally.</param>
+    private static void CreateCustomConfigFile(Dictionary<string, Entity> entityMap, int? cacheTtlSeconds)
+    {
+        DataSource dataSource = new(
+            DatabaseType.MSSQL,
+            ConfigurationTests.GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL),
+            Options: null,
+            Health: new(true));
+        HostOptions hostOptions = new(Mode: HostMode.Development, Cors: null, Authentication: new() { Provider = nameof(EasyAuthType.StaticWebApps) });
+
+        RuntimeConfig runtimeConfig = new(
+            Schema: string.Empty,
+            DataSource: dataSource,
+            Runtime: new(
+                Health: new(enabled: true, cacheTtlSeconds: cacheTtlSeconds),
+                Rest: new(Enabled: true),
+                GraphQL: new(Enabled: true),
+                Host: hostOptions
+            ),
+            Entities: new(entityMap));
+
+        File.WriteAllText(
+            path: CUSTOM_CONFIG_FILENAME,
+            contents: runtimeConfig.ToJson());
+    }
+
+}

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -4023,7 +4023,9 @@ type Planet @model(name:""PlanetAlias"") {
         /// <summary>
         /// Simulates a GET request to DAB's comprehensive health check endpoint ('/health') and validates the contents of the response.
         /// The expected format of the response is the comprehensive health check response.
+        /// This test is currently flakey, failing intermittently in our pipeline, and is therefore ignored.
         /// </summary>
+        [Ignore]
         [TestMethod]
         [TestCategory(TestCategory.MSSQL)]
         [DataRow(true, true, true, true, true, true, true, DisplayName = "Validate Health Report all enabled.")]

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -3726,6 +3726,7 @@ type Planet @model(name:""PlanetAlias"") {
         /// <summary>
         /// Tests different log level filters that are valid and check that they are deserialized correctly
         /// </summary>
+        [Ignore]
         [DataTestMethod]
         [TestCategory(TestCategory.MSSQL)]
         [DataRow(LogLevel.Trace, typeof(RuntimeConfigValidator))]
@@ -4043,7 +4044,7 @@ type Planet @model(name:""PlanetAlias"") {
             // Even though this entity is not under test, it must be supplied enable successful
             // config file creation.
             Entity requiredEntity = new(
-                Health: new(Enabled: enableEntityHealth),
+                Health: new(enabled: enableEntityHealth),
                 Source: new("books", EntitySourceType.Table, null, null),
                 Rest: new(Enabled: enableEntityRest),
                 GraphQL: new("book", "books", enableEntityGraphQL),
@@ -4682,7 +4683,7 @@ type Planet @model(name:""PlanetAlias"") {
                 Schema: string.Empty,
                 DataSource: dataSource,
                 Runtime: new(
-                    Health: new(Enabled: enableGlobalHealth),
+                    Health: new(enabled: enableGlobalHealth),
                     Rest: new(Enabled: enableGlobalRest),
                     GraphQL: new(Enabled: enableGlobalGraphql),
                     Host: hostOptions
@@ -5092,9 +5093,9 @@ type Planet @model(name:""PlanetAlias"") {
             entityName ??= "Book";
 
             Dictionary<string, Entity> entityMap = new()
-        {
-            { entityName, entity }
-        };
+            {
+                { entityName, entity }
+            };
 
             // Adding an entity with only Authorized Access
             Entity anotherEntity = new(

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -20,7 +20,6 @@ using System.Threading.Tasks;
 using System.Web;
 using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config;
-using Azure.DataApiBuilder.Config.HealthCheck;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core;
 using Azure.DataApiBuilder.Core.AuthenticationHelpers;
@@ -4018,221 +4017,7 @@ type Planet @model(name:""PlanetAlias"") {
             Dictionary<string, JsonElement> responseProperties = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(responseBody);
             Assert.AreEqual(expected: HttpStatusCode.OK, actual: response.StatusCode, message: "Received unexpected HTTP code from health check endpoint.");
 
-            ValidateBasicDetailsHealthCheckResponse(responseProperties);
-        }
-
-        /// <summary>
-        /// Simulates a GET request to DAB's comprehensive health check endpoint ('/health') and validates the contents of the response.
-        /// The expected format of the response is the comprehensive health check response.
-        /// This test is currently flakey, failing intermittently in our pipeline, and is therefore ignored.
-        /// </summary>
-        [Ignore]
-        [TestMethod]
-        [TestCategory(TestCategory.MSSQL)]
-        [DataRow(true, true, true, true, true, true, true, DisplayName = "Validate Health Report all enabled.")]
-        [DataRow(false, true, true, true, true, true, true, DisplayName = "Validate when Comprehensive Health Report is disabled")]
-        [DataRow(true, true, true, false, true, true, true, DisplayName = "Validate Health Report when data-source health is disabled")]
-        [DataRow(true, true, true, true, false, true, true, DisplayName = "Validate Health Report when entity health is disabled")]
-        [DataRow(true, false, true, true, true, true, true, DisplayName = "Validate Health Report when global rest health is disabled")]
-        [DataRow(true, true, true, true, true, false, true, DisplayName = "Validate Health Report when entity rest health is disabled")]
-        [DataRow(true, true, false, true, true, true, true, DisplayName = "Validate Health Report when global graphql health is disabled")]
-        [DataRow(true, true, true, true, true, true, false, DisplayName = "Validate Health Report when entity graphql health is disabled")]
-        public async Task ComprehensiveHealthEndpoint_ValidateContents(bool enableGlobalHealth, bool enableGlobalRest, bool enableGlobalGraphql, bool enableDatasourceHealth, bool enableEntityHealth, bool enableEntityRest, bool enableEntityGraphQL)
-        {
-            // Arrange
-            // At least one entity is required in the runtime config for the engine to start.
-            // Even though this entity is not under test, it must be supplied enable successful
-            // config file creation.
-            Entity requiredEntity = new(
-                Health: new(enabled: enableEntityHealth),
-                Source: new("books", EntitySourceType.Table, null, null),
-                Rest: new(Enabled: enableEntityRest),
-                GraphQL: new("book", "books", enableEntityGraphQL),
-                Permissions: new[] { GetMinimalPermissionConfig(AuthorizationResolver.ROLE_ANONYMOUS) },
-                Relationships: null,
-                Mappings: null);
-
-            Dictionary<string, Entity> entityMap = new()
-            {
-                { "Book", requiredEntity }
-            };
-
-            CreateCustomConfigFile(entityMap, enableGlobalRest, enableGlobalGraphql, enableGlobalHealth, enableDatasourceHealth, HostMode.Development);
-
-            string[] args = new[]
-            {
-                $"--ConfigFileName={CUSTOM_CONFIG_FILENAME}"
-            };
-
-            using (TestServer server = new(Program.CreateWebHostBuilder(args)))
-            using (HttpClient client = server.CreateClient())
-            {
-                HttpRequestMessage healthRequest = new(HttpMethod.Get, "/health");
-                HttpResponseMessage response = await client.SendAsync(healthRequest);
-
-                if (!enableGlobalHealth)
-                {
-                    Assert.AreEqual(expected: HttpStatusCode.NotFound, actual: response.StatusCode, message: "Received unexpected HTTP code from health check endpoint.");
-                }
-                else
-                {
-                    string responseBody = await response.Content.ReadAsStringAsync();
-                    Dictionary<string, JsonElement> responseProperties = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(responseBody);
-                    Assert.AreEqual(expected: HttpStatusCode.OK, actual: response.StatusCode, message: "Received unexpected HTTP code from health check endpoint.");
-
-                    ValidateBasicDetailsHealthCheckResponse(responseProperties);
-                    ValidateConfigurationDetailsHealthCheckResponse(responseProperties, enableGlobalRest, enableGlobalGraphql);
-                    ValidateIfAttributePresentInResponse(responseProperties, enableDatasourceHealth, HealthCheckConstants.DATASOURCE);
-                    ValidateIfAttributePresentInResponse(responseProperties, enableEntityHealth, HealthCheckConstants.ENDPOINT);
-                    if (enableEntityHealth)
-                    {
-                        ValidateEntityRestAndGraphQLResponse(responseProperties, enableEntityRest, enableEntityGraphQL, enableGlobalRest, enableGlobalGraphql);
-                    }
-                }
-            }
-        }
-
-        private static void ValidateEntityRestAndGraphQLResponse(
-            Dictionary<string, JsonElement> responseProperties,
-            bool enableEntityRest,
-            bool enableEntityGraphQL,
-            bool enableGlobalRest,
-            bool enableGlobalGraphQL)
-        {
-            bool hasRestTag = false, hasGraphQLTag = false;
-            if (responseProperties.TryGetValue("checks", out JsonElement checksElement) && checksElement.ValueKind == JsonValueKind.Array)
-            {
-                checksElement.EnumerateArray().ToList().ForEach(entityCheck =>
-                {
-                    // Check if the 'tags' property exists and is of type array
-                    if (entityCheck.TryGetProperty("tags", out JsonElement tagsElement) && tagsElement.ValueKind == JsonValueKind.Array)
-                    {
-                        hasRestTag = hasRestTag || tagsElement.EnumerateArray().Any(tag => tag.ToString() == HealthCheckConstants.REST);
-                        hasGraphQLTag = hasGraphQLTag || tagsElement.EnumerateArray().Any(tag => tag.ToString() == HealthCheckConstants.GRAPHQL);
-                    }
-                });
-
-                if (enableGlobalRest)
-                {
-                    // When both enableEntityRest and hasRestTag match the same value
-                    Assert.AreEqual(enableEntityRest, hasRestTag);
-                }
-                else
-                {
-                    Assert.IsFalse(hasRestTag);
-                }
-
-                if (enableGlobalGraphQL)
-                {
-                    // When both enableEntityGraphQL and hasGraphQLTag match the same value
-                    Assert.AreEqual(enableEntityGraphQL, hasGraphQLTag);
-                }
-                else
-                {
-                    Assert.IsFalse(hasGraphQLTag);
-                }
-            }
-        }
-
-        private static void ValidateIfAttributePresentInResponse(
-            Dictionary<string, JsonElement> responseProperties,
-            bool enableFlag,
-            string checkString)
-        {
-            if (responseProperties.TryGetValue("checks", out JsonElement checksElement) && checksElement.ValueKind == JsonValueKind.Array)
-            {
-                bool checksTags = checksElement.EnumerateArray().Any(entityCheck =>
-                {
-                    if (entityCheck.TryGetProperty("tags", out JsonElement tagsElement) && tagsElement.ValueKind == JsonValueKind.Array)
-                    {
-                        return tagsElement.EnumerateArray().Any(tag => tag.ToString() == checkString);
-                    }
-
-                    return false;
-                });
-
-                Assert.AreEqual(enableFlag, checksTags);
-            }
-            else
-            {
-                Assert.Fail("Checks array is not present in the Comprehensive Health Check Report.");
-            }
-        }
-
-        private static void ValidateConfigurationIsNotNull(Dictionary<string, JsonElement> configPropertyValues, string objectKey)
-        {
-            Assert.IsTrue(configPropertyValues.ContainsKey(objectKey), $"Expected {objectKey} to be present in the configuration object.");
-            Assert.IsNotNull(configPropertyValues[objectKey], $"Expected {objectKey} to be non-null.");
-        }
-
-        private static void ValidateConfigurationIsCorrectFlag(Dictionary<string, JsonElement> configElement, string objectKey, bool enableFlag)
-        {
-            Assert.AreEqual(enableFlag, configElement[objectKey].GetBoolean(), $"Expected {objectKey} to be set to {enableFlag}.");
-        }
-
-        private static void ValidateConfigurationDetailsHealthCheckResponse(Dictionary<string, JsonElement> responseProperties, bool enableGlobalRest, bool enableGlobalGraphQL)
-        {
-            if (responseProperties.TryGetValue("configuration", out JsonElement configElement) && configElement.ValueKind == JsonValueKind.Object)
-            {
-                Dictionary<string, JsonElement> configPropertyValues = new();
-
-                // Enumerate through the configProperty's object properties and add them to the dictionary
-                foreach (JsonProperty property in configElement.EnumerateObject().ToList())
-                {
-                    configPropertyValues[property.Name] = property.Value;
-                }
-
-                ValidateConfigurationIsNotNull(configPropertyValues, "rest");
-                ValidateConfigurationIsCorrectFlag(configPropertyValues, "rest", enableGlobalRest);
-                ValidateConfigurationIsNotNull(configPropertyValues, "graphql");
-                ValidateConfigurationIsCorrectFlag(configPropertyValues, "graphql", enableGlobalGraphQL);
-                ValidateConfigurationIsNotNull(configPropertyValues, "caching");
-                ValidateConfigurationIsNotNull(configPropertyValues, "telemetry");
-                ValidateConfigurationIsNotNull(configPropertyValues, "mode");
-            }
-            else
-            {
-                Assert.Fail("Missing 'configuration' object in Health Check Response.");
-            }
-        }
-
-        private static void ValidateBasicDetailsHealthCheckResponse(Dictionary<string, JsonElement> responseProperties)
-        {
-            // Validate value of 'status' property in reponse.
-            if (responseProperties.TryGetValue(key: "status", out JsonElement statusValue))
-            {
-                Assert.IsTrue(statusValue.ValueKind == JsonValueKind.String, "Unexpected or missing status value as string.");
-            }
-            else
-            {
-                Assert.Fail();
-            }
-
-            // Validate value of 'version' property in response.
-            if (responseProperties.TryGetValue(key: BasicHealthCheck.DAB_VERSION_KEY, out JsonElement versionValue))
-            {
-                Assert.AreEqual(
-                    expected: ProductInfo.GetProductVersion(),
-                    actual: versionValue.ToString(),
-                    message: "Unexpected or missing version value.");
-            }
-            else
-            {
-                Assert.Fail();
-            }
-
-            // Validate value of 'app-name' property in response.
-            if (responseProperties.TryGetValue(key: BasicHealthCheck.DAB_APPNAME_KEY, out JsonElement appNameValue))
-            {
-                Assert.AreEqual(
-                    expected: ProductInfo.GetDataApiBuilderUserAgent(),
-                    actual: appNameValue.ToString(),
-                    message: "Unexpected or missing DAB user agent string.");
-            }
-            else
-            {
-                Assert.Fail();
-            }
+            HealthEndpointTests.ValidateBasicDetailsHealthCheckResponse(responseProperties);
         }
 
         /// <summary>
@@ -4670,22 +4455,20 @@ type Planet @model(name:""PlanetAlias"") {
         /// </summary>
         /// <param name="entityMap">Collection of entityName -> Entity object.</param>
         /// <param name="enableGlobalRest">flag to enable or disabled REST globally.</param>
-        private static void CreateCustomConfigFile(Dictionary<string, Entity> entityMap, bool enableGlobalRest = true, bool enableGlobalGraphql = true, bool enableGlobalHealth = true, bool enableDatasourceHealth = true, HostMode hostMode = HostMode.Production)
+        private static void CreateCustomConfigFile(Dictionary<string, Entity> entityMap, bool enableGlobalRest = true)
         {
             DataSource dataSource = new(
                 DatabaseType.MSSQL,
                 GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL),
-                Options: null,
-                Health: new(enableDatasourceHealth));
-            HostOptions hostOptions = new(Mode: hostMode, Cors: null, Authentication: new() { Provider = nameof(EasyAuthType.StaticWebApps) });
+                Options: null);
+            HostOptions hostOptions = new(Cors: null, Authentication: new() { Provider = nameof(EasyAuthType.StaticWebApps) });
 
             RuntimeConfig runtimeConfig = new(
                 Schema: string.Empty,
                 DataSource: dataSource,
                 Runtime: new(
-                    Health: new(enabled: enableGlobalHealth),
                     Rest: new(Enabled: enableGlobalRest),
-                    GraphQL: new(Enabled: enableGlobalGraphql),
+                    GraphQL: new(Enabled: true),
                     Host: hostOptions
                 ),
                 Entities: new(entityMap));

--- a/src/Service.Tests/Configuration/HealthEndpointRolesTests.cs
+++ b/src/Service.Tests/Configuration/HealthEndpointRolesTests.cs
@@ -48,7 +48,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             // Even though this entity is not under test, it must be supplied enable successful
             // config file creation.
             Entity requiredEntity = new(
-                Health: new(Enabled: true),
+                Health: new(enabled: true),
                 Source: new("books", EntitySourceType.Table, null, null),
                 Rest: new(Enabled: true),
                 GraphQL: new("book", "books", true),
@@ -124,7 +124,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
                 Schema: string.Empty,
                 DataSource: dataSource,
                 Runtime: new(
-                    Health: new(Enabled: true, Roles: role != null ? new HashSet<string> { role } : null),
+                    Health: new(enabled: true, roles: role != null ? new HashSet<string> { role } : null),
                     Rest: new(Enabled: true),
                     GraphQL: new(Enabled: true),
                     Host: hostOptions

--- a/src/Service.Tests/Configuration/HealthEndpointTests.cs
+++ b/src/Service.Tests/Configuration/HealthEndpointTests.cs
@@ -1,0 +1,514 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config;
+using Azure.DataApiBuilder.Config.DatabasePrimitives;
+using Azure.DataApiBuilder.Config.HealthCheck;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Core.Services;
+using Azure.DataApiBuilder.Core.Services.MetadataProviders;
+using Azure.DataApiBuilder.Product;
+using Azure.DataApiBuilder.Service.HealthCheck;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Moq.Protected;
+
+namespace Azure.DataApiBuilder.Service.Tests.Configuration
+{
+    [TestClass]
+    public class HealthEndpointTests
+    {
+        private const string CUSTOM_CONFIG_FILENAME = "custom_config.json";
+        private const string BASE_DAB_URL = "http://localhost:5000";
+
+        [TestCleanup]
+        public void CleanupAfterEachTest()
+        {
+            if (File.Exists(CUSTOM_CONFIG_FILENAME))
+            {
+                File.Delete(CUSTOM_CONFIG_FILENAME);
+            }
+
+            TestHelper.UnsetAllDABEnvironmentVariables();
+        }
+
+        /// <summary>
+        /// Simulates a GET request to DAB's comprehensive health check endpoint ('/health') and validates the contents of the response.
+        /// The expected format of the response is the comprehensive health check response.
+        /// </summary>
+        [TestMethod]
+        [TestCategory(TestCategory.MSSQL)]
+        [DataRow(true, true, true, true, true, true, true, DisplayName = "Validate Health Report all enabled.")]
+        [DataRow(false, true, true, true, true, true, true, DisplayName = "Validate when Comprehensive Health Report is disabled")]
+        [DataRow(true, true, true, false, true, true, true, DisplayName = "Validate Health Report when data-source health is disabled")]
+        [DataRow(true, true, true, true, false, true, true, DisplayName = "Validate Health Report when entity health is disabled")]
+        [DataRow(true, false, true, true, true, true, true, DisplayName = "Validate Health Report when global rest health is disabled")]
+        [DataRow(true, true, true, true, true, false, true, DisplayName = "Validate Health Report when entity rest health is disabled")]
+        [DataRow(true, true, false, true, true, true, true, DisplayName = "Validate Health Report when global graphql health is disabled")]
+        [DataRow(true, true, true, true, true, true, false, DisplayName = "Validate Health Report when entity graphql health is disabled")]
+        public async Task ComprehensiveHealthEndpoint_ValidateContents(bool enableGlobalHealth, bool enableGlobalRest, bool enableGlobalGraphql, bool enableDatasourceHealth, bool enableEntityHealth, bool enableEntityRest, bool enableEntityGraphQL)
+        {
+            // Arrange
+            // Create a mock entity map with a single entity for testing
+            RuntimeConfig runtimeConfig = SetupCustomConfigFile(enableGlobalHealth, enableGlobalRest, enableGlobalGraphql, enableDatasourceHealth, enableEntityHealth, enableEntityRest, enableEntityGraphQL);
+            WriteToCustomConfigFile(runtimeConfig);
+
+            string[] args = new[]
+            {
+                $"--ConfigFileName={CUSTOM_CONFIG_FILENAME}"
+            };
+
+            using (TestServer server = new(Program.CreateWebHostBuilder(args)))
+            using (HttpClient client = server.CreateClient())
+            {
+                HttpRequestMessage healthRequest = new(HttpMethod.Get, $"{BASE_DAB_URL}/health");
+                HttpResponseMessage response = await client.SendAsync(healthRequest);
+
+                if (!enableGlobalHealth)
+                {
+                    Assert.AreEqual(expected: HttpStatusCode.NotFound, actual: response.StatusCode, message: "Received unexpected HTTP code from health check endpoint.");
+                }
+                else
+                {
+                    string responseBody = await response.Content.ReadAsStringAsync();
+                    Dictionary<string, JsonElement> responseProperties = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(responseBody);
+                    Assert.AreEqual(expected: HttpStatusCode.OK, actual: response.StatusCode, message: "Received unexpected HTTP code from health check endpoint.");
+
+                    ValidateBasicDetailsHealthCheckResponse(responseProperties);
+                    ValidateConfigurationDetailsHealthCheckResponse(responseProperties, enableGlobalRest, enableGlobalGraphql);
+                    ValidateIfAttributePresentInResponse(responseProperties, enableDatasourceHealth, HealthCheckConstants.DATASOURCE);
+                    ValidateIfAttributePresentInResponse(responseProperties, enableEntityHealth, HealthCheckConstants.ENDPOINT);
+                    if (enableEntityHealth)
+                    {
+                        ValidateEntityRestAndGraphQLResponse(responseProperties, enableEntityRest, enableEntityGraphQL, enableGlobalRest, enableGlobalGraphql);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Simulates the function call to HttpUtilities.ExecuteRestQueryAsync.
+        /// while setting up mock HTTP client to simulate the response from the server to send OK code.
+        /// Validates the response to ensure no error message is received.
+        /// </summary>
+        [TestMethod]
+        public async Task TestHealthCheckRestResponseAsync()
+        {
+            // Arrange
+            RuntimeConfig runtimeConfig = SetupCustomConfigFile(true, true, true, true, true, true, true);
+            HttpUtilities httpUtilities = SetupRestTest(runtimeConfig);
+
+            // Act
+            // Call the ExecuteRestQuery method with the mock HttpClient
+            // Simulate a REST API call to the endpoint
+            // Response should be null as error message is not expected to be returned
+            string errorMessageFromRest = await httpUtilities.ExecuteRestQueryAsync(
+                restUriSuffix: runtimeConfig.RestPath,
+                entityName: runtimeConfig.Entities.First().Key,
+                first: runtimeConfig.Entities.First().Value.Health.First,
+                incomingRoleHeader: string.Empty,
+                incomingRoleToken: string.Empty
+            );
+
+            // Assert
+            // Validate the null response from the REST API call 
+            Assert.IsNull(errorMessageFromRest);
+        }
+
+        /// <summary>
+        /// Simulates the function call to HttpUtilities.ExecuteRestQueryAsync.
+        /// while setting up mock HTTP client to simulate the response from the server to send BadRequest code.
+        /// Validates the response to ensure error message is received.
+        /// </summary>
+        [TestMethod]
+        public async Task TestFailureHealthCheckRestResponseAsync()
+        {
+            // Arrange
+            RuntimeConfig runtimeConfig = SetupCustomConfigFile(true, true, true, true, true, true, true);
+            HttpUtilities httpUtilities = SetupGraphQLTest(runtimeConfig, HttpStatusCode.BadRequest);
+
+            // Act
+            // Call the ExecuteRestQuery method with the mock HttpClient
+            // Simulate a REST API call to the endpoint
+            // Response should be null as error message is not expected to be returned
+            string errorMessageFromRest = await httpUtilities.ExecuteRestQueryAsync(
+                restUriSuffix: runtimeConfig.RestPath,
+                entityName: runtimeConfig.Entities.First().Key,
+                first: runtimeConfig.Entities.First().Value.Health.First,
+                incomingRoleHeader: string.Empty,
+                incomingRoleToken: string.Empty
+            );
+
+            // Assert
+            Assert.IsNotNull(errorMessageFromRest);
+        }
+
+        /// <summary>
+        /// Simulates the function call to HttpUtilities.ExecuteGraphQLQueryAsync.
+        /// while setting up mock HTTP client to simulate the response from the server to send OK code.
+        /// Validates the response to ensure no error message is received.
+        /// </summary>
+        [TestMethod]
+        public async Task TestHealthCheckGraphQLResponseAsync()
+        {
+            // Arrange
+            RuntimeConfig runtimeConfig = SetupCustomConfigFile(true, true, true, true, true, true, true);
+            HttpUtilities httpUtilities = SetupGraphQLTest(runtimeConfig);
+
+            // Act
+            string errorMessageFromGraphQL = await httpUtilities.ExecuteGraphQLQueryAsync(
+                graphqlUriSuffix: "/graphql",
+                entityName: runtimeConfig.Entities.First().Key,
+                entity: runtimeConfig.Entities.First().Value,
+                incomingRoleHeader: string.Empty,
+                incomingRoleToken: string.Empty);
+
+            // Assert
+            Assert.IsNull(errorMessageFromGraphQL);
+        }
+
+        /// <summary>
+        /// Simulates the function call to HttpUtilities.ExecuteGraphQLQueryAsync.
+        /// while setting up mock HTTP client to simulate the response from the server to send InternalServerError code.
+        /// Validates the response to ensure error message is received.
+        /// </summary>
+        [TestMethod]
+        public async Task TestFailureHealthCheckGraphQLResponseAsync()
+        {
+            // Arrange
+            RuntimeConfig runtimeConfig = SetupCustomConfigFile(true, true, true, true, true, true, true);
+            HttpUtilities httpUtilities = SetupGraphQLTest(runtimeConfig, HttpStatusCode.InternalServerError);
+
+            // Act
+            string errorMessageFromGraphQL = await httpUtilities.ExecuteGraphQLQueryAsync(
+                graphqlUriSuffix: "/graphql",
+                entityName: runtimeConfig.Entities.First().Key,
+                entity: runtimeConfig.Entities.First().Value,
+                incomingRoleHeader: string.Empty,
+                incomingRoleToken: string.Empty);
+
+            // Assert
+            Assert.IsNotNull(errorMessageFromGraphQL);
+        }
+
+        #region Helper Methods
+        private static HttpUtilities SetupRestTest(RuntimeConfig runtimeConfig, HttpStatusCode httpStatusCode = HttpStatusCode.OK)
+        {
+            // Arrange
+            // Create a mock entity map with a single entity for testing and load in RuntimeConfigProvider
+            Mock<IMetadataProviderFactory> metadataProviderFactory = new();
+            MockFileSystem fileSystem = new();
+            fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(runtimeConfig.ToJson()));
+            FileSystemRuntimeConfigLoader loader = new(fileSystem);
+            RuntimeConfigProvider provider = new(loader);
+
+            // Create a Mock of HttpMessageHandler
+            Mock<HttpMessageHandler> mockHandler = new();
+            // Mocking the handler to return a specific response for SendAsync
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.Method == HttpMethod.Get
+                        && req.RequestUri.Equals($"{BASE_DAB_URL}/{runtimeConfig.RestPath.Trim('/')}/{runtimeConfig.Entities.First().Key}?$first={runtimeConfig.Entities.First().Value.Health.First}")),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(httpStatusCode)
+                {
+                    Content = new StringContent("{\"message\":\"Rest response\"}")
+                });
+
+            // Mocking IHttpClientFactory
+            Mock<IHttpClientFactory> mockHttpClientFactory = new();
+            mockHttpClientFactory.Setup(x => x.CreateClient("ContextConfiguredHealthCheckClient"))
+                .Returns(new HttpClient(mockHandler.Object)
+                {
+                    BaseAddress = new Uri($"{BASE_DAB_URL}")
+                });
+
+            Mock<ILogger<HttpUtilities>> _logger = new();
+
+            // Create the mock HttpContext to return the expected scheme and host
+            // when the ConfigureApiRoute method is called.
+            Mock<HttpContext> mockHttpContext = new();
+            Mock<HttpRequest> mockHttpRequest = new();
+            mockHttpRequest.Setup(r => r.Scheme).Returns("http");
+            mockHttpRequest.Setup(r => r.Host).Returns(new HostString("localhost", 5000));
+            mockHttpContext.Setup(c => c.Request).Returns(mockHttpRequest.Object);
+
+            return new(
+                _logger.Object,
+                metadataProviderFactory.Object,
+                provider,
+                mockHttpClientFactory.Object);
+        }
+
+        private static HttpUtilities SetupGraphQLTest(RuntimeConfig runtimeConfig, HttpStatusCode httpStatusCode = HttpStatusCode.OK)
+        {
+            // Arrange
+            // Create a mock entity map with a single entity for testing and load in RuntimeConfigProvider            
+            MockFileSystem fileSystem = new();
+            fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(runtimeConfig.ToJson()));
+            FileSystemRuntimeConfigLoader loader = new(fileSystem);
+            RuntimeConfigProvider provider = new(loader);
+            Mock<IMetadataProviderFactory> metadataProviderFactory = new();
+            Mock<ISqlMetadataProvider> sqlMetadataProvider = new();
+
+            // Setup the mock database object with a source definition
+            SourceDefinition sourceDef = new();
+            sourceDef.Columns.Add("id", new ColumnDefinition());
+            sourceDef.Columns.Add("title", new ColumnDefinition());
+            // Mock DB Object to return the source definition
+            Mock<DatabaseObject> mockDbObject = new();
+            mockDbObject.SetupGet(x => x.SourceDefinition).Returns(sourceDef);
+            // Mocking the metadata provider to return the mock database object
+            sqlMetadataProvider.Setup(x => x.GetDatabaseObjectByKey(runtimeConfig.Entities.First().Key)).Returns(mockDbObject.Object);
+            metadataProviderFactory.Setup(x => x.GetMetadataProvider(It.IsAny<string>())).Returns(sqlMetadataProvider.Object);
+
+            Mock<HttpMessageHandler> mockHandler = new();
+            mockHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req =>
+                        req.Method == HttpMethod.Post &&
+                        req.RequestUri == new Uri($"{BASE_DAB_URL}/graphql") &&
+                        req.Content.ReadAsStringAsync().Result.Equals("{\"query\":\"{bookLists (first: 100) {items { id title }}}\"}")), // Use the correct GraphQL query format
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage(httpStatusCode)
+                {
+                    Content = new StringContent("{\"errors\":[{\"message\":\"Internal Server Error\"}]}")
+                });
+
+            Mock<IHttpClientFactory> mockHttpClientFactory = new();
+            mockHttpClientFactory.Setup(x => x.CreateClient("ContextConfiguredHealthCheckClient"))
+                .Returns(new HttpClient(mockHandler.Object)
+                {
+                    BaseAddress = new Uri($"{BASE_DAB_URL}")
+                });
+
+            Mock<ILogger<HttpUtilities>> logger = new();
+
+            return new(
+                logger.Object,
+                metadataProviderFactory.Object,
+                provider,
+                mockHttpClientFactory.Object);
+        }
+
+        private static void ValidateEntityRestAndGraphQLResponse(
+            Dictionary<string, JsonElement> responseProperties,
+            bool enableEntityRest,
+            bool enableEntityGraphQL,
+            bool enableGlobalRest,
+            bool enableGlobalGraphQL)
+        {
+            bool hasRestTag = false, hasGraphQLTag = false;
+            if (responseProperties.TryGetValue("checks", out JsonElement checksElement) && checksElement.ValueKind == JsonValueKind.Array)
+            {
+                checksElement.EnumerateArray().ToList().ForEach(entityCheck =>
+                {
+                    // Check if the 'tags' property exists and is of type array
+                    if (entityCheck.TryGetProperty("tags", out JsonElement tagsElement) && tagsElement.ValueKind == JsonValueKind.Array)
+                    {
+                        hasRestTag = hasRestTag || tagsElement.EnumerateArray().Any(tag => tag.ToString() == HealthCheckConstants.REST);
+                        hasGraphQLTag = hasGraphQLTag || tagsElement.EnumerateArray().Any(tag => tag.ToString() == HealthCheckConstants.GRAPHQL);
+                    }
+                });
+
+                if (enableGlobalRest)
+                {
+                    // When both enableEntityRest and hasRestTag match the same value
+                    Assert.AreEqual(enableEntityRest, hasRestTag);
+                }
+                else
+                {
+                    Assert.IsFalse(hasRestTag);
+                }
+
+                if (enableGlobalGraphQL)
+                {
+                    // When both enableEntityGraphQL and hasGraphQLTag match the same value
+                    Assert.AreEqual(enableEntityGraphQL, hasGraphQLTag);
+                }
+                else
+                {
+                    Assert.IsFalse(hasGraphQLTag);
+                }
+            }
+        }
+
+        private static void ValidateIfAttributePresentInResponse(
+            Dictionary<string, JsonElement> responseProperties,
+            bool enableFlag,
+            string checkString)
+        {
+            if (responseProperties.TryGetValue("checks", out JsonElement checksElement) && checksElement.ValueKind == JsonValueKind.Array)
+            {
+                bool checksTags = checksElement.EnumerateArray().Any(entityCheck =>
+                {
+                    if (entityCheck.TryGetProperty("tags", out JsonElement tagsElement) && tagsElement.ValueKind == JsonValueKind.Array)
+                    {
+                        return tagsElement.EnumerateArray().Any(tag => tag.ToString() == checkString);
+                    }
+
+                    return false;
+                });
+
+                Assert.AreEqual(enableFlag, checksTags);
+            }
+            else
+            {
+                Assert.Fail("Checks array is not present in the Comprehensive Health Check Report.");
+            }
+        }
+
+        private static void ValidateConfigurationIsNotNull(Dictionary<string, JsonElement> configPropertyValues, string objectKey)
+        {
+            Assert.IsTrue(configPropertyValues.ContainsKey(objectKey), $"Expected {objectKey} to be present in the configuration object.");
+            Assert.IsNotNull(configPropertyValues[objectKey], $"Expected {objectKey} to be non-null.");
+        }
+
+        private static void ValidateConfigurationIsCorrectFlag(Dictionary<string, JsonElement> configElement, string objectKey, bool enableFlag)
+        {
+            Assert.AreEqual(enableFlag, configElement[objectKey].GetBoolean(), $"Expected {objectKey} to be set to {enableFlag}.");
+        }
+
+        private static void ValidateConfigurationDetailsHealthCheckResponse(Dictionary<string, JsonElement> responseProperties, bool enableGlobalRest, bool enableGlobalGraphQL)
+        {
+            if (responseProperties.TryGetValue("configuration", out JsonElement configElement) && configElement.ValueKind == JsonValueKind.Object)
+            {
+                Dictionary<string, JsonElement> configPropertyValues = new();
+
+                // Enumerate through the configProperty's object properties and add them to the dictionary
+                foreach (JsonProperty property in configElement.EnumerateObject().ToList())
+                {
+                    configPropertyValues[property.Name] = property.Value;
+                }
+
+                ValidateConfigurationIsNotNull(configPropertyValues, "rest");
+                ValidateConfigurationIsCorrectFlag(configPropertyValues, "rest", enableGlobalRest);
+                ValidateConfigurationIsNotNull(configPropertyValues, "graphql");
+                ValidateConfigurationIsCorrectFlag(configPropertyValues, "graphql", enableGlobalGraphQL);
+                ValidateConfigurationIsNotNull(configPropertyValues, "caching");
+                ValidateConfigurationIsNotNull(configPropertyValues, "telemetry");
+                ValidateConfigurationIsNotNull(configPropertyValues, "mode");
+            }
+            else
+            {
+                Assert.Fail("Missing 'configuration' object in Health Check Response.");
+            }
+        }
+
+        public static void ValidateBasicDetailsHealthCheckResponse(Dictionary<string, JsonElement> responseProperties)
+        {
+            // Validate value of 'status' property in response.
+            if (responseProperties.TryGetValue(key: "status", out JsonElement statusValue))
+            {
+                Assert.IsTrue(statusValue.ValueKind == JsonValueKind.String, "Unexpected or missing status value as string.");
+            }
+            else
+            {
+                Assert.Fail();
+            }
+
+            // Validate value of 'version' property in response.
+            if (responseProperties.TryGetValue(key: BasicHealthCheck.DAB_VERSION_KEY, out JsonElement versionValue))
+            {
+                Assert.AreEqual(
+                    expected: ProductInfo.GetProductVersion(),
+                    actual: versionValue.ToString(),
+                    message: "Unexpected or missing version value.");
+            }
+            else
+            {
+                Assert.Fail();
+            }
+
+            // Validate value of 'app-name' property in response.
+            if (responseProperties.TryGetValue(key: BasicHealthCheck.DAB_APPNAME_KEY, out JsonElement appNameValue))
+            {
+                Assert.AreEqual(
+                    expected: ProductInfo.GetDataApiBuilderUserAgent(),
+                    actual: appNameValue.ToString(),
+                    message: "Unexpected or missing DAB user agent string.");
+            }
+            else
+            {
+                Assert.Fail();
+            }
+        }
+
+        private static RuntimeConfig SetupCustomConfigFile(bool enableGlobalHealth, bool enableGlobalRest, bool enableGlobalGraphql, bool enableDatasourceHealth, bool enableEntityHealth, bool enableEntityRest, bool enableEntityGraphQL)
+        {
+            // At least one entity is required in the runtime config for the engine to start.
+            // Even though this entity is not under test, it must be supplied enable successful
+            // config file creation.
+            Entity requiredEntity = new(
+                Health: new(enabled: enableEntityHealth),
+                Source: new("books", EntitySourceType.Table, null, null),
+                Rest: new(Enabled: enableEntityRest),
+                GraphQL: new("book", "bookLists", enableEntityGraphQL),
+                Permissions: new[] { ConfigurationTests.GetMinimalPermissionConfig(AuthorizationResolver.ROLE_ANONYMOUS) },
+                Relationships: null,
+                Mappings: null);
+
+            Dictionary<string, Entity> entityMap = new()
+            {
+                { "Book", requiredEntity }
+            };
+
+            return CreateRuntimeConfig(entityMap, enableGlobalRest, enableGlobalGraphql, enableGlobalHealth, enableDatasourceHealth, HostMode.Development);
+        }
+
+        /// <summary>
+        /// Helper function to write custom configuration file. with minimal REST/GraphQL global settings
+        /// using the supplied entities.
+        /// </summary>
+        /// <param name="entityMap">Collection of entityName -> Entity object.</param>
+        /// <param name="enableGlobalRest">flag to enable or disabled REST globally.</param>
+        private static RuntimeConfig CreateRuntimeConfig(Dictionary<string, Entity> entityMap, bool enableGlobalRest = true, bool enableGlobalGraphql = true, bool enableGlobalHealth = true, bool enableDatasourceHealth = true, HostMode hostMode = HostMode.Production)
+        {
+            DataSource dataSource = new(
+                DatabaseType.MSSQL,
+                ConfigurationTests.GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL),
+                Options: null,
+                Health: new(enableDatasourceHealth));
+            HostOptions hostOptions = new(Mode: hostMode, Cors: null, Authentication: new() { Provider = nameof(EasyAuthType.StaticWebApps) });
+
+            RuntimeConfig runtimeConfig = new(
+                Schema: string.Empty,
+                DataSource: dataSource,
+                Runtime: new(
+                    Health: new(enabled: enableGlobalHealth),
+                    Rest: new(Enabled: enableGlobalRest),
+                    GraphQL: new(Enabled: enableGlobalGraphql),
+                    Host: hostOptions
+                ),
+                Entities: new(entityMap));
+
+            return runtimeConfig;
+        }
+
+        private static void WriteToCustomConfigFile(RuntimeConfig runtimeConfig)
+        {
+            File.WriteAllText(
+                path: CUSTOM_CONFIG_FILENAME,
+                contents: runtimeConfig.ToJson());
+        }
+    }
+    #endregion
+}

--- a/src/Service.Tests/Configuration/HotReload/AuthorizationResolverHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/AuthorizationResolverHotReloadTests.cs
@@ -30,7 +30,9 @@ public class AuthorizationResolverHotReloadTests
     /// Hot Reloaded config specifies: Entity (Publisher) -> Role2 -> Include: id Exclude: name
     /// Hot-Reload tests in this class must not be parallelized as each test overwrites the same config file
     /// and uses the same test server instance.
+    /// This test is currently flakey, failing intermittently in our pipeline, and is therefore ignored.
     /// </summary>
+    [Ignore]
     [TestMethod]
     [DoNotParallelize]
     [TestCategory(TestCategory.MSSQL)]

--- a/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
+++ b/src/Service.Tests/Configuration/HotReload/ConfigurationHotReloadTests.cs
@@ -228,6 +228,7 @@ public class ConfigurationHotReloadTests
     /// Hot reload the configuration by saving a new file with different rest and graphQL paths.
     /// Validate that the response is correct when making a request with the newly hot-reloaded paths.
     /// </summary>
+    [Ignore]
     [TestCategory(MSSQL_ENVIRONMENT)]
     [TestMethod("Hot-reload runtime paths.")]
     public async Task HotReloadConfigRuntimePathsEndToEndTest()
@@ -583,6 +584,7 @@ public class ConfigurationHotReloadTests
     /// to an invalid connection string, then it hot reloads once more to the original
     /// connection string. Lastly, we assert that the first reload fails while the second one succeeds.
     /// </summary>
+    [Ignore]
     [TestCategory(MSSQL_ENVIRONMENT)]
     [TestMethod]
     public async Task HotReloadConfigConnectionString()

--- a/src/Service.Tests/Configuration/OpenTelemetryTests.cs
+++ b/src/Service.Tests/Configuration/OpenTelemetryTests.cs
@@ -61,7 +61,6 @@ public class OpenTelemetryTests
             File.Delete(CONFIG_WITHOUT_TELEMETRY);
         }
 
-        Startup.OpenTelemetryOptions = new();
     }
 
     /// <summary>

--- a/src/Service.Tests/ModuleInitializer.cs
+++ b/src/Service.Tests/ModuleInitializer.cs
@@ -85,6 +85,8 @@ static class ModuleInitializer
         VerifierSettings.IgnoreMember<RuntimeConfig>(options => options.EnableAggregation);
         // Ignore the AllowedRolesForHealth as that's unimportant from a test standpoint.
         VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.AllowedRolesForHealth);
+        // Ignore the CacheTtlSeconds as that's unimportant from a test standpoint.
+        VerifierSettings.IgnoreMember<RuntimeConfig>(config => config.CacheTtlSecondsForHealthReport);
         // Ignore the EnableAggregation as that's unimportant from a test standpoint.
         VerifierSettings.IgnoreMember<GraphQLRuntimeOptions>(options => options.EnableAggregation);
         // Ignore the EnableDwNto1JoinOpt as that's unimportant from a test standpoint.

--- a/src/Service.Tests/dab-config.CosmosDb_NoSql.json
+++ b/src/Service.Tests/dab-config.CosmosDb_NoSql.json
@@ -31,6 +31,12 @@
         "provider": "StaticWebApps"
       },
       "mode": "development"
+    },
+    "telemetry": {
+      "app-insights": {
+        "enabled": true,
+        "connection-string": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://dc.services.visualstudio.com/v2/track"
+      }
     }
   },
   "entities": {

--- a/src/Service/Azure.DataApiBuilder.Service.csproj
+++ b/src/Service/Azure.DataApiBuilder.Service.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0</TargetFrameworks>
@@ -77,7 +77,7 @@
         <PackageReference Include="System.CommandLine" />
         <PackageReference Include="System.IO.Abstractions" />
         <PackageReference Include="ZiggyCreatures.FusionCache" />
-        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol"  />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" />

--- a/src/Service/Controllers/HealthController.cs
+++ b/src/Service/Controllers/HealthController.cs
@@ -41,7 +41,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
         {
             if (IHttpContextAccessor != null && IHttpContextAccessor.HttpContext != null)
             {
-                await ComprehensiveHealthReportResponseWriter.WriteResponse(IHttpContextAccessor.HttpContext);
+                await ComprehensiveHealthReportResponseWriter.WriteResponseAsync(IHttpContextAccessor.HttpContext);
             }
 
             return;

--- a/src/Service/Controllers/RestController.cs
+++ b/src/Service/Controllers/RestController.cs
@@ -11,8 +11,8 @@ using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Services;
+using Azure.DataApiBuilder.Core.Telemetry;
 using Azure.DataApiBuilder.Service.Exceptions;
-using Azure.DataApiBuilder.Service.Telemetry;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
@@ -208,7 +208,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
 
                 if (activity is not null)
                 {
-                    activity.TrackRestControllerActivityStarted(
+                    activity.TrackMainControllerActivityStarted(
                         Enum.Parse<HttpMethod>(HttpContext.Request.Method, ignoreCase: true),
                         HttpContext.Request.Headers["User-Agent"].ToString(),
                         operationType.ToString(),
@@ -261,7 +261,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
                 if (activity is not null && activity.IsAllDataRequested)
                 {
                     HttpStatusCode httpStatusCode = Enum.Parse<HttpStatusCode>(statusCode.ToString(), ignoreCase: true);
-                    activity.TrackRestControllerActivityFinished(httpStatusCode);
+                    activity.TrackMainControllerActivityFinished(httpStatusCode);
                 }
 
                 return result;
@@ -274,7 +274,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
                     HttpContextExtensions.GetLoggerCorrelationId(HttpContext));
 
                 Response.StatusCode = (int)ex.StatusCode;
-                activity?.TrackRestControllerActivityFinishedWithException(ex, ex.StatusCode);
+                activity?.TrackMainControllerActivityFinishedWithException(ex, ex.StatusCode);
 
                 HttpMethod method = Enum.Parse<HttpMethod>(HttpContext.Request.Method, ignoreCase: true);
                 TelemetryMetricsHelper.TrackError(method, ex.StatusCode, route, ApiType.REST, ex);
@@ -290,7 +290,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
                 Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 
                 HttpMethod method = Enum.Parse<HttpMethod>(HttpContext.Request.Method, ignoreCase: true);
-                activity?.TrackRestControllerActivityFinishedWithException(ex, HttpStatusCode.InternalServerError);
+                activity?.TrackMainControllerActivityFinishedWithException(ex, HttpStatusCode.InternalServerError);
 
                 TelemetryMetricsHelper.TrackError(method, HttpStatusCode.InternalServerError, route, ApiType.REST, ex);
                 return ErrorResponse(

--- a/src/Service/Controllers/RestController.cs
+++ b/src/Service/Controllers/RestController.cs
@@ -2,15 +2,20 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Service.Exceptions;
+using Azure.DataApiBuilder.Service.Telemetry;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Azure.DataApiBuilder.Service.Controllers
@@ -47,11 +52,14 @@ namespace Azure.DataApiBuilder.Service.Controllers
 
         private readonly ILogger<RestController> _logger;
 
+        private readonly RuntimeConfigProvider _runtimeConfigProvider;
+
         /// <summary>
         /// Constructor.
         /// </summary>
-        public RestController(RestService restService, IOpenApiDocumentor openApiDocumentor, ILogger<RestController> logger)
+        public RestController(RuntimeConfigProvider runtimeConfigProvider, RestService restService, IOpenApiDocumentor openApiDocumentor, ILogger<RestController> logger)
         {
+            _runtimeConfigProvider = runtimeConfigProvider;
             _restService = restService;
             _openApiDocumentor = openApiDocumentor;
             _logger = logger;
@@ -185,11 +193,29 @@ namespace Azure.DataApiBuilder.Service.Controllers
             string route,
             EntityActionOperation operationType)
         {
+            if (route.Equals(REDIRECTED_ROUTE))
+            {
+                return NotFound();
+            }
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            // This activity tracks the entire REST request.
+            using Activity? activity = TelemetryTracesHelper.DABActivitySource.StartActivity($"{HttpContext.Request.Method} {(route.Split('/').Length > 1 ? route.Split('/')[1] : string.Empty)}");
+
             try
             {
-                if (route.Equals(REDIRECTED_ROUTE))
+                TelemetryMetricsHelper.IncrementActiveRequests(ApiType.REST);
+
+                if (activity is not null)
                 {
-                    return NotFound();
+                    activity.TrackRestControllerActivityStarted(
+                        Enum.Parse<HttpMethod>(HttpContext.Request.Method, ignoreCase: true),
+                        HttpContext.Request.Headers["User-Agent"].ToString(),
+                        operationType.ToString(),
+                        route,
+                        HttpContext.Request.QueryString.ToString(),
+                        HttpContext.Request.Headers["X-MS-API-ROLE"].FirstOrDefault() ?? HttpContext.User.FindFirst("role")?.Value,
+                        ApiType.REST);
                 }
 
                 // Validate the PathBase matches the configured REST path.
@@ -208,7 +234,20 @@ namespace Azure.DataApiBuilder.Service.Controllers
 
                 (string entityName, string primaryKeyRoute) = _restService.GetEntityNameAndPrimaryKeyRouteFromRoute(routeAfterPathBase);
 
+                // This activity tracks the query execution. This will create a new activity nested under the REST request activity.
+                using Activity? queryActivity = TelemetryTracesHelper.DABActivitySource.StartActivity($"QUERY {entityName}");
                 IActionResult? result = await _restService.ExecuteAsync(entityName, operationType, primaryKeyRoute);
+
+                RuntimeConfig runtimeConfig = _runtimeConfigProvider.GetConfig();
+                string dataSourceName = runtimeConfig.GetDataSourceNameFromEntityName(entityName);
+                DatabaseType databaseType = runtimeConfig.GetDataSourceFromDataSourceName(dataSourceName).DatabaseType;
+
+                if (queryActivity is not null)
+                {
+                    queryActivity.TrackQueryActivityStarted(
+                        databaseType,
+                        dataSourceName);
+                }
 
                 if (result is null)
                 {
@@ -216,6 +255,13 @@ namespace Azure.DataApiBuilder.Service.Controllers
                         message: $"Not Found",
                         statusCode: HttpStatusCode.NotFound,
                         subStatusCode: DataApiBuilderException.SubStatusCodes.EntityNotFound);
+                }
+
+                int statusCode = (result as ObjectResult)?.StatusCode ?? (result as StatusCodeResult)?.StatusCode ?? (result as JsonResult)?.StatusCode ?? 200;
+                if (activity is not null && activity.IsAllDataRequested)
+                {
+                    HttpStatusCode httpStatusCode = Enum.Parse<HttpStatusCode>(statusCode.ToString(), ignoreCase: true);
+                    activity.TrackRestControllerActivityFinished(httpStatusCode);
                 }
 
                 return result;
@@ -228,6 +274,10 @@ namespace Azure.DataApiBuilder.Service.Controllers
                     HttpContextExtensions.GetLoggerCorrelationId(HttpContext));
 
                 Response.StatusCode = (int)ex.StatusCode;
+                activity?.TrackRestControllerActivityFinishedWithException(ex, ex.StatusCode);
+
+                HttpMethod method = Enum.Parse<HttpMethod>(HttpContext.Request.Method, ignoreCase: true);
+                TelemetryMetricsHelper.TrackError(method, ex.StatusCode, route, ApiType.REST, ex);
                 return ErrorResponse(ex.SubStatusCode.ToString(), ex.Message, ex.StatusCode);
             }
             catch (Exception ex)
@@ -238,10 +288,25 @@ namespace Azure.DataApiBuilder.Service.Controllers
                     HttpContextExtensions.GetLoggerCorrelationId(HttpContext));
 
                 Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+
+                HttpMethod method = Enum.Parse<HttpMethod>(HttpContext.Request.Method, ignoreCase: true);
+                activity?.TrackRestControllerActivityFinishedWithException(ex, HttpStatusCode.InternalServerError);
+
+                TelemetryMetricsHelper.TrackError(method, HttpStatusCode.InternalServerError, route, ApiType.REST, ex);
                 return ErrorResponse(
                     DataApiBuilderException.SubStatusCodes.UnexpectedError.ToString(),
                     SERVER_ERROR,
                     HttpStatusCode.InternalServerError);
+            }
+            finally
+            {
+                stopwatch.Stop();
+                HttpMethod method = Enum.Parse<HttpMethod>(HttpContext.Request.Method, ignoreCase: true);
+                HttpStatusCode httpStatusCode = Enum.Parse<HttpStatusCode>(Response.StatusCode.ToString(), ignoreCase: true);
+                TelemetryMetricsHelper.TrackRequest(method, httpStatusCode, route, ApiType.REST);
+                TelemetryMetricsHelper.TrackRequestDuration(method, httpStatusCode, route, ApiType.REST, stopwatch.Elapsed);
+
+                TelemetryMetricsHelper.DecrementActiveRequests(ApiType.REST);
             }
         }
 

--- a/src/Service/HealthCheck/ComprehensiveHealthReportResponseWriter.cs
+++ b/src/Service/HealthCheck/ComprehensiveHealthReportResponseWriter.cs
@@ -69,7 +69,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         /// </summary>
         /// <param name="context">HttpContext for writing the response.</param>
         /// <returns>Writes the http response to the http context.</returns>
-        public async Task WriteResponse(HttpContext context)
+        public async Task WriteResponseAsync(HttpContext context)
         {
             RuntimeConfig config = _runtimeConfigProvider.GetConfig();
 
@@ -95,7 +95,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                             key: CACHE_KEY,
                             async (FusionCacheFactoryExecutionContext<string?> ctx, CancellationToken ct) =>
                             {
-                                string? response = await ExecuteHealthCheck(context, config).ConfigureAwait(false);
+                                string? response = await ExecuteHealthCheckAsync(config).ConfigureAwait(false);
                                 ctx.Options.SetDuration(TimeSpan.FromSeconds(config.CacheTtlSecondsForHealthReport));
                                 return response;
                             });
@@ -124,7 +124,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 }
                 else
                 {
-                    response = await ExecuteHealthCheck(context, config).ConfigureAwait(false);
+                    response = await ExecuteHealthCheckAsync(config).ConfigureAwait(false);
                     // Return the newly generated response
                     await context.Response.WriteAsync(response);
                 }
@@ -139,9 +139,9 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
             return;
         }
 
-        private async Task<string> ExecuteHealthCheck(HttpContext context, RuntimeConfig config)
+        private async Task<string> ExecuteHealthCheckAsync(RuntimeConfig config)
         {
-            ComprehensiveHealthCheckReport dabHealthCheckReport = await _healthCheckHelper.GetHealthCheckResponse(context, config);
+            ComprehensiveHealthCheckReport dabHealthCheckReport = await _healthCheckHelper.GetHealthCheckResponseAsync(config);
             string response = JsonSerializer.Serialize(dabHealthCheckReport, options: new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull });
             _logger.LogTrace($"Health check response writer writing status as: {dabHealthCheckReport.Status}");
 

--- a/src/Service/HealthCheck/ComprehensiveHealthReportResponseWriter.cs
+++ b/src/Service/HealthCheck/ComprehensiveHealthReportResponseWriter.cs
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.IO;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace Azure.DataApiBuilder.Service.HealthCheck
 {
@@ -21,15 +24,19 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         private readonly ILogger<ComprehensiveHealthReportResponseWriter> _logger;
         private readonly RuntimeConfigProvider _runtimeConfigProvider;
         private readonly HealthCheckHelper _healthCheckHelper;
+        private readonly IFusionCache _cache;
+        private const string CACHE_KEY = "HealthCheckResponse";
 
         public ComprehensiveHealthReportResponseWriter(
             ILogger<ComprehensiveHealthReportResponseWriter> logger,
             RuntimeConfigProvider runtimeConfigProvider,
-            HealthCheckHelper healthCheckHelper)
+            HealthCheckHelper healthCheckHelper,
+            IFusionCache cache)
         {
             _logger = logger;
             _runtimeConfigProvider = runtimeConfigProvider;
             _healthCheckHelper = healthCheckHelper;
+            _cache = cache;
         }
 
         /* {
@@ -62,7 +69,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         /// </summary>
         /// <param name="context">HttpContext for writing the response.</param>
         /// <returns>Writes the http response to the http context.</returns>
-        public Task WriteResponse(HttpContext context)
+        public async Task WriteResponse(HttpContext context)
         {
             RuntimeConfig config = _runtimeConfigProvider.GetConfig();
 
@@ -74,20 +81,71 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 {
                     _logger.LogError("Comprehensive Health Check Report is not allowed: 403 Forbidden due to insufficient permissions.");
                     context.Response.StatusCode = StatusCodes.Status403Forbidden;
-                    return context.Response.CompleteAsync();
+                    await context.Response.CompleteAsync();
+                    return;
                 }
 
-                ComprehensiveHealthCheckReport dabHealthCheckReport = _healthCheckHelper.GetHealthCheckResponse(context, config);
-                string response = JsonSerializer.Serialize(dabHealthCheckReport, options: new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull });
-                _logger.LogTrace($"Health check response writer writing status as: {dabHealthCheckReport.Status}");
-                return context.Response.WriteAsync(response);
+                string? response;
+                // Check if the cache is enabled 
+                if (config.CacheTtlSecondsForHealthReport > 0)
+                {
+                    try
+                    {
+                        response = await _cache.GetOrSetAsync<string?>(
+                            key: CACHE_KEY,
+                            async (FusionCacheFactoryExecutionContext<string?> ctx, CancellationToken ct) =>
+                            {
+                                string? response = await ExecuteHealthCheck(context, config).ConfigureAwait(false);
+                                ctx.Options.SetDuration(TimeSpan.FromSeconds(config.CacheTtlSecondsForHealthReport));
+                                return response;
+                            });
+
+                        _logger.LogTrace($"Health check response is fetched from cache with key: {CACHE_KEY} and TTL: {config.CacheTtlSecondsForHealthReport} seconds.");
+                    }
+                    catch (Exception ex)
+                    {
+                        response = null; // Set response to null in case of an error
+                        _logger.LogError($"Error in caching health check response: {ex.Message}");
+                    }
+
+                    // Ensure cachedResponse is not null before calling WriteAsync
+                    if (response != null)
+                    {
+                        // Return the cached or newly generated response
+                        await context.Response.WriteAsync(response);
+                    }
+                    else
+                    {
+                        // Handle the case where cachedResponse is still null
+                        _logger.LogError("Error: The health check response is null.");
+                        context.Response.StatusCode = 500; // Internal Server Error
+                        await context.Response.WriteAsync("Failed to generate health check response.");
+                    }
+                }
+                else
+                {
+                    response = await ExecuteHealthCheck(context, config).ConfigureAwait(false);
+                    // Return the newly generated response
+                    await context.Response.WriteAsync(response);
+                }
             }
             else
             {
                 _logger.LogError("Comprehensive Health Check Report Not Found: 404 Not Found.");
                 context.Response.StatusCode = StatusCodes.Status404NotFound;
-                return context.Response.CompleteAsync();
+                await context.Response.CompleteAsync();
             }
+
+            return;
+        }
+
+        private async Task<string> ExecuteHealthCheck(HttpContext context, RuntimeConfig config)
+        {
+            ComprehensiveHealthCheckReport dabHealthCheckReport = await _healthCheckHelper.GetHealthCheckResponse(context, config);
+            string response = JsonSerializer.Serialize(dabHealthCheckReport, options: new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull });
+            _logger.LogTrace($"Health check response writer writing status as: {dabHealthCheckReport.Status}");
+
+            return response;
         }
     }
 }

--- a/src/Service/HealthCheck/HealthCheckHelper.cs
+++ b/src/Service/HealthCheck/HealthCheckHelper.cs
@@ -45,21 +45,19 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         /// GetHealthCheckResponse is the main function which fetches the HttpContext and then creates the comprehensive health check report.
         /// Serializes the report to JSON and returns the response.  
         /// </summary>
-        /// <param name="context">HttpContext</param>
         /// <param name="runtimeConfig">RuntimeConfig</param>
         /// <returns>This function returns the comprehensive health report after calculating the response time of each datasource, rest and graphql health queries.</returns>
-        public async Task<ComprehensiveHealthCheckReport> GetHealthCheckResponse(HttpContext context, RuntimeConfig runtimeConfig)
+        public async Task<ComprehensiveHealthCheckReport> GetHealthCheckResponseAsync(RuntimeConfig runtimeConfig)
         {
             // Create a JSON response for the comprehensive health check endpoint using the provided basic health report.
             // If the response has already been created, it will be reused.
-            _httpUtility.ConfigureApiRoute(context);
             _logger.LogTrace("Comprehensive Health check is enabled in the runtime configuration.");
 
             ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport = new();
             UpdateVersionAndAppName(ref ComprehensiveHealthCheckReport);
             UpdateTimestampOfResponse(ref ComprehensiveHealthCheckReport);
             UpdateDabConfigurationDetails(ref ComprehensiveHealthCheckReport, runtimeConfig);
-            await UpdateHealthCheckDetails(ComprehensiveHealthCheckReport, runtimeConfig);
+            await UpdateHealthCheckDetailsAsync(ComprehensiveHealthCheckReport, runtimeConfig);
             UpdateOverallHealthStatus(ref ComprehensiveHealthCheckReport);
             return ComprehensiveHealthCheckReport;
         }
@@ -148,20 +146,20 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Main function to internally call for data source and entities health check.
-        private async Task UpdateHealthCheckDetails(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
+        private async Task UpdateHealthCheckDetailsAsync(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
         {
             ComprehensiveHealthCheckReport.Checks = new List<HealthCheckResultEntry>();
-            await UpdateDataSourceHealthCheckResults(ComprehensiveHealthCheckReport, runtimeConfig);
-            await UpdateEntityHealthCheckResults(ComprehensiveHealthCheckReport, runtimeConfig);
+            await UpdateDataSourceHealthCheckResultsAsync(ComprehensiveHealthCheckReport, runtimeConfig);
+            await UpdateEntityHealthCheckResultsAsync(ComprehensiveHealthCheckReport, runtimeConfig);
         }
 
         // Updates the DataSource Health Check Results in the response.
-        private async Task UpdateDataSourceHealthCheckResults(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
+        private async Task UpdateDataSourceHealthCheckResultsAsync(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
         {
             if (ComprehensiveHealthCheckReport.Checks != null && runtimeConfig.DataSource.IsDatasourceHealthEnabled)
             {
                 string query = Utilities.GetDatSourceQuery(runtimeConfig.DataSource.DatabaseType);
-                (int, string?) response = await ExecuteDatasourceQueryCheck(query, runtimeConfig.DataSource.ConnectionString);
+                (int, string?) response = await ExecuteDatasourceQueryCheckAsync(query, runtimeConfig.DataSource.ConnectionString);
                 bool isResponseTimeWithinThreshold = response.Item1 >= 0 && response.Item1 < runtimeConfig.DataSource.DatasourceThresholdMs;
 
                 // Add DataSource Health Check Results
@@ -181,14 +179,14 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Executes the DB Query and keeps track of the response time and error message.
-        private async Task<(int, string?)> ExecuteDatasourceQueryCheck(string query, string connectionString)
+        private async Task<(int, string?)> ExecuteDatasourceQueryCheckAsync(string query, string connectionString)
         {
             string? errorMessage = null;
             if (!string.IsNullOrEmpty(query) && !string.IsNullOrEmpty(connectionString))
             {
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
-                errorMessage = await _httpUtility.ExecuteDbQuery(query, connectionString);
+                errorMessage = await _httpUtility.ExecuteDbQueryAsync(query, connectionString);
                 stopwatch.Stop();
                 return string.IsNullOrEmpty(errorMessage) ? ((int)stopwatch.ElapsedMilliseconds, errorMessage) : (HealthCheckConstants.ERROR_RESPONSE_TIME_MS, errorMessage);
             }
@@ -198,7 +196,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
 
         // Updates the Entity Health Check Results in the response. 
         // Goes through the entities one by one and executes the rest and graphql checks (if enabled).
-        private async Task UpdateEntityHealthCheckResults(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
+        private async Task UpdateEntityHealthCheckResultsAsync(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
         {
             if (runtimeConfig?.Entities != null && runtimeConfig.Entities.Entities.Any())
             {
@@ -206,7 +204,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 {
                     if (Entity.Value.IsEntityHealthEnabled)
                     {
-                        await PopulateEntityHealth(ComprehensiveHealthCheckReport, Entity, runtimeConfig);
+                        await PopulateEntityHealthAsync(ComprehensiveHealthCheckReport, Entity, runtimeConfig);
                     }
                 }
             }
@@ -215,7 +213,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         // Populates the Entity Health Check Results in the response for a particular entity.
         // Checks for Rest enabled and executes the rest query.
         // Checks for GraphQL enabled and executes the graphql query.
-        private async Task PopulateEntityHealth(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, KeyValuePair<string, Entity> entity, RuntimeConfig runtimeConfig)
+        private async Task PopulateEntityHealthAsync(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, KeyValuePair<string, Entity> entity, RuntimeConfig runtimeConfig)
         {
             // Global Rest and GraphQL Runtime Options
             RuntimeOptions? runtimeOptions = runtimeConfig.Runtime;
@@ -234,7 +232,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                     // The path is trimmed to remove the leading '/' character.
                     // If the path is not present, use the entity key name as the path.
                     string entityPath = entityValue.Rest.Path != null ? entityValue.Rest.Path.TrimStart('/') : entityKeyName;
-                    (int, string?) response = await ExecuteRestEntityQuery(runtimeConfig.RestPath, entityPath, entityValue.EntityFirst);
+                    (int, string?) response = await ExecuteRestEntityQueryAsync(runtimeConfig.RestPath, entityPath, entityValue.EntityFirst);
                     bool isResponseTimeWithinThreshold = response.Item1 >= 0 && response.Item1 < entityValue.EntityThresholdMs;
 
                     // Add Entity Health Check Results
@@ -256,7 +254,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 {
                     ComprehensiveHealthCheckReport.Checks ??= new List<HealthCheckResultEntry>();
 
-                    (int, string?) response = await ExecuteGraphQLEntityQuery(runtimeConfig.GraphQLPath, entityValue, entityKeyName);
+                    (int, string?) response = await ExecuteGraphQLEntityQueryAsync(runtimeConfig.GraphQLPath, entityValue, entityKeyName);
                     bool isResponseTimeWithinThreshold = response.Item1 >= 0 && response.Item1 < entityValue.EntityThresholdMs;
 
                     ComprehensiveHealthCheckReport.Checks.Add(new HealthCheckResultEntry
@@ -276,14 +274,14 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Executes the Rest Entity Query and keeps track of the response time and error message.
-        private async Task<(int, string?)> ExecuteRestEntityQuery(string restUriSuffix, string entityName, int first)
+        private async Task<(int, string?)> ExecuteRestEntityQueryAsync(string restUriSuffix, string entityName, int first)
         {
             string? errorMessage = null;
             if (!string.IsNullOrEmpty(entityName))
             {
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
-                errorMessage = await _httpUtility.ExecuteRestQuery(restUriSuffix, entityName, first, _incomingRoleHeader, _incomingRoleToken);
+                errorMessage = await _httpUtility.ExecuteRestQueryAsync(restUriSuffix, entityName, first, _incomingRoleHeader, _incomingRoleToken);
                 stopwatch.Stop();
                 return string.IsNullOrEmpty(errorMessage) ? ((int)stopwatch.ElapsedMilliseconds, errorMessage) : (HealthCheckConstants.ERROR_RESPONSE_TIME_MS, errorMessage);
             }
@@ -292,14 +290,14 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Executes the GraphQL Entity Query and keeps track of the response time and error message.
-        private async Task<(int, string?)> ExecuteGraphQLEntityQuery(string graphqlUriSuffix, Entity entity, string entityName)
+        private async Task<(int, string?)> ExecuteGraphQLEntityQueryAsync(string graphqlUriSuffix, Entity entity, string entityName)
         {
             string? errorMessage = null;
             if (entity != null)
             {
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
-                errorMessage = await _httpUtility.ExecuteGraphQLQuery(graphqlUriSuffix, entityName, entity, _incomingRoleHeader, _incomingRoleToken);
+                errorMessage = await _httpUtility.ExecuteGraphQLQueryAsync(graphqlUriSuffix, entityName, entity, _incomingRoleHeader, _incomingRoleToken);
                 stopwatch.Stop();
                 return string.IsNullOrEmpty(errorMessage) ? ((int)stopwatch.ElapsedMilliseconds, errorMessage) : (HealthCheckConstants.ERROR_RESPONSE_TIME_MS, errorMessage);
             }

--- a/src/Service/HealthCheck/HealthCheckHelper.cs
+++ b/src/Service/HealthCheck/HealthCheckHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.HealthCheck;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Authorization;
@@ -47,17 +48,18 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         /// <param name="context">HttpContext</param>
         /// <param name="runtimeConfig">RuntimeConfig</param>
         /// <returns>This function returns the comprehensive health report after calculating the response time of each datasource, rest and graphql health queries.</returns>
-        public ComprehensiveHealthCheckReport GetHealthCheckResponse(HttpContext context, RuntimeConfig runtimeConfig)
+        public async Task<ComprehensiveHealthCheckReport> GetHealthCheckResponse(HttpContext context, RuntimeConfig runtimeConfig)
         {
             // Create a JSON response for the comprehensive health check endpoint using the provided basic health report.
             // If the response has already been created, it will be reused.
             _httpUtility.ConfigureApiRoute(context);
-            LogTrace("Comprehensive Health check is enabled in the runtime configuration.");
+            _logger.LogTrace("Comprehensive Health check is enabled in the runtime configuration.");
 
             ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport = new();
             UpdateVersionAndAppName(ref ComprehensiveHealthCheckReport);
+            UpdateTimestampOfResponse(ref ComprehensiveHealthCheckReport);
             UpdateDabConfigurationDetails(ref ComprehensiveHealthCheckReport, runtimeConfig);
-            UpdateHealthCheckDetails(ref ComprehensiveHealthCheckReport, runtimeConfig);
+            await UpdateHealthCheckDetails(ComprehensiveHealthCheckReport, runtimeConfig);
             UpdateOverallHealthStatus(ref ComprehensiveHealthCheckReport);
             return ComprehensiveHealthCheckReport;
         }
@@ -126,6 +128,12 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
             response.AppName = ProductInfo.GetDataApiBuilderUserAgent();
         }
 
+        // Updates the timestamp for the Health report.
+        private static void UpdateTimestampOfResponse(ref ComprehensiveHealthCheckReport response)
+        {
+            response.TimeStamp = DateTime.UtcNow;
+        }
+
         // Updates the DAB configuration details coming from RuntimeConfig for the Health report.
         private static void UpdateDabConfigurationDetails(ref ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
         {
@@ -140,20 +148,20 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Main function to internally call for data source and entities health check.
-        private void UpdateHealthCheckDetails(ref ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
+        private async Task UpdateHealthCheckDetails(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
         {
             ComprehensiveHealthCheckReport.Checks = new List<HealthCheckResultEntry>();
-            UpdateDataSourceHealthCheckResults(ref ComprehensiveHealthCheckReport, runtimeConfig);
-            UpdateEntityHealthCheckResults(ref ComprehensiveHealthCheckReport, runtimeConfig);
+            await UpdateDataSourceHealthCheckResults(ComprehensiveHealthCheckReport, runtimeConfig);
+            await UpdateEntityHealthCheckResults(ComprehensiveHealthCheckReport, runtimeConfig);
         }
 
         // Updates the DataSource Health Check Results in the response.
-        private void UpdateDataSourceHealthCheckResults(ref ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
+        private async Task UpdateDataSourceHealthCheckResults(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
         {
             if (ComprehensiveHealthCheckReport.Checks != null && runtimeConfig.DataSource.IsDatasourceHealthEnabled)
             {
                 string query = Utilities.GetDatSourceQuery(runtimeConfig.DataSource.DatabaseType);
-                (int, string?) response = ExecuteDatasourceQueryCheck(query, runtimeConfig.DataSource.ConnectionString);
+                (int, string?) response = await ExecuteDatasourceQueryCheck(query, runtimeConfig.DataSource.ConnectionString);
                 bool isResponseTimeWithinThreshold = response.Item1 >= 0 && response.Item1 < runtimeConfig.DataSource.DatasourceThresholdMs;
 
                 // Add DataSource Health Check Results
@@ -173,14 +181,14 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Executes the DB Query and keeps track of the response time and error message.
-        private (int, string?) ExecuteDatasourceQueryCheck(string query, string connectionString)
+        private async Task<(int, string?)> ExecuteDatasourceQueryCheck(string query, string connectionString)
         {
             string? errorMessage = null;
             if (!string.IsNullOrEmpty(query) && !string.IsNullOrEmpty(connectionString))
             {
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
-                errorMessage = _httpUtility.ExecuteDbQuery(query, connectionString);
+                errorMessage = await _httpUtility.ExecuteDbQuery(query, connectionString);
                 stopwatch.Stop();
                 return string.IsNullOrEmpty(errorMessage) ? ((int)stopwatch.ElapsedMilliseconds, errorMessage) : (HealthCheckConstants.ERROR_RESPONSE_TIME_MS, errorMessage);
             }
@@ -190,7 +198,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
 
         // Updates the Entity Health Check Results in the response. 
         // Goes through the entities one by one and executes the rest and graphql checks (if enabled).
-        private void UpdateEntityHealthCheckResults(ref ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
+        private async Task UpdateEntityHealthCheckResults(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, RuntimeConfig runtimeConfig)
         {
             if (runtimeConfig?.Entities != null && runtimeConfig.Entities.Entities.Any())
             {
@@ -198,7 +206,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 {
                     if (Entity.Value.IsEntityHealthEnabled)
                     {
-                        PopulateEntityHealth(ComprehensiveHealthCheckReport, Entity, runtimeConfig);
+                        await PopulateEntityHealth(ComprehensiveHealthCheckReport, Entity, runtimeConfig);
                     }
                 }
             }
@@ -207,7 +215,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         // Populates the Entity Health Check Results in the response for a particular entity.
         // Checks for Rest enabled and executes the rest query.
         // Checks for GraphQL enabled and executes the graphql query.
-        private void PopulateEntityHealth(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, KeyValuePair<string, Entity> entity, RuntimeConfig runtimeConfig)
+        private async Task PopulateEntityHealth(ComprehensiveHealthCheckReport ComprehensiveHealthCheckReport, KeyValuePair<string, Entity> entity, RuntimeConfig runtimeConfig)
         {
             // Global Rest and GraphQL Runtime Options
             RuntimeOptions? runtimeOptions = runtimeConfig.Runtime;
@@ -226,8 +234,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                     // The path is trimmed to remove the leading '/' character.
                     // If the path is not present, use the entity key name as the path.
                     string entityPath = entityValue.Rest.Path != null ? entityValue.Rest.Path.TrimStart('/') : entityKeyName;
-
-                    (int, string?) response = ExecuteRestEntityQuery(runtimeConfig.RestPath, entityPath, entityValue.EntityFirst);
+                    (int, string?) response = await ExecuteRestEntityQuery(runtimeConfig.RestPath, entityPath, entityValue.EntityFirst);
                     bool isResponseTimeWithinThreshold = response.Item1 >= 0 && response.Item1 < entityValue.EntityThresholdMs;
 
                     // Add Entity Health Check Results
@@ -249,7 +256,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 {
                     ComprehensiveHealthCheckReport.Checks ??= new List<HealthCheckResultEntry>();
 
-                    (int, string?) response = ExecuteGraphQLEntityQuery(runtimeConfig.GraphQLPath, entityValue, entityKeyName);
+                    (int, string?) response = await ExecuteGraphQLEntityQuery(runtimeConfig.GraphQLPath, entityValue, entityKeyName);
                     bool isResponseTimeWithinThreshold = response.Item1 >= 0 && response.Item1 < entityValue.EntityThresholdMs;
 
                     ComprehensiveHealthCheckReport.Checks.Add(new HealthCheckResultEntry
@@ -269,14 +276,14 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Executes the Rest Entity Query and keeps track of the response time and error message.
-        private (int, string?) ExecuteRestEntityQuery(string restUriSuffix, string entityName, int first)
+        private async Task<(int, string?)> ExecuteRestEntityQuery(string restUriSuffix, string entityName, int first)
         {
             string? errorMessage = null;
             if (!string.IsNullOrEmpty(entityName))
             {
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
-                errorMessage = _httpUtility.ExecuteRestQuery(restUriSuffix, entityName, first, _incomingRoleHeader, _incomingRoleToken);
+                errorMessage = await _httpUtility.ExecuteRestQuery(restUriSuffix, entityName, first, _incomingRoleHeader, _incomingRoleToken);
                 stopwatch.Stop();
                 return string.IsNullOrEmpty(errorMessage) ? ((int)stopwatch.ElapsedMilliseconds, errorMessage) : (HealthCheckConstants.ERROR_RESPONSE_TIME_MS, errorMessage);
             }
@@ -285,28 +292,19 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Executes the GraphQL Entity Query and keeps track of the response time and error message.
-        private (int, string?) ExecuteGraphQLEntityQuery(string graphqlUriSuffix, Entity entity, string entityName)
+        private async Task<(int, string?)> ExecuteGraphQLEntityQuery(string graphqlUriSuffix, Entity entity, string entityName)
         {
             string? errorMessage = null;
             if (entity != null)
             {
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
-                errorMessage = _httpUtility.ExecuteGraphQLQuery(graphqlUriSuffix, entityName, entity, _incomingRoleHeader, _incomingRoleToken);
+                errorMessage = await _httpUtility.ExecuteGraphQLQuery(graphqlUriSuffix, entityName, entity, _incomingRoleHeader, _incomingRoleToken);
                 stopwatch.Stop();
                 return string.IsNullOrEmpty(errorMessage) ? ((int)stopwatch.ElapsedMilliseconds, errorMessage) : (HealthCheckConstants.ERROR_RESPONSE_TIME_MS, errorMessage);
             }
 
             return (HealthCheckConstants.ERROR_RESPONSE_TIME_MS, errorMessage);
-        }
-
-        // <summary>
-        /// Logs a trace message if a logger is present and the logger is enabled for trace events.
-        /// </summary>
-        /// <param name="message">Message to emit.</param>
-        private void LogTrace(string message)
-        {
-            _logger.LogTrace(message);
         }
     }
 }

--- a/src/Service/HealthCheck/HealthCheckHelper.cs
+++ b/src/Service/HealthCheck/HealthCheckHelper.cs
@@ -221,7 +221,12 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 if (runtimeOptions.IsRestEnabled && entityValue.IsRestEnabled)
                 {
                     ComprehensiveHealthCheckReport.Checks ??= new List<HealthCheckResultEntry>();
+
+                    // In case of REST API, use the path specified in [entity.path] (if present).
+                    // The path is trimmed to remove the leading '/' character.
+                    // If the path is not present, use the entity key name as the path.
                     string entityPath = entityValue.Rest.Path != null ? entityValue.Rest.Path.TrimStart('/') : entityKeyName;
+
                     (int, string?) response = ExecuteRestEntityQuery(runtimeConfig.RestPath, entityPath, entityValue.EntityFirst);
                     bool isResponseTimeWithinThreshold = response.Item1 >= 0 && response.Item1 < entityValue.EntityThresholdMs;
 

--- a/src/Service/HealthCheck/HttpUtilities.cs
+++ b/src/Service/HealthCheck/HttpUtilities.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.DatabasePrimitives;
@@ -14,8 +13,7 @@ using Azure.DataApiBuilder.Core.Authorization;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Core.Services.MetadataProviders;
-using Humanizer;
-using Microsoft.AspNetCore.Http;
+using Azure.DataApiBuilder.Service.GraphQLBuilder;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 
@@ -27,7 +25,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
     public class HttpUtilities
     {
         private readonly ILogger<HttpUtilities> _logger;
-        private string _apiRoute;
+        private HttpClient _httpClient;
         private IMetadataProviderFactory _metadataProviderFactory;
         private RuntimeConfigProvider _runtimeConfigProvider;
 
@@ -37,34 +35,21 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         /// <param name="logger">Logger</param>
         /// <param name="metadataProviderFactory">MetadataProviderFactory</param>
         /// <param name="runtimeConfigProvider">RuntimeConfigProvider</param>
+        /// <param name="httpClientFactory">HttpClientFactory</param>
         public HttpUtilities(
             ILogger<HttpUtilities> logger,
             IMetadataProviderFactory metadataProviderFactory,
-            RuntimeConfigProvider runtimeConfigProvider)
+            RuntimeConfigProvider runtimeConfigProvider,
+            IHttpClientFactory httpClientFactory)
         {
             _logger = logger;
-            _apiRoute = string.Empty;
             _metadataProviderFactory = metadataProviderFactory;
             _runtimeConfigProvider = runtimeConfigProvider;
-        }
-
-        /// <summary>
-        /// Fetches the Http Base URI from the Context information to execute the REST and GraphQL queries.
-        /// </summary>
-        /// <param name="httpContext">HttpContext</param>
-        public void ConfigureApiRoute(HttpContext httpContext)
-        {
-            if (httpContext == null || httpContext.Request == null)
-            {
-                throw new ArgumentNullException(nameof(httpContext));
-            }
-
-            // Extract base URL: scheme + host + port (if present)
-            _apiRoute = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
+            _httpClient = httpClientFactory.CreateClient("ContextConfiguredHealthCheckClient");
         }
 
         // Executes the DB query by establishing a connection to the DB.
-        public async Task<string?> ExecuteDbQuery(string query, string connectionString)
+        public async Task<string?> ExecuteDbQueryAsync(string query, string connectionString)
         {
             string? errorMessage = null;
             // Execute the query on DB and return the response time.
@@ -89,50 +74,44 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         }
 
         // Executes the REST query by sending a GET request to the API.
-        public async Task<string?> ExecuteRestQuery(string restUriSuffix, string entityName, int first, string incomingRoleHeader, string incomingRoleToken)
+        public async Task<string?> ExecuteRestQueryAsync(string restUriSuffix, string entityName, int first, string incomingRoleHeader, string incomingRoleToken)
         {
             string? errorMessage = null;
             try
             {
                 // Base URL of the API that handles SQL operations
-                string apiRoute = Utilities.GetServiceRoute(_apiRoute, restUriSuffix);
+                string apiRoute = $"{restUriSuffix}{Utilities.CreateHttpRestQuery(entityName, first)}";
                 if (string.IsNullOrEmpty(apiRoute))
                 {
                     _logger.LogError("The API route is not available, hence HealthEndpoint is not available.");
                     return errorMessage;
                 }
 
-                if (!Program.CheckSanityOfUrl(apiRoute))
+                if (!Program.CheckSanityOfUrl($"{_httpClient.BaseAddress}{restUriSuffix}"))
                 {
                     _logger.LogError("Blocked outbound request due to invalid or unsafe URI.");
                     return "Blocked outbound request due to invalid or unsafe URI.";
                 }
 
-                // Create an instance of HttpClient
-                using (HttpClient client = CreateClient(apiRoute))
+                HttpRequestMessage message = new(method: HttpMethod.Get, requestUri: apiRoute);
+                if (!string.IsNullOrEmpty(incomingRoleToken))
                 {
-                    // Send a GET request to the API
-                    apiRoute = $"{apiRoute}{Utilities.CreateHttpRestQuery(entityName, first)}";
-                    HttpRequestMessage message = new(method: HttpMethod.Get, requestUri: apiRoute);
-                    if (!string.IsNullOrEmpty(incomingRoleToken))
-                    {
-                        message.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, incomingRoleToken);
-                    }
+                    message.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, incomingRoleToken);
+                }
 
-                    if (!string.IsNullOrEmpty(incomingRoleHeader))
-                    {
-                        message.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, incomingRoleHeader);
-                    }
+                if (!string.IsNullOrEmpty(incomingRoleHeader))
+                {
+                    message.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, incomingRoleHeader);
+                }
 
-                    HttpResponseMessage response = await client.SendAsync(message);
-                    if (response.IsSuccessStatusCode)
-                    {
-                        _logger.LogTrace($"The REST HealthEndpoint query executed successfully with code {response.IsSuccessStatusCode}.");
-                    }
-                    else
-                    {
-                        errorMessage = $"The REST HealthEndpoint query failed with code: {response.StatusCode}.";
-                    }
+                HttpResponseMessage response = await _httpClient.SendAsync(message);
+                if (response.IsSuccessStatusCode)
+                {
+                    _logger.LogTrace($"The REST HealthEndpoint query executed successfully with code {response.IsSuccessStatusCode}.");
+                }
+                else
+                {
+                    errorMessage = $"The REST HealthEndpoint query failed with code: {response.StatusCode}.";
                 }
 
                 return errorMessage;
@@ -146,18 +125,11 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
 
         // Executes the GraphQL query by sending a POST request to the API.
         // Internally calls the metadata provider to fetch the column names to create the graphql payload.
-        public async Task<string?> ExecuteGraphQLQuery(string graphqlUriSuffix, string entityName, Entity entity, string incomingRoleHeader, string incomingRoleToken)
+        public async Task<string?> ExecuteGraphQLQueryAsync(string graphqlUriSuffix, string entityName, Entity entity, string incomingRoleHeader, string incomingRoleToken)
         {
             string? errorMessage = null;
-            // Base URL of the API that handles SQL operations
-            string apiRoute = Utilities.GetServiceRoute(_apiRoute, graphqlUriSuffix);
-            if (string.IsNullOrEmpty(apiRoute))
-            {
-                _logger.LogError("The API route is not available, hence HealthEndpoint is not available.");
-                return errorMessage;
-            }
 
-            if (!Program.CheckSanityOfUrl(apiRoute))
+            if (!Program.CheckSanityOfUrl($"{_httpClient.BaseAddress}{graphqlUriSuffix}"))
             {
                 _logger.LogError("Blocked outbound request due to invalid or unsafe URI.");
                 return "Blocked outbound request due to invalid or unsafe URI.";
@@ -169,46 +141,43 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
 
                 // Fetch Column Names from Metadata Provider
                 ISqlMetadataProvider sqlMetadataProvider = _metadataProviderFactory.GetMetadataProvider(dataSourceName);
-                DatabaseObject dbObject = sqlMetadataProvider.EntityToDatabaseObject[entityName];
+                DatabaseObject dbObject = sqlMetadataProvider.GetDatabaseObjectByKey(entityName);
                 List<string> columnNames = dbObject.SourceDefinition.Columns.Keys.ToList();
 
                 // In case of GraphQL API, use the plural value specified in [entity.graphql.type.plural].
                 // Further, we need to camel case this plural value to match the GraphQL object name.                  
-                string graphqlObjectName = LowerFirstLetter(entity.GraphQL.Plural.Pascalize());
+                string graphqlObjectName = GraphQLNaming.GenerateListQueryName(entityName, entity);
 
                 // In case any primitive column names are present, execute the query
                 if (columnNames.Any())
                 {
-                    using (HttpClient client = CreateClient(apiRoute))
+                    string jsonPayload = Utilities.CreateHttpGraphQLQuery(graphqlObjectName, columnNames, entity.EntityFirst);
+                    HttpContent content = new StringContent(jsonPayload, Encoding.UTF8, Utilities.JSON_CONTENT_TYPE);
+
+                    HttpRequestMessage message = new(method: HttpMethod.Post, requestUri: graphqlUriSuffix)
                     {
-                        string jsonPayload = Utilities.CreateHttpGraphQLQuery(graphqlObjectName, columnNames, entity.EntityFirst);
-                        HttpContent content = new StringContent(jsonPayload, Encoding.UTF8, Utilities.JSON_CONTENT_TYPE);
+                        Content = content
+                    };
 
-                        HttpRequestMessage message = new(method: HttpMethod.Post, requestUri: apiRoute)
-                        {
-                            Content = content
-                        };
+                    if (!string.IsNullOrEmpty(incomingRoleToken))
+                    {
+                        message.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, incomingRoleToken);
+                    }
 
-                        if (!string.IsNullOrEmpty(incomingRoleToken))
-                        {
-                            message.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, incomingRoleToken);
-                        }
+                    if (!string.IsNullOrEmpty(incomingRoleHeader))
+                    {
+                        message.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, incomingRoleHeader);
+                    }
 
-                        if (!string.IsNullOrEmpty(incomingRoleHeader))
-                        {
-                            message.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, incomingRoleHeader);
-                        }
+                    HttpResponseMessage response = await _httpClient.SendAsync(message);
 
-                        HttpResponseMessage response = await client.SendAsync(message);
-
-                        if (response.IsSuccessStatusCode)
-                        {
-                            _logger.LogTrace("The GraphQL HealthEndpoint query executed successfully.");
-                        }
-                        else
-                        {
-                            errorMessage = $"The GraphQL HealthEndpoint query failed with code: {response.StatusCode}.";
-                        }
+                    if (response.IsSuccessStatusCode)
+                    {
+                        _logger.LogTrace("The GraphQL HealthEndpoint query executed successfully.");
+                    }
+                    else
+                    {
+                        errorMessage = $"The GraphQL HealthEndpoint query failed with code: {response.StatusCode}.";
                     }
                 }
 
@@ -219,35 +188,6 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 _logger.LogError($"An exception occurred while executing the GraphQL health check query: {ex.Message}");
                 return ex.Message;
             }
-        }
-
-        /// <summary>
-        /// Creates a <see cref="HttpClient" /> for processing HTTP requests/responses with the test server.
-        /// </summary>
-        public HttpClient CreateClient(string apiRoute)
-        {
-            return new HttpClient()
-            {
-                // Set the base URL for the client
-                BaseAddress = new Uri(apiRoute),
-                DefaultRequestHeaders =
-                {
-                    Accept = { new MediaTypeWithQualityHeaderValue(Utilities.JSON_CONTENT_TYPE) }
-                },
-                Timeout = TimeSpan.FromSeconds(200),
-            };
-        }
-
-        // Updates the entity key name to camel case for the health check report.
-        public static string LowerFirstLetter(string input)
-        {
-            if (string.IsNullOrEmpty(input) || char.IsLower(input[0]))
-            {
-                // If the input is null or empty, or if the first character is already lowercase, return the input as is.
-                return input;
-            }
-
-            return char.ToLower(input[0]) + input.Substring(1);
         }
     }
 }

--- a/src/Service/HealthCheck/HttpUtilities.cs
+++ b/src/Service/HealthCheck/HttpUtilities.cs
@@ -101,6 +101,12 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                     return errorMessage;
                 }
 
+                if (!Program.CheckSanityOfUrl(apiRoute))
+                {
+                    LogTrace("Blocked outbound request due to invalid or unsafe URI.");
+                    return "Blocked outbound request due to invalid or unsafe URI.";
+                }
+
                 // Create an instance of HttpClient
                 using (HttpClient client = CreateClient(apiRoute))
                 {
@@ -148,6 +154,12 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
             {
                 LogTrace("The API route is not available, hence HealthEndpoint is not available.");
                 return errorMessage;
+            }
+
+            if (!Program.CheckSanityOfUrl(apiRoute))
+            {
+                LogTrace("Blocked outbound request due to invalid or unsafe URI.");
+                return "Blocked outbound request due to invalid or unsafe URI.";
             }
 
             try

--- a/src/Service/HealthCheck/HttpUtilities.cs
+++ b/src/Service/HealthCheck/HttpUtilities.cs
@@ -13,6 +13,7 @@ using Azure.DataApiBuilder.Core.Authorization;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Core.Services.MetadataProviders;
+using Humanizer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
@@ -157,14 +158,17 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 ISqlMetadataProvider sqlMetadataProvider = _metadataProviderFactory.GetMetadataProvider(dataSourceName);
                 DatabaseObject dbObject = sqlMetadataProvider.EntityToDatabaseObject[entityName];
                 List<string> columnNames = dbObject.SourceDefinition.Columns.Keys.ToList();
-                string databaseObjectName = entity.Source.Object;
+
+                // In case of GraphQL API, use the plural value specified in [entity.graphql.type.plural].
+                // Further, we need to camel case this plural value to match the GraphQL object name.                  
+                string graphqlObjectName = LowerFirstLetter(entity.GraphQL.Plural.Pascalize());
 
                 // In case any primitive column names are present, execute the query
                 if (columnNames.Any())
                 {
                     using (HttpClient client = CreateClient(apiRoute))
                     {
-                        string jsonPayload = Utilities.CreateHttpGraphQLQuery(databaseObjectName, columnNames, entity.EntityFirst);
+                        string jsonPayload = Utilities.CreateHttpGraphQLQuery(graphqlObjectName, columnNames, entity.EntityFirst);
                         HttpContent content = new StringContent(jsonPayload, Encoding.UTF8, Utilities.JSON_CONTENT_TYPE);
 
                         HttpRequestMessage message = new(method: HttpMethod.Post, requestUri: apiRoute)
@@ -219,6 +223,18 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
                 },
                 Timeout = TimeSpan.FromSeconds(200),
             };
+        }
+
+        // Updates the entity key name to camel case for the health check report.
+        public static string LowerFirstLetter(string input)
+        {
+            if (string.IsNullOrEmpty(input) || char.IsLower(input[0]))
+            {
+                // If the input is null or empty, or if the first character is already lowercase, return the input as is.
+                return input;
+            }
+
+            return char.ToLower(input[0]) + input.Substring(1);
         }
 
         // <summary>

--- a/src/Service/HealthCheck/Model/ComprehensiveHealthCheckReport.cs
+++ b/src/Service/HealthCheck/Model/ComprehensiveHealthCheckReport.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -35,6 +36,12 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         /// </summary>
         [JsonPropertyName("app-name")]
         public string? AppName { get; set; }
+
+        /// <summary>
+        /// The timestamp of the response.
+        /// </summary>
+        [JsonPropertyName("timestamp")]
+        public DateTime TimeStamp { get; set; }
 
         /// <summary>
         /// The configuration details of the dab service.

--- a/src/Service/HealthCheck/Utilities.cs
+++ b/src/Service/HealthCheck/Utilities.cs
@@ -37,7 +37,7 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
             var payload = new
             {
                 //{"query":"{publishers(first:4) {items {id name} }}"}
-                query = $"{{{entityName.ToLowerInvariant()} (first: {first}) {{items {{ {string.Join(" ", columnNames)} }}}}}}"
+                query = $"{{{entityName} (first: {first}) {{items {{ {string.Join(" ", columnNames)} }}}}}}"
             };
 
             // Serialize the payload to a JSON string

--- a/src/Service/HealthCheck/Utilities.cs
+++ b/src/Service/HealthCheck/Utilities.cs
@@ -48,20 +48,8 @@ namespace Azure.DataApiBuilder.Service.HealthCheck
         public static string CreateHttpRestQuery(string entityName, int first)
         {
             // Create the payload for the REST HTTP request.
-            // "/EntityName?$first=4"
+            // "EntityName?$first=4"
             return $"/{entityName}?$first={first}";
-        }
-
-        public static string GetServiceRoute(string route, string uriSuffix)
-        {
-            // The RuntimeConfigProvider enforces the expectation that the configured REST and GraphQL path starts with a
-            // forward slash '/'. This is to ensure that the path is always relative to the base URL.
-            if (uriSuffix == string.Empty)
-            {
-                return string.Empty;
-            }
-
-            return $"{route}{uriSuffix.ToLowerInvariant()}";
         }
     }
 }

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -283,8 +283,7 @@ namespace Azure.DataApiBuilder.Service
                 }
 
                 string testUrl = ReplaceWildcardHost(url);
-                if (!Uri.TryCreate(testUrl, UriKind.Absolute, out Uri? uriResult) ||
-                    (uriResult.Scheme != Uri.UriSchemeHttp && uriResult.Scheme != Uri.UriSchemeHttps))
+                if (!CheckSanityOfUrl(testUrl))
                 {
                     return false;
                 }
@@ -300,6 +299,28 @@ namespace Azure.DataApiBuilder.Service
 
             static string ReplaceWildcardHost(string url) =>
                 Regex.Replace(url, @"^(https?://)[\+\*]", "$1localhost", RegexOptions.IgnoreCase);
+        }
+
+        public static bool CheckSanityOfUrl(string uri)
+        {
+            if (!Uri.TryCreate(uri, UriKind.Absolute, out Uri? parsedUri))
+            {
+                return false;
+            }
+
+            // Only allow HTTP or HTTPS schemes
+            if (parsedUri.Scheme != Uri.UriSchemeHttp && parsedUri.Scheme != Uri.UriSchemeHttps)
+            {
+                return false;
+            }
+
+            // Disallow empty hostnames
+            if (string.IsNullOrWhiteSpace(parsedUri.Host))
+            {
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -22,6 +22,7 @@ using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Core.Services.Cache;
 using Azure.DataApiBuilder.Core.Services.MetadataProviders;
 using Azure.DataApiBuilder.Core.Services.OpenAPI;
+using Azure.DataApiBuilder.Core.Telemetry;
 using Azure.DataApiBuilder.Service.Controllers;
 using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.HealthCheck;

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -46,6 +46,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using NodaTime;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -275,22 +277,44 @@ namespace Azure.DataApiBuilder.Service
             services.AddHttpClient("ContextConfiguredHealthCheckClient")
                 .ConfigureHttpClient((serviceProvider, client) =>
                 {
-                    IHttpContextAccessor httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
-                    HttpContext? httpContext = httpContextAccessor.HttpContext;
+                    IHttpContextAccessor httpCtxAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
+                    HttpContext? httpContext = httpCtxAccessor.HttpContext;
+                    string baseUri = string.Empty;
 
-                    if (httpContext != null)
+                    if (httpContext is not null)
                     {
-                        // Build base address from request
-                        string baseUri = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
+                        string scheme = httpContext.Request.Scheme;  // "http" or "https"
+                        string host = httpContext.Request.Host.Host ?? "localhost"; // e.g. "localhost"
+                        int port = ResolveInternalPort(httpContext);
+                        baseUri = $"{scheme}://{host}:{port}";
                         client.BaseAddress = new Uri(baseUri);
-
-                        // Set default Accept header
-                        client.DefaultRequestHeaders.Accept.Clear();
-                        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    }
+                    else
+                    {
+                        // Optional fallback if ever needed in non-request scenarios
+                        baseUri = $"http://localhost:{ResolveInternalPort()}";
+                        client.BaseAddress = new Uri(baseUri);
                     }
 
-                    // Optional: Set a timeout
+                    _logger.LogInformation($"Configured HealthCheck HttpClient BaseAddress as: {baseUri}");
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                     client.Timeout = TimeSpan.FromSeconds(200);
+                })
+                .ConfigurePrimaryHttpMessageHandler(serviceProvider =>
+                {
+                    // For debug purpose, USE_SELF_SIGNED_CERT can be set to true in Environment variables
+                    bool allowSelfSigned = Environment.GetEnvironmentVariable("USE_SELF_SIGNED_CERT")?.Equals("true", StringComparison.OrdinalIgnoreCase) == true;
+
+                    HttpClientHandler handler = new();
+
+                    if (allowSelfSigned)
+                    {
+                        handler.ServerCertificateCustomValidationCallback =
+                            HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                    }
+
+                    return handler;
                 });
 
             if (runtimeConfig is not null && runtimeConfig.Runtime?.Host?.Mode is HostMode.Development)
@@ -936,5 +960,59 @@ namespace Azure.DataApiBuilder.Service
             LoggerFilters.AddFilter(typeof(IAuthorizationResolver).FullName);
             LoggerFilters.AddFilter("default");
         }
+
+        /// <summary>
+        /// Get the internal port of the container.
+        /// </summary>
+        /// <param name="httpContext">The HttpContext</param>
+        /// <returns>The internal container port</returns>
+        private static int ResolveInternalPort(HttpContext? httpContext = null)
+        {
+            // Try X-Forwarded-Port if context is present
+            if (httpContext is not null &&
+                httpContext.Request.Headers.TryGetValue("X-Forwarded-Port", out StringValues fwdPortVal) &&
+                int.TryParse(fwdPortVal.ToString(), out int fwdPort) &&
+                fwdPort > 0)
+            {
+                return fwdPort;
+            }
+
+            // Infer scheme from context if available, else default to "http"
+            string scheme = httpContext?.Request.Scheme ?? "http";
+
+            // Check ASPNETCORE_URLS env var
+            string? aspnetcoreUrls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
+
+            if (!string.IsNullOrWhiteSpace(aspnetcoreUrls))
+            {
+                foreach (string part in aspnetcoreUrls.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    string trimmed = part.Trim();
+
+                    // Handle wildcard format (e.g. http://+:5002)
+                    if (trimmed.StartsWith($"{scheme}://+:", StringComparison.OrdinalIgnoreCase))
+                    {
+                        int colonIndex = trimmed.LastIndexOf(':');
+                        if (colonIndex != -1 &&
+                            int.TryParse(trimmed.Substring(colonIndex + 1), out int wildcardPort) &&
+                            wildcardPort > 0)
+                        {
+                            return wildcardPort;
+                        }
+                    }
+
+                    // Handle standard URI format
+                    if (trimmed.StartsWith($"{scheme}://", StringComparison.OrdinalIgnoreCase) &&
+                        Uri.TryCreate(trimmed, UriKind.Absolute, out Uri? uri))
+                    {
+                        return uri.Port;
+                    }
+                }
+            }
+
+            // Fallback
+            return scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? 443 : 5000;
+        }
+
     }
 }

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO.Abstractions;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config;
@@ -270,6 +271,27 @@ namespace Azure.DataApiBuilder.Service
             //Enable accessing HttpContext in RestService to get ClaimsPrincipal.
             services.AddHttpContextAccessor();
 
+            services.AddHttpClient("ContextConfiguredHealthCheckClient")
+                .ConfigureHttpClient((serviceProvider, client) =>
+                {
+                    IHttpContextAccessor httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
+                    HttpContext? httpContext = httpContextAccessor.HttpContext;
+
+                    if (httpContext != null)
+                    {
+                        // Build base address from request
+                        string baseUri = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
+                        client.BaseAddress = new Uri(baseUri);
+
+                        // Set default Accept header
+                        client.DefaultRequestHeaders.Accept.Clear();
+                        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    }
+
+                    // Optional: Set a timeout
+                    client.Timeout = TimeSpan.FromSeconds(200);
+                });
+
             if (runtimeConfig is not null && runtimeConfig.Runtime?.Host?.Mode is HostMode.Development)
             {
                 // Development mode implies support for "Hot Reload". The V2 authentication function
@@ -501,6 +523,7 @@ namespace Azure.DataApiBuilder.Service
                 {
                     context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
                 }
+
             });
 
             app.UseAuthentication();

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -47,7 +47,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using NodaTime;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -61,9 +61,9 @@ namespace Azure.DataApiBuilder.Service
         public static LogLevel MinimumLogLevel = LogLevel.Error;
 
         public static bool IsLogLevelOverriddenByCli;
-        public static OpenTelemetryOptions OpenTelemetryOptions = new();
 
         public static ApplicationInsightsOptions AppInsightsOptions = new();
+        public static OpenTelemetryOptions OpenTelemetryOptions = new();
         public const string NO_HTTPS_REDIRECT_FLAG = "--no-https-redirect";
         private HotReloadEventHandler<HotReloadEventArgs> _hotReloadEventHandler = new();
         private RuntimeConfigProvider? _configProvider;
@@ -119,11 +119,38 @@ namespace Azure.DataApiBuilder.Service
                 && runtimeConfig?.Runtime?.Telemetry?.OpenTelemetry is not null
                 && runtimeConfig.Runtime.Telemetry.OpenTelemetry.Enabled)
             {
+                services.Configure<OpenTelemetryLoggerOptions>(options =>
+                {
+                    options.IncludeScopes = true;
+                    options.ParseStateValues = true;
+                    options.IncludeFormattedMessage = true;
+                });
                 services.AddOpenTelemetry()
+                .WithLogging(logging =>
+                {
+                    logging.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(runtimeConfig.Runtime.Telemetry.OpenTelemetry.ServiceName!))
+                    .AddOtlpExporter(configure =>
+                    {
+                        configure.Endpoint = new Uri(runtimeConfig.Runtime.Telemetry.OpenTelemetry.Endpoint!);
+                        configure.Headers = runtimeConfig.Runtime.Telemetry.OpenTelemetry.Headers;
+                        configure.Protocol = OtlpExportProtocol.Grpc;
+                    });
+
+                })
                 .WithMetrics(metrics =>
                 {
                     metrics.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(runtimeConfig.Runtime.Telemetry.OpenTelemetry.ServiceName!))
-                        .AddAspNetCoreInstrumentation()
+                        .AddOtlpExporter(configure =>
+                        {
+                            configure.Endpoint = new Uri(runtimeConfig.Runtime.Telemetry.OpenTelemetry.Endpoint!);
+                            configure.Headers = runtimeConfig.Runtime.Telemetry.OpenTelemetry.Headers;
+                            configure.Protocol = OtlpExportProtocol.Grpc;
+                        })
+                        .AddMeter(TelemetryMetricsHelper.MeterName);
+                })
+                .WithTracing(tracing =>
+                {
+                    tracing.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(runtimeConfig.Runtime.Telemetry.OpenTelemetry.ServiceName!))
                         .AddHttpClientInstrumentation()
                         .AddOtlpExporter(configure =>
                         {
@@ -131,19 +158,7 @@ namespace Azure.DataApiBuilder.Service
                             configure.Headers = runtimeConfig.Runtime.Telemetry.OpenTelemetry.Headers;
                             configure.Protocol = OtlpExportProtocol.Grpc;
                         })
-                        .AddRuntimeInstrumentation();
-                })
-                .WithTracing(tracing =>
-                {
-                    tracing.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(runtimeConfig.Runtime.Telemetry.OpenTelemetry.ServiceName!))
-                        .AddAspNetCoreInstrumentation()
-                        .AddHttpClientInstrumentation()
-                        .AddOtlpExporter(configure =>
-                        {
-                            configure.Endpoint = new Uri(runtimeConfig.Runtime.Telemetry.OpenTelemetry.Endpoint!);
-                            configure.Headers = runtimeConfig.Runtime.Telemetry.OpenTelemetry.Headers;
-                            configure.Protocol = OtlpExportProtocol.Grpc;
-                        });
+                        .AddSource(TelemetryTracesHelper.DABActivitySource.Name);
                 });
             }
 
@@ -395,6 +410,7 @@ namespace Azure.DataApiBuilder.Service
             {
                 // Configure Application Insights Telemetry
                 ConfigureApplicationInsightsTelemetry(app, runtimeConfig);
+                ConfigureOpenTelemetry(runtimeConfig);
 
                 // Config provided before starting the engine.
                 isRuntimeReady = PerformOnConfigChangeAsync(app).Result;
@@ -708,6 +724,37 @@ namespace Azure.DataApiBuilder.Service
 
                 // Updating Startup Logger to Log from Startup Class.
                 ILoggerFactory? loggerFactory = Program.GetLoggerFactoryForLogLevel(MinimumLogLevel, appTelemetryClient);
+                _logger = loggerFactory.CreateLogger<Startup>();
+            }
+        }
+
+        /// <summary>
+        /// Configure Open Telemetry based on the loaded runtime configuration. If Open Telemetry
+        /// is enabled, we can track different events and metrics.
+        /// </summary>
+        /// <param name="runtimeConfigurationProvider">The provider used to load runtime configuration.</param>
+        /// <seealso cref="https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core#enable-application-insights-telemetry-collection"/>
+        private void ConfigureOpenTelemetry(RuntimeConfig runtimeConfig)
+        {
+            if (runtimeConfig?.Runtime?.Telemetry is not null
+                && runtimeConfig.Runtime.Telemetry.OpenTelemetry is not null)
+            {
+                OpenTelemetryOptions = runtimeConfig.Runtime.Telemetry.OpenTelemetry;
+
+                if (!OpenTelemetryOptions.Enabled)
+                {
+                    _logger.LogInformation("Open Telemetry are disabled.");
+                    return;
+                }
+
+                if (string.IsNullOrWhiteSpace(OpenTelemetryOptions?.Endpoint))
+                {
+                    _logger.LogWarning("Logs won't be sent to Open Telemetry because an Open Telemetry connection string is not available in the runtime config.");
+                    return;
+                }
+
+                // Updating Startup Logger to Log from Startup Class.
+                ILoggerFactory? loggerFactory = Program.GetLoggerFactoryForLogLevel(MinimumLogLevel);
                 _logger = loggerFactory.CreateLogger<Startup>();
             }
         }

--- a/src/Service/Telemetry/TelemetryMetricsHelper.cs
+++ b/src/Service/Telemetry/TelemetryMetricsHelper.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Kestral = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
+
+namespace Azure.DataApiBuilder.Service.Telemetry
+{
+    /// <summary>
+    /// Helper class for tracking telemetry metrics such as active requests, errors, total requests,
+    /// and request durations using the .NET Meter and Counter APIs.
+    /// </summary>
+    public static class TelemetryMetricsHelper
+    {
+        public static readonly string MeterName = "DataApiBuilder.Metrics";
+        private static readonly Meter _meter = new(MeterName);
+        private static readonly UpDownCounter<long> _activeRequests = _meter.CreateUpDownCounter<long>("active_requests");
+        private static readonly Counter<long> _errorCounter = _meter.CreateCounter<long>("total_errors");
+        private static readonly Counter<long> _totalRequests = _meter.CreateCounter<long>("total_requests");
+        private static readonly Histogram<double> _requestDuration = _meter.CreateHistogram<double>("request_duration", "ms");
+
+        public static void IncrementActiveRequests(ApiType kind) => _activeRequests.Add(1, new KeyValuePair<string, object?>("api_type", kind));
+
+        public static void DecrementActiveRequests(ApiType kind) => _activeRequests.Add(-1, new KeyValuePair<string, object?>("api_type", kind));
+
+        /// <summary>
+        /// Tracks a request by incrementing the total requests counter and associating it with metadata.
+        /// </summary>
+        /// <param name="method">The HTTP method of the request (e.g., GET, POST).</param>
+        /// <param name="statusCode">The HTTP status code of the response.</param>
+        /// <param name="endpoint">The endpoint being accessed.</param>
+        /// <param name="apiType">The type of API being used (e.g., REST, GraphQL).</param>
+        public static void TrackRequest(Kestral method, HttpStatusCode statusCode, string endpoint, ApiType apiType)
+        {
+            _totalRequests.Add(1,
+                new("method", method),
+                new("status_code", statusCode),
+                new("endpoint", endpoint),
+                new("api_type", apiType));
+        }
+
+        /// <summary>
+        /// Tracks an error by incrementing the error counter and associating it with metadata.
+        /// </summary>
+        /// <param name="method">The HTTP method of the request (e.g., GET, POST).</param>
+        /// <param name="statusCode">The HTTP status code of the response.</param>
+        /// <param name="endpoint">The endpoint being accessed.</param>
+        /// <param name="apiType">The type of API being used (e.g., REST, GraphQL).</param>
+        /// <param name="ex">The exception that occurred.</param>
+        public static void TrackError(Kestral method, HttpStatusCode statusCode, string endpoint, ApiType apiType, Exception ex)
+        {
+            _errorCounter.Add(1,
+                new("method", method),
+                new("status_code", statusCode),
+                new("endpoint", endpoint),
+                new("api_type", apiType),
+                new("error_type", ex.GetType().Name));
+        }
+
+        /// <summary>
+        /// Tracks the duration of a request by recording it in a histogram and associating it with metadata.
+        /// </summary>
+        /// <param name="method">The HTTP method of the request (e.g., GET, POST).</param>
+        /// <param name="statusCode">The HTTP status code of the response.</param>
+        /// <param name="endpoint">The endpoint being accessed.</param>
+        /// <param name="apiType">The type of API being used (e.g., REST, GraphQL).</param>
+        /// <param name="duration">The duration of the request in milliseconds.</param>
+        public static void TrackRequestDuration(Kestral method, HttpStatusCode statusCode, string endpoint, ApiType apiType, TimeSpan duration)
+        {
+            _requestDuration.Record(duration.TotalMilliseconds,
+                new("method", method),
+                new("status_code", statusCode),
+                new("endpoint", endpoint),
+                new("api_type", apiType));
+        }
+    }
+}

--- a/src/Service/Telemetry/TelemetryTracesHelper.cs
+++ b/src/Service/Telemetry/TelemetryTracesHelper.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using OpenTelemetry.Trace;
+using Kestral = Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpMethod;
+
+namespace Azure.DataApiBuilder.Service.Telemetry
+{
+    public static class TelemetryTracesHelper
+    {
+        /// <summary>
+        /// Activity source for Data API Builder telemetry.
+        /// </summary>
+        public static readonly ActivitySource DABActivitySource = new("DataApiBuilder");
+
+        /// <summary>
+        /// Tracks the start of a REST controller activity.
+        /// </summary>
+        /// <param name="activity">The activity instance.</param>
+        /// <param name="httpMethod">The HTTP method of the request (e.g., GET, POST).</param>
+        /// <param name="userAgent">The user agent string from the request.</param>
+        /// <param name="actionType">The type of action being performed (e.g. Read).</param>
+        /// <param name="httpURL">The URL of the request.</param>
+        /// <param name="queryString">The query string of the request, if any.</param>
+        /// <param name="userRole">The role of the user making the request.</param>
+        /// <param name="apiType">The type of API being used (e.g., REST, GraphQL).</param>
+        public static void TrackRestControllerActivityStarted(
+            this Activity activity,
+            Kestral httpMethod,
+            string userAgent,
+            string actionType,
+            string httpURL,
+            string? queryString,
+            string? userRole,
+            ApiType apiType)
+        {
+            if (activity.IsAllDataRequested)
+            {
+                activity.SetTag("http.method", httpMethod);
+                activity.SetTag("user-agent", userAgent);
+                activity.SetTag("action.type", actionType);
+                activity.SetTag("http.url", httpURL);
+                if (!string.IsNullOrEmpty(queryString))
+                {
+                    activity.SetTag("http.querystring", queryString);
+                }
+
+                if (!string.IsNullOrEmpty(userRole))
+                {
+                    activity.SetTag("user.role", userRole);
+                }
+
+                activity.SetTag("api.type", apiType);
+            }
+        }
+
+        /// <summary>
+        /// Tracks the start of a query activity.
+        /// </summary>
+        /// <param name="activity">The activity instance.</param>
+        /// <param name="databaseType">The type of database being queried.</param>
+        /// <param name="dataSourceName">The name of the data source being queried.</param>
+        public static void TrackQueryActivityStarted(
+            this Activity activity,
+            DatabaseType databaseType,
+            string dataSourceName)
+        {
+            if (activity.IsAllDataRequested)
+            {
+                activity.SetTag("data-source.type", databaseType);
+                activity.SetTag("data-source.name", dataSourceName);
+            }
+
+        }
+
+        /// <summary>
+        /// Tracks the completion of a REST controller activity.
+        /// </summary>
+        /// <param name="activity">The activity instance.</param>
+        /// <param name="statusCode">The HTTP status code of the response.</param>
+        public static void TrackRestControllerActivityFinished(
+            this Activity activity,
+            HttpStatusCode statusCode)
+        {
+            if (activity.IsAllDataRequested)
+            {
+                activity.SetTag("status.code", statusCode);
+            }
+        }
+
+        /// <summary>
+        /// Tracks the completion of a REST controller activity with an exception.
+        /// </summary>
+        /// <param name="activity">The activity instance.</param>
+        /// <param name="ex">The exception that occurred.</param>
+        /// <param name="statusCode">The HTTP status code of the response.</param>
+        public static void TrackRestControllerActivityFinishedWithException(
+            this Activity activity,
+            Exception ex,
+            HttpStatusCode statusCode)
+        {
+            if (activity.IsAllDataRequested)
+            {
+                activity.SetStatus(Status.Error.WithDescription(ex.Message));
+                activity.RecordException(ex);
+                activity.SetTag("error.type", ex.GetType().Name);
+                activity.SetTag("error.message", ex.Message);
+                activity.SetTag("status.code", statusCode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why make this change?

This change is made in order to add all of the commits for milestone 1.5 into its respective branch.

## What is this change?

This change cherry-picks all of the commits that were added after the first release candidate.
Cherry-picked commits:
 - #2648 
#2657
#2617 
#2659 
#2655 
#2633 
#2667 
#2673 
#2650 
#2695 
#2702 
#2688

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

## Sample Request(s)
