### PR TITLE
Cherry-Pick for Release 1.5 Revert SqlClient.SNI License Name from 5.2.3 to 5.2.0

### DIFF
--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -14,7 +14,7 @@ Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Out-File $chiliCreamLicenseSavePath
 
 # Define the path to the license file in your repository and Read the content of the license file
-$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.3.License.txt"
+$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.0.License.txt"
 $sqlClientSNILicense = Get-Content -Path $sqlClientSNILicenseFilePath -Raw
 
 # Path of notice file generated in CI/CD pipeline.


### PR DESCRIPTION
## Why make this change?

Need to update license agreement to old version in script. SqlClient.SNI does not have a new version the same way the SqlClient package does with 5.2.3.

## What is this change?

This changes the name of the license agreement from 5.2.3 to 5.2.0. Related to PR #2702

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

## Sample Request(s)