### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ Demo source code: [startrek](https://aka.ms/dab/startrek)
 | **REST** | • `$select` for projection<br>• `$filter` for filtering<br>• `$orderBy` for sorting |
 | **GraphQL** | • Relationship navigation<br>• Data aggregation<br>• Multiple mutations |
 | **Telemetry** | • Structured logs<br>• OpenTelemetry<br>• Application Insights<br>• Health endpoints |
-| **Advanced** | • Pagination<br>• Level 1 (in-memory) cache<br>• Level 2 (Redis) cache |
+| **Advanced** | • Pagination<br>• Level 1 (in-memory) cache |
 | **Authentication** | • OAuth2/JWT<br>• EasyAuth<br>• Entra ID |
 | **Authorization** | • Role-based support<br>• Entity permissions<br>• Database policies |
-| **Developer** | • Cross-platform CLI<br>• Swagger (REST)<br>• Banana Cake Pop (GraphQL)<br>• Open Source<br>• Hot Reload |
+| **Developer** | • Cross-platform CLI<br>• Swagger (REST)<br>• Nitro [previously Banana Cake Pop] (GraphQL)<br>• Open Source<br>• Configuration Hot Reload |
 
 ## How does it work?
 


### PR DESCRIPTION
## Please merge immediately

This pull request updates the `README.md` file to refine descriptions of advanced features and developer tools. The changes include removing references to Redis caching and renaming a GraphQL tool to its updated name.

Updates to feature descriptions:

* Removed "Level 2 (Redis) cache" from the list of advanced features under the **Advanced** section.

Updates to developer tools:

* Renamed "Banana Cake Pop" to "Nitro" in the **Developer** section to reflect the updated name of the GraphQL tool. Added clarification that Nitro supports configuration hot reload.