### PR TITLE
Write CacheTtl to entity when add/update command is used and CacheTtl is provided

### DIFF
--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -14,7 +14,7 @@ Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Out-File $chiliCreamLicenseSavePath
 
 # Define the path to the license file in your repository and Read the content of the license file
-$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.3.License.txt"
+$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.0.License.txt"
 $sqlClientSNILicense = Get-Content -Path $sqlClientSNILicenseFilePath -Raw
 
 # Path of notice file generated in CI/CD pipeline.

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -843,6 +843,7 @@ namespace Cli
 
             EntityCacheOptions cacheOptions = new();
             bool isEnabled = false;
+            bool isCacheTtlUserProvided = false;
             int ttl = EntityCacheOptions.DEFAULT_TTL_SECONDS;
 
             if (cacheEnabled is not null && !bool.TryParse(cacheEnabled, out isEnabled))
@@ -855,12 +856,17 @@ namespace Cli
                 _logger.LogError("Invalid format for --cache.ttl. Accepted values are any non-negative integer.");
             }
 
+            if (cacheTtl is not null)
+            {
+                isCacheTtlUserProvided = true;
+            }
+
             // Both cacheEnabled and cacheTtl can not be null here, so if either one
             // is, the other is not, and we return the cacheOptions with just that other
             // value.
             if (cacheEnabled is null)
             {
-                return cacheOptions with { TtlSeconds = ttl };
+                return cacheOptions with { TtlSeconds = ttl, UserProvidedTtlOptions = isCacheTtlUserProvided };
             }
 
             if (cacheTtl is null)
@@ -868,7 +874,7 @@ namespace Cli
                 return cacheOptions with { Enabled = isEnabled };
             }
 
-            return cacheOptions with { Enabled = isEnabled, TtlSeconds = ttl };
+            return cacheOptions with { Enabled = isEnabled, TtlSeconds = ttl, UserProvidedTtlOptions = isCacheTtlUserProvided };
         }
 
         /// <summary>

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -856,6 +856,7 @@ namespace Cli
                 _logger.LogError("Invalid format for --cache.ttl. Accepted values are any non-negative integer.");
             }
 
+            // This is needed so the cacheTtl is correctly written to config.
             if (cacheTtl is not null)
             {
                 isCacheTtlUserProvided = true;


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/2716

## What is this change?

When we create the entity cache options, we start with a new object and then later set the values for the fields. Because of this, the `bool` `UserProvidedTtlOptions` must explicitly be set when we later set these values or it will forever remain `false`. When it is false it is not written back out into the configuration file.

## How was this tested?

Manually used the update command in the CLI to verify the field is written out.

## Sample Request(s)

- Example REST and/or GraphQL request to demonstrate modifications
- Example of CLI usage to demonstrate modifications
