### PR TITLE
Cherry-Pick Cache CLI Add and Update Commands Bug Fix for 1.5 Release

### DIFF
--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -843,6 +843,7 @@ namespace Cli
 
             EntityCacheOptions cacheOptions = new();
             bool isEnabled = false;
+            bool isCacheTtlUserProvided = false;
             int ttl = EntityCacheOptions.DEFAULT_TTL_SECONDS;
 
             if (cacheEnabled is not null && !bool.TryParse(cacheEnabled, out isEnabled))
@@ -855,12 +856,18 @@ namespace Cli
                 _logger.LogError("Invalid format for --cache.ttl. Accepted values are any non-negative integer.");
             }
 
+            // This is needed so the cacheTtl is correctly written to config.
+            if (cacheTtl is not null)
+            {
+                isCacheTtlUserProvided = true;
+            }
+
             // Both cacheEnabled and cacheTtl can not be null here, so if either one
             // is, the other is not, and we return the cacheOptions with just that other
             // value.
             if (cacheEnabled is null)
             {
-                return cacheOptions with { TtlSeconds = ttl };
+                return cacheOptions with { TtlSeconds = ttl, UserProvidedTtlOptions = isCacheTtlUserProvided };
             }
 
             if (cacheTtl is null)
@@ -868,7 +875,7 @@ namespace Cli
                 return cacheOptions with { Enabled = isEnabled };
             }
 
-            return cacheOptions with { Enabled = isEnabled, TtlSeconds = ttl };
+            return cacheOptions with { Enabled = isEnabled, TtlSeconds = ttl, UserProvidedTtlOptions = isCacheTtlUserProvided };
         }
 
         /// <summary>


### PR DESCRIPTION
## Why make this change?

When we create the entity cache options, we start with a new object and then later set the values for the fields. Because of this, the `bool` `UserProvidedTtlOptions` must explicitly be set when we later set these values or it will forever remain `false`. When it is false it is not written back out into the configuration file.

## What is this change?

Fixes bug found in release candidate for 1.5
Cherry-picked PR:
- #2717 

## How was this tested?

## Sample Request(s)