### PR TITLE
Prevent empty input node generation in mutation builder.

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -457,6 +457,11 @@
               "type": "integer",
               "description": "Time to live in seconds for the Comprehensive Health Check Report cache entry.",
               "default": 5
+            },
+            "max-query-parallelism": {
+              "type": "integer",
+              "description": "The max degree of parallelism for running parallel health check queries.",
+              "default": 4
             }
           }
         }

--- a/src/Config/HealthCheck/RuntimeHealthCheckConfig.cs
+++ b/src/Config/HealthCheck/RuntimeHealthCheckConfig.cs
@@ -7,22 +7,46 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 
 public record RuntimeHealthCheckConfig : HealthCheckConfig
 {
+    /// <summary>
+    /// Represents the lowest maximum query parallelism for health check.
+    /// </summary>
+    public const int LOWEST_MAX_QUERY_PARALLELISM = 1;
+
+    /// <summary>
+    /// Default maximum query parallelism for health check.
+    /// </summary>
+    public const int DEFAULT_MAX_QUERY_PARALLELISM = 4;
+
+    /// <summary>
+    /// Upper limit of maximum query parallelism for health check.
+    /// </summary>
+    public const int UPPER_LIMIT_MAX_QUERY_PARALLELISM = 8;
+
     [JsonPropertyName("cache-ttl-seconds")]
     public int CacheTtlSeconds { get; set; }
 
     public HashSet<string>? Roles { get; set; }
 
-    // TODO: Add support for parallel stream to run the health check query in upcoming PRs
-    // public int MaxDop { get; set; } = 1; // Parallelized streams to run Health Check (Default: 1)
-
     [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
     public bool UserProvidedTtlOptions { get; init; } = false;
+
+    /// <summary>
+    /// Flag to indicate if the user has provided a value for MaxQueryParallelism.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+    public bool UserProvidedMaxQueryParallelism { get; init; } = false;
+
+    /// <summary>
+    /// Gets or sets the maximum number of queries that can be executed in parallel.
+    /// </summary>
+    [JsonPropertyName("max-query-parallelism")]
+    public int? MaxQueryParallelism { get; set; }
 
     public RuntimeHealthCheckConfig() : base()
     {
     }
 
-    public RuntimeHealthCheckConfig(bool? enabled, HashSet<string>? roles = null, int? cacheTtlSeconds = null) : base(enabled)
+    public RuntimeHealthCheckConfig(bool? enabled, HashSet<string>? roles = null, int? cacheTtlSeconds = null, int? maxQueryParallelism = null) : base(enabled)
     {
         this.Roles = roles;
 
@@ -35,5 +59,17 @@ public record RuntimeHealthCheckConfig : HealthCheckConfig
         {
             this.CacheTtlSeconds = EntityCacheOptions.DEFAULT_TTL_SECONDS;
         }
+
+        // Allow user to set values between 1 and 8 (inclusive). If not set, the value will be set to 4 during health check.
+        if (maxQueryParallelism is not null)
+        {
+            this.MaxQueryParallelism = maxQueryParallelism;
+            UserProvidedMaxQueryParallelism = true;
+        }
+        else
+        {
+            this.MaxQueryParallelism = DEFAULT_MAX_QUERY_PARALLELISM;
+        }
+
     }
 }

--- a/src/Service.Tests/Configuration/HealthEndpointTests.cs
+++ b/src/Service.Tests/Configuration/HealthEndpointTests.cs
@@ -206,6 +206,46 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
             Assert.IsNotNull(errorMessageFromGraphQL);
         }
 
+        /// <summary>
+        /// Tests the serialization behavior of <see cref="RuntimeHealthCheckConfig"/> for the <see cref="RuntimeHealthCheckConfig.MaxQueryParallelism"/> property."
+        /// </summary>
+        /// <remarks>This test ensures that the JSON serialization behavior of <see
+        /// cref="RuntimeHealthCheckConfig"/>  adheres to the expected behavior where default values are omitted from
+        /// the output.</remarks>
+        [TestMethod]
+        public void MaxQueryParallelismSerializationDependsOnUserInput()
+        {
+            // Case 1: default value NOT explicitly provided => should NOT serialize
+            RuntimeHealthCheckConfig configWithDefault = new(
+                enabled: true,
+                roles: null,
+                cacheTtlSeconds: null,
+                maxQueryParallelism: null // implicit default
+            );
+
+            Assert.IsFalse(configWithDefault.UserProvidedMaxQueryParallelism, "UserProvidedMaxQueryParallelism should be false for default value.");
+
+            // Case 2: default value EXPLICITLY provided => should serialize
+            RuntimeHealthCheckConfig configWithExplicitDefault = new(
+                enabled: true,
+                roles: null,
+                cacheTtlSeconds: null,
+                maxQueryParallelism: RuntimeHealthCheckConfig.DEFAULT_MAX_QUERY_PARALLELISM
+            );
+
+            Assert.IsTrue(configWithExplicitDefault.UserProvidedMaxQueryParallelism, "UserProvidedMaxQueryParallelism should be true for explicit default value.");
+
+            // Case 3: non-default value => should serialize
+            RuntimeHealthCheckConfig configWithCustomValue = new(
+                enabled: true,
+                roles: null,
+                cacheTtlSeconds: null,
+                maxQueryParallelism: RuntimeHealthCheckConfig.DEFAULT_MAX_QUERY_PARALLELISM + 1
+            );
+
+            Assert.IsTrue(configWithCustomValue.UserProvidedMaxQueryParallelism, "UserProvidedMaxQueryParallelism should be true for custom value.");
+        }
+
         #region Helper Methods
         private static HttpUtilities SetupRestTest(RuntimeConfig runtimeConfig, HttpStatusCode httpStatusCode = HttpStatusCode.OK)
         {


### PR DESCRIPTION
## Why make this change?
Currently today when the tables has only autogenerated fileds, then the schema generation is failing with an error saying that "Empty input for create and update mutation input".
Error trace:
`For more details look at the `Errors` property.\r\n\r\n1. InputObject `CreateNewTableInput` has no fields declared. (HotChocolate.Types.InputObjectType)\r\n2. InputObject `UpdateNewTableInput` has no fields declared.`

https://github.com/Azure/data-api-builder/issues/2739

## What is this change?
This PR addresses the issue by conditionally generating create and update mutation input types only when the table contains at least one non-auto-generated field. This ensures that the schema remains valid and avoids generating empty input objects.

## How was this tested?
- Unit tests
- Manual testing

## screenshots

### For create:
![image](https://github.com/user-attachments/assets/fb6e841e-f27b-4b89-b827-bb3dbab1bade)

### for update:
![image](https://github.com/user-attachments/assets/4891b165-4a01-4497-8f21-d91c852c20d5)




