### PR TITLE
Allow unsupported cache-control options without error

### DIFF
--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -14,7 +14,7 @@ Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Out-File $chiliCreamLicenseSavePath
 
 # Define the path to the license file in your repository and Read the content of the license file
-$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.3.License.txt"
+$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.0.License.txt"
 $sqlClientSNILicense = Get-Content -Path $sqlClientSNILicenseFilePath -Raw
 
 # Path of notice file generated in CI/CD pipeline.

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -843,6 +843,7 @@ namespace Cli
 
             EntityCacheOptions cacheOptions = new();
             bool isEnabled = false;
+            bool isCacheTtlUserProvided = false;
             int ttl = EntityCacheOptions.DEFAULT_TTL_SECONDS;
 
             if (cacheEnabled is not null && !bool.TryParse(cacheEnabled, out isEnabled))
@@ -855,12 +856,17 @@ namespace Cli
                 _logger.LogError("Invalid format for --cache.ttl. Accepted values are any non-negative integer.");
             }
 
+            if (cacheTtl is not null)
+            {
+                isCacheTtlUserProvided = true;
+            }
+
             // Both cacheEnabled and cacheTtl can not be null here, so if either one
             // is, the other is not, and we return the cacheOptions with just that other
             // value.
             if (cacheEnabled is null)
             {
-                return cacheOptions with { TtlSeconds = ttl };
+                return cacheOptions with { TtlSeconds = ttl, UserProvidedTtlOptions = isCacheTtlUserProvided };
             }
 
             if (cacheTtl is null)
@@ -868,7 +874,7 @@ namespace Cli
                 return cacheOptions with { Enabled = isEnabled };
             }
 
-            return cacheOptions with { Enabled = isEnabled, TtlSeconds = ttl };
+            return cacheOptions with { Enabled = isEnabled, TtlSeconds = ttl, UserProvidedTtlOptions = isCacheTtlUserProvided };
         }
 
         /// <summary>

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -856,6 +856,7 @@ namespace Cli
                 _logger.LogError("Invalid format for --cache.ttl. Accepted values are any non-negative integer.");
             }
 
+            // This is needed so the cacheTtl is correctly written to config.
             if (cacheTtl is not null)
             {
                 isCacheTtlUserProvided = true;


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/2735

## What is this change?

Removes the check to make sure that only supported `cache-control` options are included in the request headers.

## How was this tested?

Manually ran GraphQL request with headers that failed in bug report. To reproduce use any valid graphQL query with cache enabled in the runtime section of the config, and the entity being queries having cache enabled.

![image](https://github.com/user-attachments/assets/942e6870-e5a9-4bcd-86a0-200a3ad7a0b9)

Then any graphQL query against that entity should enter the code path in question.



## Sample Request(s)

```
query {
  publishers (first: 5 orderBy: {name: DESC
  })
  {
    items {
      id
    }
  }
}
```
