### PR TITLE
Allow unsupported cache-control options without error

### DIFF
--- a/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -587,15 +587,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             {
                 CacheControlOption = cacheControlOption;
             }
-
-            if (!string.IsNullOrEmpty(CacheControlOption) &&
-                !cacheControlHeaderOptions.Contains(CacheControlOption))
-            {
-                throw new DataApiBuilderException(
-                    message: "Request Header Cache-Control is invalid: " + CacheControlOption,
-                    statusCode: HttpStatusCode.BadRequest,
-                    subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/2735

## What is this change?

Removes the check to make sure that only supported `cache-control` options are included in the request headers.

## How was this tested?

Manually ran GraphQL request with headers that failed in bug report. To reproduce use any valid graphQL query with cache enabled in the runtime section of the config, and for the entity being queried.

![image](https://github.com/user-attachments/assets/942e6870-e5a9-4bcd-86a0-200a3ad7a0b9)

Then any graphQL query against that entity with `cache-control` headers should enter the code path in question.



## Sample Request(s)

```
query {
  publishers (first: 5 orderBy: {name: DESC
  })
  {
    items {
      id
    }
  }
}
```
