### PR TITLE
Port cache-control bug fix into release 1.5

### DIFF
--- a/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -587,15 +587,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             {
                 CacheControlOption = cacheControlOption;
             }
-
-            if (!string.IsNullOrEmpty(CacheControlOption) &&
-                !cacheControlHeaderOptions.Contains(CacheControlOption))
-            {
-                throw new DataApiBuilderException(
-                    message: "Request Header Cache-Control is invalid: " + CacheControlOption,
-                    statusCode: HttpStatusCode.BadRequest,
-                    subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Why make this change?

We recently added a bug fix for https://github.com/Azure/data-api-builder/issues/2735 and we want to port this fix to the 1.5 release.

## What is this change?

Allows unsupported `cache-control` options to go through requests without error.

## How was this tested?

See: https://github.com/Azure/data-api-builder/pull/2737

## Sample Request(s)

See: https://github.com/Azure/data-api-builder/pull/2737
