### PR TITLE
CodeQL suppression for DefaultAzureCredential default and SwaggerUI usage

### DIFF
--- a/src/Core/Resolvers/CosmosClientProvider.cs
+++ b/src/Core/Resolvers/CosmosClientProvider.cs
@@ -79,7 +79,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     }
                     else if (!_accessToken.ContainsKey(dataSourceName))
                     {
-                        client = new CosmosClient(accountEndPoint, new DefaultAzureCredential(), options);
+                        client = new CosmosClient(accountEndPoint, new DefaultAzureCredential(), options); // CodeQL [SM05137] DefaultAzureCredential will use Managed Identity if available or fallback to default.
                     }
                     else
                     {

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -44,7 +44,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         public override IDictionary<string, DbConnectionStringBuilder> ConnectionStringBuilders
             => base.ConnectionStringBuilders;
 
-        public DefaultAzureCredential AzureCredential { get; set; } = new();
+        public DefaultAzureCredential AzureCredential { get; set; } = new();  // CodeQL [SM05137] DefaultAzureCredential will use Managed Identity if available or fallback to default.
 
         /// <summary>
         /// The saved cached access token obtained from DefaultAzureCredentials

--- a/src/Core/Resolvers/MySqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MySqlQueryExecutor.cs
@@ -32,7 +32,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         private Dictionary<string, string?> _accessTokensFromConfiguration;
 
-        public DefaultAzureCredential AzureCredential { get; set; } = new();
+        public DefaultAzureCredential AzureCredential { get; set; } = new(); // CodeQL [SM05137] DefaultAzureCredential will use Managed Identity if available or fallback to default.
 
         /// <summary>
         /// The MySql specific connection string builders.

--- a/src/Core/Resolvers/PostgreSqlExecutor.cs
+++ b/src/Core/Resolvers/PostgreSqlExecutor.cs
@@ -33,7 +33,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         /// </summary>
         private Dictionary<string, string?> _accessTokensFromConfiguration;
 
-        public DefaultAzureCredential AzureCredential { get; set; } = new();
+        public DefaultAzureCredential AzureCredential { get; set; } = new(); // CodeQL [SM05137] DefaultAzureCredential will use Managed Identity if available or fallback to default.
 
         /// <summary>
         /// The PostgreSql specific connection string builders.

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -576,7 +576,7 @@ namespace Azure.DataApiBuilder.Service
             // Consequently, SwaggerUI is not presented in a StaticWebApps (late-bound config) environment.
             if (IsUIEnabled(runtimeConfig, env))
             {
-                app.UseSwaggerUI(c =>
+                app.UseSwaggerUI(c => // CodeQL [SM04686] SwaggerUI is only enabled for Development environment.
                 {
                     c.ConfigObject.Urls = new SwaggerEndpointMapper(app.ApplicationServices.GetService<RuntimeConfigProvider?>());
                 });


### PR DESCRIPTION
## Why make this change?

- Closes #2746 
  - This PR addresses a CodeQL false positive regarding
    - the usage of `DefaultAzureCredential()`
    - the usage of SwaggerUI
  - Reference documentation:  
    - https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-semmle
    - [CodeQL suppression syntax](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#suppressing-or-resolving-alerts)
    - [DefaultAzureCredential documentation](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential)
    - https://liquid.microsoft.com/Web/Object/Read/Campaign.Requirements/Requirements/SSIRP.floss

## What is this change?

- Suppresses the CodeQL warnings:
  - Adds a suppression rule to the relevant file
  - No logic or runtime code is changed; this is a configuration only update to streamline code analysis.

## How was this tested?

- [x] Integration Tests
- [x] Unit Tests

The change will be validated by running the full test suite and triggering a CodeQL analysis to confirm the warning is suppressed and no new issues are introduced as part of a next build.

## Sample Request(s)

- NA