### PR TITLE
Remove caseInsensitive filter operator added back by incorrect merge

### DIFF
--- a/src/Service.GraphQLBuilder/Queries/StandardQueryInputs.cs
+++ b/src/Service.GraphQLBuilder/Queries/StandardQueryInputs.cs
@@ -45,8 +45,6 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Queries
         private static readonly StringValueNode _startsWithDescription = new("Starts With");
         private static readonly NameNode _endsWith = new("endsWith");
         private static readonly StringValueNode _endsWithDescription = new("Ends With");
-        private static readonly NameNode _caseInsensitive = new("caseInsensitive");
-        private static readonly StringValueNode _caseInsensitiveDescription = new("Case Insensitive");
         private static readonly NameNode _in = new("in");
         private static readonly StringValueNode _inDescription = new("In");
 
@@ -154,7 +152,6 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Queries
                     new(null, _startsWith, _startsWithDescription, type, null, []),
                     new(null, _endsWith, _endsWithDescription, type, null, []),
                     new(null, _neq, _neqDescription, type, null, []),
-                    new(null, _caseInsensitive, _caseInsensitiveDescription, type, null, []),
                     new(null, _isNull, _isNullDescription, _boolean, null, []),
                     new(null, _in, _inDescription, new ListTypeNode(type), null, [])
                 ]


### PR DESCRIPTION
## Why make this change?

caseInsensitive filter operator is not implemented in the resolvers leading to runtime error when used. Including it in schema seems to be an oversight. Removing it for schema generated until we have an approach defined for case insensitive comparisons with different source types

Relevant issue #2280

This was already addressed in PR https://github.com/Azure/data-api-builder/pull/2607
but was readded unintentionally by https://github.com/Azure/data-api-builder/pull/2348/files#diff-f74a036f2a72f2b3f2642c66613b149c5dca7a9696859a26d4ce95863c124d9f

## What is this change?

Remove caseInsensitive filter operator from schema generated

## How was this tested?

- [x] Integration Tests
- [x] Unit Tests


