### PR TITLE
Change use of DefaultAzureCredential to ManagedIdentityCredential for Azure Log Analytics 

### DIFF
--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -185,7 +185,7 @@ namespace Azure.DataApiBuilder.Service
                 services.AddSingleton(sp =>
                 {
                     AzureLogAnalyticsOptions options = runtimeConfig.Runtime.Telemetry.AzureLogAnalytics;
-                    DefaultAzureCredential credential = new();
+                    ManagedIdentityCredential credential = new();
                     LogsIngestionClient logsIngestionClient = new(new Uri(options.Auth!.DceEndpoint!), credential);
                     return new AzureLogAnalyticsFlusherService(options, CustomLogCollector, logsIngestionClient, _logger);
                 });


### PR DESCRIPTION
## Why make this change?
- It resolves issue #2810 
`ManagedIdentityCredential` class only authenticates with Azure Managed Identity which makes it a better fit to use in AzureLogAnalytics than `DefaultAzureCredential`.

## What is this change?
We stop using the `DefaultAzureCredential` class and instead start using the `ManagedIdentityCredential` class. 
Important Note: As of this moment with this change, the Azure Log Analytics feature can only authenticate against system-assigned identities.

## How was this tested?
- [ ] Integration Tests
- [ ] Unit Tests
- [X] Manual Tests
This change cannot be directly tested in the pipeline so it was tested by using a VM and ensuring the logs are correctly sent to Azure Log Analytics table.
- See #2787 for more information on how this was set up.

## Sample Request(s)
<img width="1028" height="448" alt="image" src="https://github.com/user-attachments/assets/67221e39-4114-4fc2-ba72-1df3ed120b16" />
