### PR TITLE
Dev/rubencerna/fix azure log analytics flushinterval bug

### DIFF
--- a/src/Service.Tests/Configuration/Telemetry/AzureLogAnalyticsTests.cs
+++ b/src/Service.Tests/Configuration/Telemetry/AzureLogAnalyticsTests.cs
@@ -120,7 +120,7 @@ public class AzureLogAnalyticsTests
 
         _ = Task.Run(() => flusherService.StartAsync(tokenSource.Token));
 
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         // Assert
         AzureLogAnalyticsLogs actualLog = customClient.LogAnalyticsLogs[0];

--- a/src/Service/Telemetry/AzureLogAnalyticsCustomLogCollector.cs
+++ b/src/Service/Telemetry/AzureLogAnalyticsCustomLogCollector.cs
@@ -53,19 +53,23 @@ public class AzureLogAnalyticsCustomLogCollector : ICustomLogCollector
     public async Task<List<AzureLogAnalyticsLogs>> DequeueAllAsync(string dabIdentifier, int flushIntervalSeconds)
     {
         List<AzureLogAnalyticsLogs> list = new();
-        Stopwatch time = Stopwatch.StartNew();
 
-        while (await _logs.Reader.WaitToReadAsync())
+        if (await _logs.Reader.WaitToReadAsync())
         {
-            if (_logs.Reader.TryRead(out AzureLogAnalyticsLogs? item))
-            {
-                item.Identifier = dabIdentifier;
-                list.Add(item);
-            }
+            Stopwatch time = Stopwatch.StartNew();
 
-            if (time.Elapsed >= TimeSpan.FromSeconds(flushIntervalSeconds))
+            while (true)
             {
-                break;
+                if (_logs.Reader.TryRead(out AzureLogAnalyticsLogs? item))
+                {
+                    item.Identifier = dabIdentifier;
+                    list.Add(item);
+                }
+
+                if (time.Elapsed >= TimeSpan.FromSeconds(flushIntervalSeconds))
+                {
+                    break;
+                }
             }
         }
 

--- a/src/Service/Telemetry/AzureLogAnalyticsCustomLogCollector.cs
+++ b/src/Service/Telemetry/AzureLogAnalyticsCustomLogCollector.cs
@@ -55,17 +55,17 @@ public class AzureLogAnalyticsCustomLogCollector : ICustomLogCollector
         List<AzureLogAnalyticsLogs> list = new();
         Stopwatch time = Stopwatch.StartNew();
 
-        if (await _logs.Reader.WaitToReadAsync())
+        while (await _logs.Reader.WaitToReadAsync())
         {
-            while (_logs.Reader.TryRead(out AzureLogAnalyticsLogs? item))
+            if (_logs.Reader.TryRead(out AzureLogAnalyticsLogs? item))
             {
                 item.Identifier = dabIdentifier;
                 list.Add(item);
+            }
 
-                if (time.Elapsed >= TimeSpan.FromSeconds(flushIntervalSeconds))
-                {
-                    break;
-                }
+            if (time.Elapsed >= TimeSpan.FromSeconds(flushIntervalSeconds))
+            {
+                break;
             }
         }
 


### PR DESCRIPTION
## Why make this change?

- This change fixes #2853 
  - The Azure Log Analytics feature is uploading the logs before the time interval ends.

## What is this change?

- It fixes the logic that pushes the logs to the Azure Log Analytics workspace by ensuring it doesn't stop if there aren't any logs coming into the `CustomLogCollector`.

## How was this tested?

- [ ] Integration Tests
- [X] Unit Tests

## Sample Request(s)

