### PR TITLE
[DAB-MCP] Added description property to entities and GraphQL Schema.

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -640,6 +640,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "description": {
+              "type": "string",
+              "description": "Optional description for the entity. Will be surfaced in generated API documentation and GraphQL schema as comments."
+            },
             "health": {
               "description": "Health check configuration for entity",
               "type": [ "object", "null" ],

--- a/src/Config/ObjectModel/Entity.cs
+++ b/src/Config/ObjectModel/Entity.cs
@@ -23,10 +23,12 @@ namespace Azure.DataApiBuilder.Config.ObjectModel;
 /// how long that response should be valid in the cache.</param>
 /// <param name="Health">Defines whether to enable comprehensive health check for the entity
 /// and how many rows to return in query and under what threshold-ms.</param>
+/// <param name="Description">Optional description for the entity. Used for API documentation and GraphQL schema comments.</param>
 public record Entity
 {
     public const string PROPERTY_PATH = "path";
     public const string PROPERTY_METHODS = "methods";
+    public string? Description { get; init; }
     public EntitySource Source { get; init; }
     public EntityGraphQLOptions GraphQL { get; init; }
     public EntityRestOptions Rest { get; init; }
@@ -50,7 +52,8 @@ public record Entity
         Dictionary<string, EntityRelationship>? Relationships,
         EntityCacheOptions? Cache = null,
         bool IsLinkingEntity = false,
-        EntityHealthCheckConfig? Health = null)
+        EntityHealthCheckConfig? Health = null,
+        string? Description = null)
     {
         this.Health = Health;
         this.Source = Source;
@@ -61,6 +64,7 @@ public record Entity
         this.Relationships = Relationships;
         this.Cache = Cache;
         this.IsLinkingEntity = IsLinkingEntity;
+        this.Description = Description;
     }
 
     /// <summary>

--- a/src/Core/Generator/SchemaGenerator.cs
+++ b/src/Core/Generator/SchemaGenerator.cs
@@ -28,10 +28,15 @@ namespace Azure.DataApiBuilder.Core.Generator
 
         // List of JSON documents to process.
         private List<JsonDocument> _data;
+
         // Name of the Azure Cosmos DB container from which the JSON data is obtained.
         private string _containerName;
+
         // Dictionary mapping plural entity names to singular names based on the provided configuration.
         private Dictionary<string, string> _entityAndSingularNameMapping = new();
+
+        // Entities from config for description lookup
+        private IReadOnlyDictionary<string, Entity>? _entities;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SchemaGenerator"/> class.
@@ -57,6 +62,9 @@ namespace Azure.DataApiBuilder.Core.Generator
                 {
                     _entityAndSingularNameMapping.Add(item.Value.GraphQL.Singular.Pascalize(), item.Key);
                 }
+
+                // Convert RuntimeEntities to Dictionary for description lookup
+                _entities = config.Entities.ToDictionary(x => x.Key, x => x.Value);
             }
         }
 
@@ -128,6 +136,22 @@ namespace Azure.DataApiBuilder.Core.Generator
             {
                 // Determine if the entity is the root entity.
                 bool isRoot = entity.Key == _containerName.Pascalize();
+
+                // Get description from config if available
+                string? description = null;
+                if (_entityAndSingularNameMapping.ContainsKey(entity.Key) && _entities != null)
+                {
+                    string configEntityName = _entityAndSingularNameMapping[entity.Key];
+                    if (_entities.ContainsKey(configEntityName))
+                    {
+                        description = _entities[configEntityName].Description;
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(description))
+                {
+                    sb.AppendLine($"\"\"\"{description}\"\"\"");
+                }
 
                 sb.Append($"type {entity.Key} ");
 

--- a/src/Service.GraphQLBuilder/Sql/SchemaConverter.cs
+++ b/src/Service.GraphQLBuilder/Sql/SchemaConverter.cs
@@ -78,6 +78,18 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
                         subStatusCode: DataApiBuilderException.SubStatusCodes.NotSupported);
             }
 
+            StringValueNode? descriptionNode = null;
+            if (!string.IsNullOrEmpty(configEntity.Description))
+            {
+                descriptionNode = new StringValueNode(configEntity.Description);
+            }
+            
+            // Set the description node if available
+            if (descriptionNode != null)
+            {
+                objectDefinitionNode = objectDefinitionNode.WithDescription(descriptionNode);
+            }
+
             return objectDefinitionNode;
         }
 
@@ -122,6 +134,12 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
                 }
             }
 
+            StringValueNode? descriptionNode = null;
+            if (!string.IsNullOrEmpty(configEntity.Description))
+            {
+                descriptionNode = new StringValueNode(configEntity.Description);
+            }
+
             // Top-level object type definition name should be singular.
             // The singularPlural.Singular value is used, and if not configured,
             // the top-level entity name value is used. No singularization occurs
@@ -129,7 +147,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
             return new ObjectTypeDefinitionNode(
                 location: null,
                 name: new(value: GetDefinedSingularName(entityName, configEntity)),
-                description: null,
+                description: descriptionNode,
                 directives: GenerateObjectTypeDirectivesForEntity(entityName, configEntity, rolesAllowedForEntity),
                 new List<NamedTypeNode>(),
                 fields.Values.ToImmutableList());
@@ -213,6 +231,12 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
                 }
             }
 
+            StringValueNode? descriptionNode = null;
+            if (!string.IsNullOrEmpty(configEntity.Description))
+            {
+                descriptionNode = new StringValueNode(configEntity.Description);
+            }
+            
             // Top-level object type definition name should be singular.
             // The singularPlural.Singular value is used, and if not configured,
             // the top-level entity name value is used. No singularization occurs
@@ -220,7 +244,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
             return new ObjectTypeDefinitionNode(
                 location: null,
                 name: new(value: GetDefinedSingularName(entityName, configEntity)),
-                description: null,
+                description: descriptionNode,
                 directives: GenerateObjectTypeDirectivesForEntity(entityName, configEntity, rolesAllowedForEntity),
                 new List<NamedTypeNode>(),
                 fieldDefinitionNodes.Values.ToImmutableList());

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
@@ -779,6 +779,43 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
             await base.TestNoAggregationOptionsForTableWithoutNumericFields();
         }
 
+        [TestMethod]
+        public void TestEntityDescriptionInGraphQLSchema()
+        {
+            // Create a config with an entity description
+            EntitySource source = new("TestTable", EntitySourceType.Table, null, null);
+            EntityGraphQLOptions gqlOptions = new("TestEntity", "TestEntities", true);
+            EntityRestOptions restOptions = new(null, "/test", true);
+            Entity entity = new(
+                source,
+                gqlOptions,
+                restOptions,
+                [],
+                null,
+                null,
+                null,
+                false,
+                null,
+                Description: "This is a test entity description for MSSQL."
+            );
+
+            Dictionary<string, Entity> entityDict = new() { { "TestEntity", entity } };
+            RuntimeEntities entities = new(entityDict);
+            RuntimeConfig config = new(
+                "",
+                new DataSource(DatabaseType.MSSQL, "", null),
+                entities,
+                null
+            );
+            List<JsonDocument> jsonArray = [
+                JsonDocument.Parse("{ \"id\": 1, \"name\": \"Test\" }")
+            ];
+
+            string actualSchema = Core.Generator.SchemaGenerator.Generate(jsonArray, "TestEntity", config);
+            string expectedComment = "\"\"\"This is a test entity description for MSSQL.\"\"\"";
+            Assert.IsTrue(actualSchema.Contains(expectedComment, StringComparison.Ordinal), "Entity description should be present as a GraphQL comment for MSSQL.");
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## Why make this change?
  - Adds support for entity-level descriptions in Data API Builder GraphQL schema.
  - This feature request aims to surface entity descriptions from the config file in the generated GraphQL schema, improving API documentation and discoverability.
  - See related discussion: [https://github.com/Azure/data-api-builder/issues/2834]

## What is this change?
- Adds a `description` property to the entity model and ensures it is deserialized from the config.
- Updates the GraphQL schema generator and converter to include entity descriptions as comments in the SDL and as HotChocolate type descriptions.
- Adds unit tests to verify that entity descriptions appear in the generated schema.

## How was this tested?

- [x] Unit Tests: Added tests to check for presence of entity description in generated GraphQL schema.
- [x] Manual verification: Ran GraphQL introspection queries and checked schema SDL output.

## Sample Request(s)

**GraphQL Introspection Query:**
```graphql
{
  __type(name: "Todo") {
    name
    description
  }
}
```
**Sample Query Response:**
```
{
  "data": {
    "__type": {
      "name": "Todo",
      "description": "Represents a todo item in the system"
    }
  }
}
```

**Sample SDL output:**
```
"""Represents a todo item in the system"""
type Todo {
  ...
}
```