### PR TITLE
Ensure JsonDocuments cleaned up after request

### DIFF
--- a/config-generators/mssql-commands.txt
+++ b/config-generators/mssql-commands.txt
@@ -236,3 +236,4 @@ add dbo_DimAccount --config "dab-config.MsSql.json" --source "DimAccount" --perm
 update dbo_DimAccount --config "dab-config.MsSql.json" --relationship parent_account --target.entity dbo_DimAccount --cardinality one --relationship.fields "ParentAccountKey:AccountKey"
 update dbo_DimAccount --config "dab-config.MsSql.json" --relationship child_accounts --target.entity dbo_DimAccount --cardinality many --relationship.fields "AccountKey:ParentAccountKey"
 add DateOnlyTable --config "dab-config.MsSql.json" --source "date_only_table" --permissions "anonymous:*" --rest true --graphql true --source.key-fields "event_date"
+add GetBooksAuth --config "dab-config.MsSql.json" --source "get_books" --source.type "stored-procedure" --permissions "teststoredprocauth:execute" --rest true --graphql true --graphql.operation "Query" --rest.methods "Get"

--- a/src/Core/Services/ExecutionHelper.cs
+++ b/src/Core/Services/ExecutionHelper.cs
@@ -314,6 +314,7 @@ namespace Azure.DataApiBuilder.Service.Services
                     result.Dispose();
                     return ValueTask.CompletedTask;
                 });
+
                 // The disposal could occur before we were finished using the value from the jsondocument,
                 // thus needing to ensure copying the root element. Hence, we clone the root element.
                 context.Result = result.RootElement.Clone();

--- a/src/Core/Services/ExecutionHelper.cs
+++ b/src/Core/Services/ExecutionHelper.cs
@@ -78,7 +78,8 @@ namespace Azure.DataApiBuilder.Service.Services
                         }
 
                         return ValueTask.CompletedTask;
-                    });
+                    },
+                    cleanAfter: CleanAfter.Request);
 
                 context.Result = result.Item1.Select(t => t.RootElement).ToArray();
                 SetNewMetadata(context, result.Item2);
@@ -125,7 +126,8 @@ namespace Azure.DataApiBuilder.Service.Services
                         }
 
                         return ValueTask.CompletedTask;
-                    });
+                    },
+                    cleanAfter: CleanAfter.Request);
 
                 context.Result = result.Item1.Select(t => t.RootElement).ToArray();
                 SetNewMetadata(context, result.Item2);

--- a/src/Service.Tests/Authorization/GraphQL/GraphQLAuthorizationHandlerTests.cs
+++ b/src/Service.Tests/Authorization/GraphQL/GraphQLAuthorizationHandlerTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
+using HotChocolate.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Azure.DataApiBuilder.Service.Tests.Authorization.GraphQL
@@ -137,6 +138,64 @@ namespace Azure.DataApiBuilder.Service.Tests.Authorization.GraphQL
                 actual.ToString(),
                 message: "Access forbidden to field 'publisher_id' referenced in the aggregation function 'min'.",
                 path: @"[""booksNF""]"
+            );
+        }
+
+        /// <summary>
+        /// Tests that a GraphQL query backed by stored procedure with a client role is allowed access and returns results.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task Query_StoredProc_Allowed()
+        {
+            string graphQLQueryName = "executeGetBooksAuth";
+            string graphQLQuery = @"{
+                executeGetBooksAuth {
+                    id
+                    title
+                    publisher_id
+                }
+            }";
+
+            JsonElement actual = await ExecuteGraphQLRequestAsync(
+                graphQLQuery,
+                graphQLQueryName,
+                isAuthenticated: true,
+                clientRoleHeader: "teststoredprocauth");
+
+            string dbQuery = $"EXEC dbo.get_books";
+            string expected = await GetDatabaseResultAsync(dbQuery, expectJson: false);
+
+            SqlTestHelper.PerformTestEqualJsonStrings(expected, actual.ToString());
+        }
+
+        /// <summary>
+        /// Tests that a GraphQL query backed by stored procedure with a client role is not allowed access and results in an
+        /// appropriate error message.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task Query_StoredProc_NotAllowed()
+        {
+            string graphQLQueryName = "executeGetBooksAuth";
+            string graphQLQuery = @"{
+                executeGetBooksAuth {
+                    id
+                    title
+                    publisher_id
+                }
+            }";
+
+            JsonElement actual = await ExecuteGraphQLRequestAsync(
+                graphQLQuery,
+                graphQLQueryName,
+                isAuthenticated: true,
+                clientRoleHeader: "roledoesnotexist");
+
+            SqlTestHelper.TestForErrorInGraphQLResponse(
+                actual.ToString(),
+                message: "The current user is not authorized to access this resource.",
+                path: @"[""executeGetBooksAuth""]"
             );
         }
     }

--- a/src/Service.Tests/Authorization/GraphQL/GraphQLAuthorizationHandlerTests.cs
+++ b/src/Service.Tests/Authorization/GraphQL/GraphQLAuthorizationHandlerTests.cs
@@ -4,7 +4,6 @@
 using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
-using HotChocolate.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Azure.DataApiBuilder.Service.Tests.Authorization.GraphQL

--- a/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
+++ b/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
@@ -3651,6 +3651,36 @@
           }
         ]
       }
+    },
+    {
+      GetBooksAuth: {
+        Source: {
+          Object: get_books,
+          Type: stored-procedure
+        },
+        GraphQL: {
+          Singular: GetBooksAuth,
+          Plural: GetBooksAuths,
+          Enabled: true,
+          Operation: Query
+        },
+        Rest: {
+          Methods: [
+            Get
+          ],
+          Enabled: true
+        },
+        Permissions: [
+          {
+            Role: teststoredprocauth,
+            Actions: [
+              {
+                Action: Execute
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/Service.Tests/dab-config.MsSql.json
+++ b/src/Service.Tests/dab-config.MsSql.json
@@ -3580,6 +3580,19 @@
               "action": "read"
             }
           ]
+        },
+        {
+          "role": "TestFieldExcludedForAggregation",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [
+                  "publisher_id"
+                ]
+              }
+            }
+          ]
         }
       ],
       "mappings": {
@@ -3794,6 +3807,36 @@
           "actions": [
             {
               "action": "*"
+            }
+          ]
+        }
+      ]
+    },
+    "GetBooksAuth": {
+      "source": {
+        "object": "get_books",
+        "type": "stored-procedure"
+      },
+      "graphql": {
+        "enabled": true,
+        "operation": "query",
+        "type": {
+          "singular": "GetBooksAuth",
+          "plural": "GetBooksAuths"
+        }
+      },
+      "rest": {
+        "enabled": true,
+        "methods": [
+          "get"
+        ]
+      },
+      "permissions": [
+        {
+          "role": "teststoredprocauth",
+          "actions": [
+            {
+              "action": "execute"
             }
           ]
         }


### PR DESCRIPTION
## Why make this change?
Closes #2858

When stored procedures are applied with authorization policies in DAB configuration, then at runtime we observe that queries or mutations via stored procedures fail unexpectedly with object disposed exception. This PR fixes the bug.

In the query and mutation root resolvers, the intermediate results in the form of JsonDocuments are registered for cleanup. These were getting cleaned even before the leaf resolvers executed so DAB would encounter exception accessing already disposed objects.

If registerForCleanup is invoked without additional parameter specifying when to cleanup, then by default, the cleanup happens immediately after the current resolver execution. This was causing the objects to be disposed early for stored procedure flow before the leaf resolvers were executed.

## What is this change?

Invoke registerForCleanup with the additional param specifying the cleanup to happen after request is complete. 

## How was this tested?

- [x] Integration Tests
- [ ] Unit Tests

