### PR TITLE
[MCP] Fixes and Refactoring execute_entity

### DIFF
--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ExecuteEntityTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ExecuteEntityTool.cs
@@ -232,7 +232,7 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                 catch (DataApiBuilderException dabEx)
                 {
                     // Handle specific DAB exceptions
-                    logger?.LogError(dabEx, "Data API Builder error executing stored procedure {StoredProcedure}", entity);
+                    logger?.LogError(dabEx, "Data API builder error executing stored procedure {StoredProcedure}", entity);
 
                     string message = dabEx.Message;
 


### PR DESCRIPTION
## Why make this change?

### Closes on
- `execute_entity` https://github.com/Azure/data-api-builder/issues/2831

## What is this change?
This PR implements built-int tool execute_entity as part of built-in tools to support execution of stored procedures or functions.

- Performs execute operation on a stored procedure or function entity
- Supports both querying and mutation
- `entity` (required) name and `parameters` (optional based on entity parameters signature) should be specified (see sample below)
- Operation is performed based on permissions as configured in dab-config
- Success or Failure message response is generated on execution of the delete operation

## How was this tested?

- [x] Manual functional test using MCP inpector/HTTP client
- [ ] Integration Tests
- [ ] Unit Tests

## Sample Request(s)

Execute stored procedure to read queries-

```
POST http://localhost:5000/mcp

{
  "jsonrpc": "2.0",
  "method": "tools/call",
  "params": {
    "name": "execute_entity",
    "arguments": {
      "entity": "GetBook",
      "parameters": {
        "id": 1
      }
    }
  }
}
```

Execute stored procedure without parameters-

```
POST http://localhost:5000/mcp

{
  "jsonrpc": "2.0",
  "method": "tools/call",
  "params": {
    "name": "execute_entity",
    "arguments": {
      "entity": "GetBooks"
    }
  }
}
```
