### PR TITLE
[MCP] Add the Create_Record Built in tool

### DIFF
--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/CreateRecordTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/CreateRecordTool.cs
@@ -173,8 +173,8 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                         new Dictionary<string, object?>
                         {
                             ["entity"] = entityName,
-                            ["operation"] = "create",
-                            ["result"] = createdResult.Value
+                            ["result"] = createdResult.Value,
+                            ["message"] = $"Successfully created record in entity '{entityName}'"
                         },
                         logger,
                         $"Successfully created record in entity '{entityName}'");
@@ -195,12 +195,11 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                             new Dictionary<string, object?>
                             {
                                 ["entity"] = entityName,
-                                ["operation"] = "create",
                                 ["result"] = objectResult.Value,
-                                ["note"] = "Unable to perform read-back of inserted records"
+                                ["message"] = $"Successfully created record in entity '{entityName}'. Unable to perform read-back of inserted records."
                             },
                             logger,
-                            $"Successfully created record in entity '{entityName}' (read-back unavailable)");
+                            $"Successfully created record in entity '{entityName}'. Unable to perform read-back of inserted records.");
                     }
                 }
                 else
@@ -218,9 +217,7 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                             new Dictionary<string, object?>
                             {
                                 ["entity"] = entityName,
-                                ["operation"] = "create",
-                                ["result_type"] = result.GetType().Name,
-                                ["note"] = "Create operation completed with unexpected result type"
+                                ["message"] = $"Create operation completed with unexpected result type: {result.GetType().Name}"
                             },
                             logger,
                             $"Create operation completed for entity '{entityName}' with unexpected result type: {result.GetType().Name}");


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/2828

By adding the `Create_Record` tool to the MCP endpoint.

## What is this change?
Add a built in tool, `Create_Record` which uses the `rest` infrastructure to form and validate the query needed to complete a create action. Behavior is at parity with the rest equivalent create operation.


## How was this tested?

Manually tested Insomnia using post.
<img width="904" height="382" alt="image" src="https://github.com/user-attachments/assets/691de33e-f948-445d-84b7-390136813d31" />

<img width="231" height="93" alt="image" src="https://github.com/user-attachments/assets/af97c5c0-f175-4786-9b6b-aaca8ebf3925" />

<img width="233" height="110" alt="image" src="https://github.com/user-attachments/assets/57e2f72f-ae0e-48f8-bf23-f0f258086dad" />


## Sample Request(s)

```
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "tools/call",
  "params": {
    "name": "create_record",
    "arguments": {
      "entity": "Broker",
      "data": {
        "ID Number": 3,
				"First Name": "Michael",
				"Last Name": "Jordan"
      }
    }
  }
}
 
```