### PR TITLE
[MCP] Prevent duplicating entities between custom tools and describe_entities

### DIFF
--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/DescribeEntitiesTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/DescribeEntitiesTool.cs
@@ -159,6 +159,12 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                         string entityName = entityEntry.Key;
                         Entity entity = entityEntry.Value;
 
+                        // Check entity filter first to avoid counting entities that wouldn't be included anyway
+                        if (!ShouldIncludeEntity(entityName, entityFilter))
+                        {
+                            continue;
+                        }
+
                         // Filter out entities when dml-tools is explicitly disabled (false).
                         // This applies to all entity types (tables, views, stored procedures).
                         // When dml-tools is false, the entity is not exposed via DML tools
@@ -166,11 +172,6 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                         if (entity.Mcp?.DmlToolEnabled == false)
                         {
                             filteredDmlDisabledCount++;
-                            continue;
-                        }
-
-                        if (!ShouldIncludeEntity(entityName, entityFilter))
-                        {
                             continue;
                         }
 
@@ -210,7 +211,7 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                         return Task.FromResult(McpResponseBuilder.BuildErrorResult(
                             toolName,
                             "AllEntitiesFilteredDmlDisabled",
-                            $"All {filteredDmlDisabledCount} configured entities have DML tools disabled (dml-tools: false). Entities with dml-tools disabled do not appear in describe_entities. For stored procedures, check tools/list if custom-tool is enabled.",
+                            $"All {filteredDmlDisabledCount} configured entities have DML tools disabled (dml-tools: false). Entities with dml-tools disabled do not appear in describe_entities. If the filtered entities are stored procedures with custom-tool enabled, check tools/list.",
                             logger));
                     }
                     // Truly no entities configured in the runtime config, or entities failed to build for other reasons

--- a/src/Service.Tests/Mcp/DescribeEntitiesFilteringTests.cs
+++ b/src/Service.Tests/Mcp/DescribeEntitiesFilteringTests.cs
@@ -35,7 +35,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
         /// This ensures users understand why describe_entities is empty.
         /// </summary>
         [TestMethod]
-        public async Task DescribeEntities_ExcludesCustomToolStoredProcedures()
+        public async Task DescribeEntities_AllEntitiesFilteredWhenDmlToolsDisabled()
         {
             // Arrange
             RuntimeConfig config = CreateConfigWithCustomToolSP();
@@ -108,7 +108,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
             Assert.IsTrue(content.TryGetProperty("count", out JsonElement countElement));
 
             int entityCount = entities.GetArrayLength();
-            Assert.AreEqual(2, entityCount, "Config has 3 entities but only 2 should be returned (custom-tool SP excluded)");
+            Assert.AreEqual(2, entityCount, "Config has 3 entities but only 2 should be returned (entity with dml-tools:false excluded)");
             Assert.AreEqual(entityCount, countElement.GetInt32(), "Count field should match filtered entity array length");
         }
 


### PR DESCRIPTION
## Why make this change?

- Closes on - #3043

Entities with `dml-tools: false` should not appear in `describe_entities` because they are not accessible via DML operations (read_records, create_record, update_record, delete_record). Showing them in the DML discovery endpoint creates a confusing experience where entities appear available but cannot actually be used.

## What is this change?

- Added filtering logic to exclude stored procedure entities when `dml-tools` is explicitly set to false
- The filtering ensures stored procedures are removed from `describe_entities` only when they are not available for DML operations
- Entities with `dml-tools: true` (or null/default) continue to appear in `describe_entities`
- Stored procedures with `dml-tools: true` (or null/default) continue to appear in `describe_entities` even if they have `custom-tool: true`, allowing dual exposure when needed

## How was this tested?

- [x] Unit Tests

## Sample Request(s)

```
{
  "jsonrpc": "2.0",
  "method": "tools/call",
  "params": {
    "name": "describe_entities"
  },
  "id": 1
}
```
