### PR TITLE
Remove docker install task to fix pipeline failure

### DIFF
--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -62,12 +62,6 @@ jobs:
       feedsToUse: config
       nugetConfigPath: Nuget.config
 
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: Bash@3
     displayName: 'Generate password'
     inputs:

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -63,12 +63,6 @@ jobs:
       feedsToUse: config
       nugetConfigPath: Nuget.config
 
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: Bash@3
     displayName: 'Generate password'
     inputs:

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -61,12 +61,6 @@ jobs:
       feedsToUse: config
       nugetConfigPath: Nuget.config
 
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: Bash@3
     displayName: 'Generate password'
     inputs:

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -56,12 +56,6 @@ jobs:
       feedsToUse: config
       nugetConfigPath: Nuget.config
 
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: Bash@3
     displayName: 'Generate password'
     inputs:


### PR DESCRIPTION
## Why make this change?

DAB test pipelines are failing with following error-

`docker: Error response from daemon: client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.`

Since pipeline agents already come with docker, this is actually downgrading docker. Skipping this allows the latest available docker client to run.

## What is this change?

- pipelines.yml files updated by removing the docker installation task

## How was this tested?

- Pipeline runs

## Sample Request(s)

NA
