### PR TITLE
Cherry pick - Docker task pipeline fix

### DIFF
--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -50,12 +50,6 @@ jobs:
       feedsToUse: config
       nugetConfigPath: Nuget.config
 
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: Bash@3
     displayName: 'Generate password'
     inputs:

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -51,12 +51,6 @@ jobs:
       feedsToUse: config
       nugetConfigPath: Nuget.config
 
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: Bash@3
     displayName: 'Generate password'
     inputs:

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -49,12 +49,6 @@ jobs:
       feedsToUse: config
       nugetConfigPath: Nuget.config
 
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: Bash@3
     displayName: 'Generate password'
     inputs:

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -44,12 +44,6 @@ jobs:
       feedsToUse: config
       nugetConfigPath: Nuget.config
 
-  - task: DockerInstaller@0
-    displayName: Docker Installer
-    inputs:
-      dockerVersion: 17.09.0-ce
-      releaseType: stable
-
   - task: Bash@3
     displayName: 'Generate password'
     inputs:


### PR DESCRIPTION
## Why make this change?

This is a cherry pick for original PR https://github.com/Azure/data-api-builder/pull/3130

------------------------------------------------------------
DAB test pipelines are failing with following error-

`docker: Error response from daemon: client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.`

Since pipeline agents already come with docker, this is actually downgrading docker. Skipping this allows the latest available docker client to run.

## What is this change?

- pipelines.yml files updated by removing the docker installation task

## How was this tested?

- Pipeline runs

## Sample Request(s)

NA
