### PR TITLE
Use DotNetCoreCLI@2 for Nuget Restore to avoid 120 second timeout, and add RuntimeIdentifiers="" to avoid needing packages not in our feed

### DIFF
--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -69,6 +69,7 @@ steps:
     projects: '$(solution)'
     feedsToUse: config
     nugetConfigPath: Nuget.config
+    restoreArguments: '/p:RuntimeIdentifiers=""'
 
 - task: DotNetCoreCLI@2
   displayName: Build

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -61,6 +61,7 @@ jobs:
       projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
+      restoreArguments: '/p:RuntimeIdentifiers=""'
 
   - task: Bash@3
     displayName: 'Generate password'
@@ -189,6 +190,7 @@ jobs:
       projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
+      restoreArguments: '/p:RuntimeIdentifiers=""'
 
   - task: PowerShell@2
     displayName: Install SQL LocalDB # Update when clarity on how to setup 

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -62,6 +62,7 @@ jobs:
       projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
+      restoreArguments: '/p:RuntimeIdentifiers=""'
 
   - task: Bash@3
     displayName: 'Generate password'
@@ -193,6 +194,7 @@ jobs:
       projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
+      restoreArguments: '/p:RuntimeIdentifiers=""'
 
   - task: PowerShell@2
     displayName: Install SQL LocalDB

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -60,6 +60,7 @@ jobs:
       projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
+      restoreArguments: '/p:RuntimeIdentifiers=""'
 
   - task: Bash@3
     displayName: 'Generate password'

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -55,6 +55,7 @@ jobs:
       projects: '$(solution)'
       feedsToUse: config
       nugetConfigPath: Nuget.config
+      restoreArguments: '/p:RuntimeIdentifiers=""'
 
   - task: Bash@3
     displayName: 'Generate password'


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/3210

Closes https://github.com/Azure/data-api-builder/issues/3212

## What is this change?

We replace the `NuGetCommand@2` task with `DotNetCoreCLI@2 ` to avoid the hard coded 120 second timeout in the former which is causing pipeline failures.

We add `restoreArguments: '/p:RuntimeIdentifiers=""'` to the pipelines for build and test. Since these pipelines only build and test (no publish), runtime packs aren't needed. The argument overrides `RuntimeIdentifiers` to empty during restore, skipping those downloads.


## How was this tested?

Pipeline ran.