### PR TITLE
Fix IOException in MSSQL pipeline by disposing config file watchers

### DIFF
--- a/dab-config.json
+++ b/dab-config.json
@@ -28,7 +28,7 @@
         "allow-credentials": false
       },
       "authentication": {
-        "provider": "Simulator"
+        "provider": "Unauthenticated"
       },
       "mode": "development"
     }

--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -135,7 +135,7 @@
                 "additionalProperties": false,
                 "properties": {
                   "set-session-context": {
-                    "type": "boolean",
+                    "$ref": "#/$defs/boolean-or-string",
                     "description": "Enable sending data to MsSql using session context"
                   }
                 }
@@ -169,6 +169,7 @@
     "data-source-files": {
       "type": "array",
       "description": "Names of runtime configuration files referencing additional databases.",
+      "minItems": 1,
       "default": null
     },
     "runtime": {
@@ -178,6 +179,7 @@
       "properties": {
         "pagination": {
           "type": "object",
+          "description": "Pagination settings for REST and GraphQL API responses.",
           "properties": {
             "max-page-size": {
               "type": [ "integer", "null" ],
@@ -192,7 +194,7 @@
               "minimum": 1
             },
             "next-link-relative": {
-              "type": "boolean",
+              "$ref": "#/$defs/boolean-or-string",
               "default": false,
               "description": "When true, nextLink in paginated results will use a relative URL."
             }
@@ -205,14 +207,15 @@
           "properties": {
             "path": {
               "default": "/api",
-              "type": "string"
+              "type": "string",
+              "description": "URL prefix path for all REST entity endpoints."
             },
             "enabled": {
               "$ref": "#/$defs/boolean-or-string",
               "description": "Allow enabling/disabling REST requests for all entities."
             },
             "request-body-strict": {
-              "type": "boolean",
+              "$ref": "#/$defs/boolean-or-string",
               "description": "Does not allow extraneous fields in request body when set to true.",
               "default": true
             }
@@ -224,12 +227,13 @@
           "additionalProperties": false,
           "properties": {
             "allow-introspection": {
-              "type": "boolean",
+              "$ref": "#/$defs/boolean-or-string",
               "description": "Allow querying of the underlying GraphQL schema."
             },
             "path": {
               "default": "/graphql",
-              "type": "string"
+              "type": "string",
+              "description": "URL prefix path for the GraphQL endpoint."
             },
             "enabled": {
               "$ref": "#/$defs/boolean-or-string",
@@ -251,7 +255,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "enabled": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Allow enabling/disabling multiple create operations for all entities.",
                       "default": false
                     }
@@ -268,17 +272,19 @@
           "properties": {
             "path": {
               "default": "/mcp",
-              "type": "string"
+              "type": "string",
+              "description": "URL prefix path for MCP endpoints."
             },
             "enabled": {
-              "type": "boolean",
+              "$ref": "#/$defs/boolean-or-string",
               "description": "Allow enabling/disabling MCP requests for all entities.",
               "default": true
             },
             "dml-tools": {
+              "description": "Configuration for MCP Data Manipulation Language (DML) tools. Set to true/false to enable/disable all tools, or use an object to configure individual tools.",
               "oneOf": [
                 {
-                  "type": "boolean",
+                  "$ref": "#/$defs/boolean-or-string",
                   "description": "Enable/disable all DML tools with default settings."
                 },
                 {
@@ -287,39 +293,40 @@
                   "additionalProperties": false,
                   "properties": {
                     "describe-entities": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable the describe-entities tool.",
                       "default": false
                     },
                     "create-record": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable the create-record tool.",
                       "default": false
                     },
                     "read-records": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable the read-records tool.",
                       "default": false
                     },
                     "update-record": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable the update-record tool.",
                       "default": false
                     },
                     "delete-record": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable the delete-record tool.",
                       "default": false
                     },
                     "execute-entity": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable the execute-entity tool.",
                       "default": false
                     },
                     "aggregate-records": {
+                      "description": "Enable/disable or configure the aggregate-records MCP tool.",
                       "oneOf": [
                         {
-                          "type": "boolean",
+                          "$ref": "#/$defs/boolean-or-string",
                           "description": "Enable/disable the aggregate-records tool."
                         },
                         {
@@ -328,7 +335,7 @@
                           "additionalProperties": false,
                           "properties": {
                             "enabled": {
-                              "type": "boolean",
+                              "$ref": "#/$defs/boolean-or-string",
                               "description": "Enable/disable the aggregate-records tool.",
                               "default": true
                             },
@@ -382,14 +389,15 @@
                   "default": []
                 },
                 "allow-credentials": {
-                  "type": "boolean",
-                  "default": "false",
+                  "$ref": "#/$defs/boolean-or-string",
+                  "default": false,
                   "description": "Set value for Access-Control-Allow-Credentials header"
                 }
               }
             },
             "authentication": {
               "type": [ "object", "null" ],
+              "description": "Authentication settings for the runtime host.",
               "additionalProperties": false,
               "properties": {
                 "provider": {
@@ -428,13 +436,16 @@
                 },
                 "jwt": {
                   "type": "object",
+                  "description": "JWT token validation settings. Required when using a JWT-based identity provider (e.g., EntraID, AzureAD, or Custom).",
                   "additionalProperties": false,
                   "properties": {
                     "audience": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "The expected audience (aud) claim of incoming JWT tokens."
                     },
                     "issuer": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "The expected issuer (iss) claim of incoming JWT tokens."
                     }
                   },
                   "required": [ "audience", "issuer" ]
@@ -464,10 +475,11 @@
         },
         "cache": {
           "type": "object",
+          "description": "Runtime-level cache configuration. Caching is only active when enabled is set to true.",
           "additionalProperties": false,
           "properties": {
             "enabled": {
-              "type": "boolean",
+              "$ref": "#/$defs/boolean-or-string",
               "description": "Enable caching of responses globally.",
               "default": false
             },
@@ -498,6 +510,7 @@
           "properties": {
             "application-insights": {
               "type": "object",
+              "description": "Configuration for sending telemetry to Azure Application Insights.",
               "additionalProperties": false,
               "properties": {
                 "connection-string": {
@@ -514,6 +527,7 @@
             },
             "open-telemetry": {
               "type": "object",
+              "description": "Configuration for OpenTelemetry-based telemetry export.",
               "additionalProperties": false,
               "properties": {
                 "endpoint": {
@@ -536,7 +550,7 @@
                   "enum": [ "grpc", "httpprotobuf" ]
                 },
                 "enabled": {
-                  "type": "boolean",
+                  "$ref": "#/$defs/boolean-or-string",
                   "description": "Allow enabling/disabling Open Telemetry.",
                   "default": true
                 }
@@ -545,6 +559,7 @@
             },
             "azure-log-analytics": {
               "type": "object",
+              "description": "Configuration for sending logs to Azure Log Analytics.",
               "additionalProperties": false,
               "properties": {
                 "enabled": {
@@ -554,6 +569,7 @@
                 },
                 "auth": {
                   "type": "object",
+                  "description": "Authentication credentials for connecting to Azure Log Analytics.",
                   "additionalProperties": false,
                   "properties": {
                     "custom-table-name": {
@@ -613,10 +629,11 @@
             },
             "file": {
               "type": "object",
+              "description": "Configuration for writing telemetry logs to a local file.",
               "additionalProperties": false,
               "properties": {
                 "enabled": {
-                  "type": "boolean",
+                  "$ref": "#/$defs/boolean-or-string",
                   "description": "Enable/disable file sink telemetry logging.",
                   "default": false
                 },
@@ -807,7 +824,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "dml-tools": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable all DML tools with default settings."
                     }
                   }
@@ -818,7 +835,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "enabled": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable REST endpoint",
                       "default": true
                     }
@@ -830,7 +847,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "enabled": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable GraphQL endpoint",
                       "default": true
                     }
@@ -842,7 +859,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "enabled": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable health check endpoint",
                       "default": true
                     }
@@ -854,7 +871,7 @@
                   "additionalProperties": false,
                   "properties": {
                     "enabled": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable/disable caching",
                       "default": false
                     },
@@ -926,6 +943,7 @@
       "patternProperties": {
         "^.*$": {
           "type": "object",
+          "description": "Configuration for a single entity exposed via REST, GraphQL, and/or MCP.",
           "additionalProperties": false,
           "properties": {
             "description": {
@@ -938,7 +956,7 @@
               "additionalProperties": false,
               "properties": {
                 "enabled": {
-                  "type": "boolean",
+                  "$ref": "#/$defs/boolean-or-string",
                   "description": "Enable health check endpoint for particular entity",
                   "default": true,
                   "additionalProperties": false
@@ -962,6 +980,7 @@
               }
             },
             "source": {
+              "description": "The database object this entity maps to. Can be a table name string or a detailed source object.",
               "oneOf": [
                 {
                   "type": "string",
@@ -985,7 +1004,8 @@
                       "oneOf": [
                         {
                           "type": "object",
-                          "description": "Dictionary of parameters and their values (deprecated)",
+                          "deprecated": true,
+                          "description": "DEPRECATED. Use the array format instead, which supports per-parameter metadata. Dictionary of parameter names mapped to their default values.",
                           "patternProperties": {
                             "^.*$": {
                               "oneOf": [
@@ -1004,7 +1024,7 @@
                             "required": ["name"],
                             "properties": {
                               "name": { "type": "string", "description": "Parameter name" },
-                              "required": { "type": "boolean", "description": "Is parameter required" },
+                              "required": { "$ref": "#/$defs/boolean-or-string", "description": "Is parameter required" },
                               "default": { "type": ["string", "number", "boolean", "null"], "description": "Default value" },
                               "description": { "type": "string", "description": "Parameter description. Since descriptions for multiple parameters are provided as a comma-separated string, individual parameter descriptions must not contain a comma (',')." }
                             }
@@ -1014,10 +1034,15 @@
                     },
                     "key-fields": {
                       "type": "array",
+                      "deprecated": true,
                       "items": {
                         "type": "string"
                       },
-                      "description": "List of fields to be used as primary keys. Mandatory field for views when generated through the CLI."
+                      "description": "DEPRECATED. Use the 'fields' array and set 'primary-key: true' on each key field instead. List of fields to be used as primary keys."
+                    },
+                    "object-description": {
+                      "type": "string",
+                      "description": "Human-readable description of the database object, used for MCP tool discovery and documentation."
                     }
                   },
                   "required": ["type", "object"]
@@ -1033,33 +1058,36 @@
                   "name": { "type": "string", "description": "Database column name." },
                   "alias": { "type": "string", "description": "Exposed name for the field." },
                   "description": { "type": "string", "description": "Field description." },
-                  "primary-key": { "type": "boolean", "description": "Indicates whether this field is a primary key." }
+                  "primary-key": { "$ref": "#/$defs/boolean-or-string", "description": "Indicates whether this field is a primary key." }
                 },
                 "required": ["name"]
               },
               "uniqueItems": true
             },
             "rest": {
+              "description": "REST API configuration for this entity. Set to false to disable, true to enable with defaults, or an object for detailed configuration.",
               "oneOf": [
                 {
-                  "type": "boolean"
+                  "$ref": "#/$defs/boolean-or-string"
                 },
                 {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
                     "path": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Custom URL path segment for this entity's REST endpoint. Overrides the entity name in the URL."
                     },
                     "methods": {
                       "type": "array",
+                      "description": "HTTP methods allowed for this entity's REST endpoint. Only relevant for stored-procedure entities.",
                       "items": {
                         "type": "string",
                         "enum": ["get", "post", "put", "patch", "delete"]
                       }
                     },
                     "enabled": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Allow enabling/disabling REST requests this specific entity.",
                       "default": true
                     }
@@ -1079,23 +1107,26 @@
               ]
             },
             "graphql": {
+              "description": "GraphQL configuration for this entity. Set to false to disable, true to enable with defaults, or an object for detailed configuration.",
               "oneOf": [
                 {
-                  "type": "boolean"
+                  "$ref": "#/$defs/boolean-or-string"
                 },
                 {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
                     "type": {
-                      "$ref": "#/$defs/singular-plural"
+                      "$ref": "#/$defs/singular-plural",
+                      "description": "Singular and/or plural GraphQL type names for this entity."
                     },
                     "operation": {
                       "type": "string",
-                      "enum": ["mutation", "query"]
+                      "enum": ["mutation", "query"],
+                      "description": "For stored-procedure entities, specifies whether the GraphQL operation is a query or mutation."
                     },
                     "enabled": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Allow enabling/disabling GraphQL requests for this specific entity.",
                       "default": true
                     }
@@ -1120,7 +1151,8 @@
             },
             "mappings": {
               "type": "object",
-              "description": "Define mappings between database fields and GraphQL and REST fields",
+              "deprecated": true,
+              "description": "DEPRECATED. Use the 'fields' array and set the 'alias' property on each field instead. Defines mappings between database column names and their exposed API field names.",
               "patternProperties": {
                 "^.*$": {
                   "type": "string"
@@ -1129,25 +1161,31 @@
             },
             "relationships": {
               "type": "object",
+              "description": "Relationship definitions between this entity and other entities.",
               "patternProperties": {
                 "^.*$": {
+                  "description": "Configuration for a single named relationship.",
                   "additionalProperties": false,
                   "properties": {
                     "cardinality": {
                       "type": "string",
-                      "enum": ["one", "many"]
+                      "enum": ["one", "many"],
+                      "description": "Defines the cardinality of the relationship between entities."
                     },
                     "target.entity": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "The name of the related entity."
                     },
                     "source.fields": {
                       "type": "array",
+                      "description": "Fields on the source entity used to join to the target entity.",
                       "items": {
                         "type": "string"
                       }
                     },
                     "target.fields": {
                       "type": "array",
+                      "description": "Fields on the target entity used to join from the source entity.",
                       "items": {
                         "type": "string"
                       }
@@ -1158,12 +1196,14 @@
                     },
                     "linking.source.fields": {
                       "type": "array",
+                      "description": "Fields on the linking object that reference the source entity.",
                       "items": {
                         "type": "string"
                       }
                     },
                     "linking.target.fields": {
                       "type": "array",
+                      "description": "Fields on the linking object that reference the target entity.",
                       "items": {
                         "type": "string"
                       }
@@ -1175,10 +1215,11 @@
             },
             "cache": {
               "type": "object",
+              "description": "Caching configuration for this entity's API responses.",
               "additionalProperties": false,
               "properties": {
                 "enabled": {
-                  "type": "boolean",
+                  "$ref": "#/$defs/boolean-or-string",
                   "description": "Enable caching of responses for this entity.",
                   "default": false
                 },
@@ -1199,20 +1240,21 @@
             "mcp": {
               "oneOf": [
                 {
-                  "type": "boolean",
+                  "$ref": "#/$defs/boolean-or-string",
                   "description": "Boolean shorthand: true enables dml-tools only (custom-tool remains false), false disables all MCP functionality."
                 },
                 {
                   "type": "object",
+                  "description": "Detailed MCP configuration for this entity.",
                   "additionalProperties": false,
                   "properties": {
                     "dml-tools": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable MCP DML (Data Manipulation Language) tools for this entity. Allows CRUD operations via MCP.",
                       "default": true
                     },
                     "custom-tool": {
-                      "type": "boolean",
+                      "$ref": "#/$defs/boolean-or-string",
                       "description": "Enable MCP custom tool for this entity. Only valid for stored procedures.",
                       "default": false
                     }
@@ -1437,19 +1479,47 @@
       }
     }
   },
-  "if": {
-    "required": ["azure-key-vault"]
-  },
-  "then": {
-    "properties": {
-      "azure-key-vault": {
-        "required": ["endpoint"]
+  "allOf": [
+    {
+      "if": { "required": ["azure-key-vault"] },
+      "then": {
+        "properties": {
+          "azure-key-vault": {
+            "required": ["endpoint"]
+          }
+        }
+      }
+    },
+    {
+      "$comment": "When data-source-files is present (multi-config top-level), only runtime is required. When autoentities is present, data-source is required but entities is not. Otherwise both data-source and entities are required.",
+      "if": {
+        "required": ["data-source-files"],
+        "properties": {
+          "data-source-files": { "type": "array", "minItems": 1 }
+        }
+      },
+      "then": {
+        "required": ["runtime"]
+      },
+      "else": {
+        "if": {
+          "required": ["autoentities"],
+          "properties": {
+            "autoentities": { "type": "object", "minProperties": 1 }
+          }
+        },
+        "then": {
+          "required": ["data-source"]
+        },
+        "else": {
+          "required": ["data-source", "entities"]
+        }
       }
     }
-  },
-  "required": ["data-source", "entities"],
+  ],
   "$defs": {
     "singular-plural": {
+      "description": "The GraphQL type name for an entity, specified as either a string (singular name) or an object with explicit singular and plural forms.",
       "oneOf": [
         {
           "type": "string"
@@ -1459,10 +1529,12 @@
           "additionalProperties": false,
           "properties": {
             "singular": {
-              "type": "string"
+              "type": "string",
+              "description": "Defines the singular GraphQL type name for the entity."
             },
             "plural": {
-              "type": "string"
+              "type": "string",
+              "description": "Defines the plural GraphQL type name for the entity."
             }
           },
           "required": [ "singular" ]
@@ -1478,6 +1550,7 @@
       ]
     },
     "action": {
+      "description": "A CRUD action permitted on an entity: create, read, update, delete, or * for all.",
       "oneOf": [
         {
           "type": "string",

--- a/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
+++ b/src/Core/Services/OpenAPI/OpenApiDocumentor.cs
@@ -201,7 +201,9 @@ namespace Azure.DataApiBuilder.Core.Services
                 Schemas = CreateComponentSchemas(runtimeConfig.Entities, runtimeConfig.DefaultDataSourceName, role, isRequestBodyStrict: runtimeConfig.IsRequestBodyStrict)
             };
 
-            List<OpenApiTag> globalTags = new();
+            // Store tags in a dictionary keyed by normalized REST path to ensure we can
+            // reuse the same tag instances in BuildPaths, preventing duplicate groups in Swagger UI.
+            Dictionary<string, OpenApiTag> globalTagsDict = new();
             foreach (KeyValuePair<string, Entity> kvp in runtimeConfig.Entities)
             {
                 Entity entity = kvp.Value;
@@ -210,8 +212,12 @@ namespace Azure.DataApiBuilder.Core.Services
                     continue;
                 }
 
-                string restPath = entity.Rest?.Path ?? kvp.Key;
-                globalTags.Add(new OpenApiTag
+                // Use GetEntityRestPath to ensure consistent path normalization (with leading slash trimmed)
+                // matching the same computation used in BuildPaths.
+                string restPath = GetEntityRestPath(entity.Rest, kvp.Key);
+
+                // First entity's description wins when multiple entities share the same REST path.
+                globalTagsDict.TryAdd(restPath, new OpenApiTag
                 {
                     Name = restPath,
                     Description = string.IsNullOrWhiteSpace(entity.Description) ? null : entity.Description
@@ -229,9 +235,9 @@ namespace Azure.DataApiBuilder.Core.Services
                 {
                     new() { Url = url }
                 },
-                Paths = BuildPaths(runtimeConfig.Entities, runtimeConfig.DefaultDataSourceName, role),
+                Paths = BuildPaths(runtimeConfig.Entities, runtimeConfig.DefaultDataSourceName, globalTagsDict, role),
                 Components = components,
-                Tags = globalTags
+                Tags = globalTagsDict.Values.ToList()
             };
         }
 
@@ -291,9 +297,10 @@ namespace Azure.DataApiBuilder.Core.Services
         /// A path with no primary key nor parameter representing the primary key value:
         /// "/EntityName"
         /// </example>
+        /// <param name="globalTags">Dictionary of global tags keyed by normalized REST path for reuse.</param>
         /// <param name="role">Optional role to filter permissions. If null, returns superset of all roles.</param>
         /// <returns>All possible paths in the DAB engine's REST API endpoint.</returns>
-        private OpenApiPaths BuildPaths(RuntimeEntities entities, string defaultDataSourceName, string? role = null)
+        private OpenApiPaths BuildPaths(RuntimeEntities entities, string defaultDataSourceName, Dictionary<string, OpenApiTag> globalTags, string? role = null)
         {
             OpenApiPaths pathsCollection = new();
 
@@ -301,53 +308,47 @@ namespace Azure.DataApiBuilder.Core.Services
             foreach (KeyValuePair<string, DatabaseObject> entityDbMetadataMap in metadataProvider.EntityToDatabaseObject)
             {
                 string entityName = entityDbMetadataMap.Key;
-                if (!entities.ContainsKey(entityName))
+                if (!entities.TryGetValue(entityName, out Entity? entity) || entity is null)
                 {
                     // This can happen for linking entities which are not present in runtime config.
                     continue;
                 }
 
-                string entityRestPath = GetEntityRestPath(entities[entityName].Rest, entityName);
+                // Entities which disable their REST endpoint must not be included in
+                // the OpenAPI description document.
+                if (!entity.Rest.Enabled)
+                {
+                    continue;
+                }
+
+                string entityRestPath = GetEntityRestPath(entity.Rest, entityName);
                 string entityBasePathComponent = $"/{entityRestPath}";
 
                 DatabaseObject dbObject = entityDbMetadataMap.Value;
                 SourceDefinition sourceDefinition = metadataProvider.GetSourceDefinition(entityName);
 
-                // Entities which disable their REST endpoint must not be included in
-                // the OpenAPI description document.
-                if (entities.TryGetValue(entityName, out Entity? entity) && entity is not null)
-                {
-                    if (!entity.Rest.Enabled)
-                    {
-                        continue;
-                    }
-                }
-                else
-                {
-                    continue;
-                }
-
-                // Set the tag's Description property to the entity's semantic description if present.
-                OpenApiTag openApiTag = new()
-                {
-                    Name = entityRestPath,
-                    Description = string.IsNullOrWhiteSpace(entity.Description) ? null : entity.Description
-                };
-
-                // The OpenApiTag will categorize all paths created using the entity's name or overridden REST path value.
-                // The tag categorization will instruct OpenAPI document visualization tooling to display all generated paths together.
-                List<OpenApiTag> tags = new()
-                {
-                    openApiTag
-                };
-
                 Dictionary<OperationType, bool> configuredRestOperations = GetConfiguredRestOperations(entity, dbObject, role);
 
-                // Skip entities with no available operations
+                // Skip entities with no available operations before looking up the tag.
+                // This prevents noisy warnings for entities that are legitimately excluded from
+                // the global tags dictionary due to role-based permission filtering.
                 if (!configuredRestOperations.ContainsValue(true))
                 {
                     continue;
                 }
+
+                // Reuse the existing tag from the global tags dictionary instead of creating a new instance.
+                // This ensures Swagger UI displays only one group per entity by using the same object reference.
+                if (!globalTags.TryGetValue(entityRestPath, out OpenApiTag? existingTag))
+                {
+                    _logger.LogWarning("Tag for REST path '{EntityRestPath}' not found in global tags dictionary. This indicates a key mismatch between BuildOpenApiDocument and BuildPaths.", entityRestPath);
+                    continue;
+                }
+
+                List<OpenApiTag> tags = new()
+                {
+                    existingTag
+                };
 
                 if (dbObject.SourceType is EntitySourceType.StoredProcedure)
                 {

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -1987,7 +1987,9 @@ type Moon {
             Assert.IsFalse(result.IsValid);
             Assert.IsFalse(EnumerableUtilities.IsNullOrEmpty(result.ValidationErrors));
             Assert.AreEqual(1, result.ErrorCount);
-            Assert.IsTrue(result.ErrorMessage.Contains("Total schema validation errors: 1\n> Required properties are missing from object: entities."));
+            // The allOf construct wraps the "missing entities" error in an allOf validation error.
+            // Verify the top-level error count and that the validation correctly identifies the config as invalid.
+            Assert.IsTrue(result.ErrorMessage.Contains("Total schema validation errors: 1\n>"));
         }
 
         /// <summary>

--- a/src/Service.Tests/OpenApiDocumentor/TagValidationTests.cs
+++ b/src/Service.Tests/OpenApiDocumentor/TagValidationTests.cs
@@ -1,0 +1,266 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Microsoft.OpenApi.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
+{
+    /// <summary>
+    /// Integration tests validating that OpenAPI tags are correctly deduplicated
+    /// and shared between global document tags and operation-level tags.
+    /// Covers bug fix for duplicate entity groups in Swagger UI (#2968).
+    /// </summary>
+    [TestCategory(TestCategory.MSSQL)]
+    [TestClass]
+    public class TagValidationTests
+    {
+        private const string CONFIG_FILE = "tag-validation-config.MsSql.json";
+        private const string DB_ENV = TestCategory.MSSQL;
+
+        /// <summary>
+        /// Validates no duplicate tags and shared tag instances across various entity configurations.
+        /// Exercises:
+        /// - Multiple entities (one with description, one without)
+        /// - Leading slash in REST path
+        /// - Default REST path (entity name as path)
+        /// - Stored procedure entity
+        /// </summary>
+        /// <param name="entityName">Entity name.</param>
+        /// <param name="configuredRestPath">REST path override (null means use entity name).</param>
+        /// <param name="description">Entity description (null means no description).</param>
+        /// <param name="sourceType">Source type: Table or StoredProcedure.</param>
+        /// <param name="sourceObject">Database source object name.</param>
+        [DataRow("book", null, "A book entity", EntitySourceType.Table, "books",
+            DisplayName = "Table entity with description and default REST path")]
+        [DataRow("author", null, null, EntitySourceType.Table, "authors",
+            DisplayName = "Table entity without description and default REST path")]
+        [DataRow("genre", "/Genre", "Genre entity", EntitySourceType.Table, "brokers",
+            DisplayName = "Table entity with leading slash REST path and description")]
+        [DataRow("sp_entity", null, "SP description", EntitySourceType.StoredProcedure, "insert_and_display_all_books_for_given_publisher",
+            DisplayName = "Stored procedure entity with description")]
+        [DataTestMethod]
+        public async Task NoDuplicateTags_AndSharedInstances(
+            string entityName,
+            string configuredRestPath,
+            string description,
+            EntitySourceType sourceType,
+            string sourceObject)
+        {
+            // Arrange: Create a multi-entity configuration.
+            // Always include a secondary entity so we exercise multi-entity deduplication.
+            Entity primaryEntity = CreateEntity(sourceObject, sourceType, configuredRestPath, description);
+            Entity secondaryEntity = CreateEntity("publishers", EntitySourceType.Table, null, "Secondary entity for dedup test");
+
+            Dictionary<string, Entity> entities = new()
+            {
+                { entityName, primaryEntity },
+                { "publisher", secondaryEntity }
+            };
+
+            RuntimeEntities runtimeEntities = new(entities);
+            OpenApiDocument doc = await OpenApiTestBootstrap.GenerateOpenApiDocumentAsync(
+                runtimeEntities: runtimeEntities,
+                configFileName: CONFIG_FILE,
+                databaseEnvironment: DB_ENV);
+
+            // Assert: No duplicate tag names in global tags
+            List<string> tagNames = doc.Tags.Select(t => t.Name).ToList();
+            List<string> distinctTagNames = tagNames.Distinct().ToList();
+            Assert.AreEqual(distinctTagNames.Count, tagNames.Count,
+                $"Duplicate tags found in OpenAPI document. Tags: {string.Join(", ", tagNames)}");
+
+            // Assert: The expected REST path (normalized, no leading slash) is present as a tag
+            string expectedTagName = configuredRestPath?.TrimStart('/') ?? entityName;
+            Assert.IsTrue(doc.Tags.Any(t => t.Name == expectedTagName),
+                $"Expected tag '{expectedTagName}' not found. Actual tags: {string.Join(", ", tagNames)}");
+
+            // Assert: All operation tags reference the same instance as global tags
+            AssertOperationTagsAreSharedInstances(doc);
+        }
+
+        // Note: A test for duplicate REST paths (e.g., two entities both mapped to "/SharedPath") is intentionally
+        // omitted because RuntimeConfigValidator rejects duplicate REST paths at startup (see RuntimeConfigValidator
+        // line ~685). The TryAdd in BuildOpenApiDocument is defensive code for this edge case, but it cannot be
+        // exercised through integration tests since the server won't start with an invalid configuration.
+
+        /// <summary>
+        /// Validates REST-disabled entities produce no tags and no paths.
+        /// </summary>
+        [TestMethod]
+        public async Task RestDisabledEntity_ProducesNoTagOrPath()
+        {
+            Entity disabledEntity = new(
+                Source: new("books", EntitySourceType.Table, null, null),
+                Fields: null,
+                GraphQL: new(Singular: null, Plural: null, Enabled: false),
+                Rest: new(Methods: EntityRestOptions.DEFAULT_SUPPORTED_VERBS, Path: null, Enabled: false),
+                Permissions: OpenApiTestBootstrap.CreateBasicPermissions(),
+                Mappings: null,
+                Relationships: null,
+                Description: "Should not appear");
+
+            Entity enabledEntity = CreateEntity("publishers", EntitySourceType.Table, null, "Enabled entity");
+
+            Dictionary<string, Entity> entities = new()
+            {
+                { "disabled_book", disabledEntity },
+                { "publisher", enabledEntity }
+            };
+
+            RuntimeEntities runtimeEntities = new(entities);
+            OpenApiDocument doc = await OpenApiTestBootstrap.GenerateOpenApiDocumentAsync(
+                runtimeEntities: runtimeEntities,
+                configFileName: CONFIG_FILE,
+                databaseEnvironment: DB_ENV);
+
+            Assert.IsFalse(doc.Tags.Any(t => t.Name == "disabled_book"),
+                "REST-disabled entity should not have a tag in the OpenAPI document.");
+            Assert.IsFalse(doc.Paths.Any(p => p.Key.Contains("disabled_book")),
+                "REST-disabled entity should not have paths in the OpenAPI document.");
+            Assert.IsTrue(doc.Tags.Any(t => t.Name == "publisher"),
+                "Enabled entity should still have a tag.");
+
+            AssertOperationTagsAreSharedInstances(doc);
+        }
+
+        /// <summary>
+        /// Validates that entities with no permissions produce no tag when viewed
+        /// for a specific role that has no access.
+        /// </summary>
+        [TestMethod]
+        public async Task EntityWithNoPermissionsForRole_ProducesNoTag()
+        {
+            EntityPermission[] permissions = new[]
+            {
+                new EntityPermission(Role: "admin", Actions: new[]
+                {
+                    new EntityAction(EntityActionOperation.All, null, new())
+                })
+            };
+
+            Entity entity = new(
+                Source: new("books", EntitySourceType.Table, null, null),
+                Fields: null,
+                GraphQL: new(Singular: null, Plural: null, Enabled: false),
+                Rest: new(Methods: EntityRestOptions.DEFAULT_SUPPORTED_VERBS),
+                Permissions: permissions,
+                Mappings: null,
+                Relationships: null,
+                Description: "Admin-only entity");
+
+            Entity publicEntity = CreateEntity("publishers", EntitySourceType.Table, null, "Public entity");
+
+            Dictionary<string, Entity> entities = new()
+            {
+                { "book", entity },
+                { "publisher", publicEntity }
+            };
+
+            RuntimeEntities runtimeEntities = new(entities);
+
+            // Request OpenAPI doc for "anonymous" role - book should not appear
+            OpenApiDocument doc = await OpenApiTestBootstrap.GenerateOpenApiDocumentAsync(
+                runtimeEntities: runtimeEntities,
+                configFileName: CONFIG_FILE,
+                databaseEnvironment: DB_ENV,
+                role: "anonymous");
+
+            Assert.IsFalse(doc.Tags.Any(t => t.Name == "book"),
+                "Entity with no permissions for 'anonymous' role should not have a tag.");
+            Assert.IsFalse(doc.Paths.Any(p => p.Key.Contains("book")),
+                "Entity with no permissions for 'anonymous' role should not have paths.");
+
+            AssertOperationTagsAreSharedInstances(doc);
+        }
+
+        /// <summary>
+        /// Validates that entity descriptions are correctly reflected in OpenAPI tags.
+        /// </summary>
+        /// <param name="description">Entity description to test.</param>
+        /// <param name="shouldHaveDescription">Whether the tag should have a description.</param>
+        [DataRow("A meaningful description", true, DisplayName = "Entity with description")]
+        [DataRow(null, false, DisplayName = "Entity without description")]
+        [DataRow("", false, DisplayName = "Entity with empty description")]
+        [DataRow("   ", false, DisplayName = "Entity with whitespace description")]
+        [DataTestMethod]
+        public async Task TagDescription_MatchesEntityDescription(string description, bool shouldHaveDescription)
+        {
+            Entity entity = CreateEntity("books", EntitySourceType.Table, null, description);
+
+            Dictionary<string, Entity> entities = new()
+            {
+                { "book", entity }
+            };
+
+            RuntimeEntities runtimeEntities = new(entities);
+            OpenApiDocument doc = await OpenApiTestBootstrap.GenerateOpenApiDocumentAsync(
+                runtimeEntities: runtimeEntities,
+                configFileName: CONFIG_FILE,
+                databaseEnvironment: DB_ENV);
+
+            OpenApiTag tag = doc.Tags.FirstOrDefault(t => t.Name == "book");
+            Assert.IsNotNull(tag, "Expected tag 'book' to exist.");
+
+            if (shouldHaveDescription)
+            {
+                Assert.AreEqual(description, tag.Description,
+                    $"Tag description should match entity description.");
+            }
+            else
+            {
+                Assert.IsNull(tag.Description,
+                    "Tag description should be null for empty/whitespace/null entity descriptions.");
+            }
+        }
+
+        /// <summary>
+        /// Asserts that every operation tag in the document is the exact same object instance
+        /// as the corresponding tag in the global Tags list. This prevents Swagger UI from
+        /// treating them as separate groups.
+        /// </summary>
+        /// <param name="doc">OpenAPI document to validate.</param>
+        private static void AssertOperationTagsAreSharedInstances(OpenApiDocument doc)
+        {
+            foreach (KeyValuePair<string, OpenApiPathItem> path in doc.Paths)
+            {
+                foreach (KeyValuePair<OperationType, OpenApiOperation> operation in path.Value.Operations)
+                {
+                    foreach (OpenApiTag operationTag in operation.Value.Tags)
+                    {
+                        bool isSharedInstance = doc.Tags.Any(globalTag => ReferenceEquals(globalTag, operationTag));
+                        Assert.IsTrue(isSharedInstance,
+                            $"Operation tag '{operationTag.Name}' at path '{path.Key}' ({operation.Key}) " +
+                            $"is not the same instance as the global tag. This will cause duplicate groups in Swagger UI.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper to create an Entity with common defaults for tag validation tests.
+        /// </summary>
+        private static Entity CreateEntity(
+            string sourceObject,
+            EntitySourceType sourceType,
+            string configuredRestPath,
+            string description)
+        {
+            return new Entity(
+                Source: new(sourceObject, sourceType, null, null),
+                Fields: null,
+                GraphQL: new(Singular: null, Plural: null, Enabled: false),
+                Rest: sourceType == EntitySourceType.StoredProcedure
+                    ? new(Methods: EntityRestOptions.DEFAULT_SUPPORTED_VERBS, Path: configuredRestPath)
+                    : new(Methods: EntityRestOptions.DEFAULT_SUPPORTED_VERBS, Path: configuredRestPath),
+                Permissions: OpenApiTestBootstrap.CreateBasicPermissions(),
+                Mappings: null,
+                Relationships: null,
+                Description: description);
+        }
+    }
+}


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/2992

Several configuration tests create a TestServer that sets up a `ConfigFileWatcher` to support hot-reload. When the file watcher detects a change, its callback reads the file, holding a read handle. Neither `ConfigFileWatcher` nor `FileSystemRuntimeConfigLoader` implemented `IDisposable`, so when the TestServer is disposed, the DI container could not clean up the file watcher. The watcher remained active, and if its callback was mid-read when `CleanupAfterEachTest` called `File.Delete`, the delete failed with an `IOException`

Hot reload of the data source in the tests were also creating failures via a race condition from a GraphQL query.

## What is this change?

`ConfigFileWatcher` now implements `IDisposable`. It stops raising events, unsubscribes the Changed handler, and disposes the underlying `IFileSystemWatcher`.

`FileSystemRuntimeConfigLoader` now implements `IDisposable`. It disposes the owned `ConfigFileWatcher`. As a DI singleton, it is now automatically disposed when the TestServer shuts down.

`CleanupAfterEachTest` retries with exponential backoff. As a safety net, `File.Delete` is retried up to 3 times on `IOException` (2s, 4s, 8s delays), matching the existing retry pattern used elsewhere. 

`Startup` changed to have the container create the service so that it will automatically dispose.

`using` keyword used on remaining test servers for disposal.

`ConfigurationHotReloadTests` now has a retry mechanism on a `GraphQL` query that was causing a race condition leading to failures.

## How was this tested?

Run against the pipeline. Several pipeline runs were initiated to add certainty that the fix is working, since this issue is intermittent.

https://dev.azure.com/sqldab/Data%20API%20builder%20Dependency%20Packages/_build/results?buildId=18957&view=results

https://dev.azure.com/sqldab/Data%20API%20builder%20Dependency%20Packages/_build/results?buildId=18958&view=results

https://dev.azure.com/sqldab/Data%20API%20builder%20Dependency%20Packages/_build/results?buildId=18952&view=results

https://dev.azure.com/sqldab/Data%20API%20builder%20Dependency%20Packages/_build/results?buildId=18959&view=results

https://dev.azure.com/sqldab/Data%20API%20builder%20Dependency%20Packages/_build/results?buildId=18960&view=results

