### PR TITLE
Added server description to dab.draft.schema

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -280,6 +280,10 @@
               "description": "Allow enabling/disabling MCP requests for all entities.",
               "default": true
             },
+            "description": {
+              "type": "string",
+              "description": "Description of the MCP server, exposed as the 'instructions' field in the MCP initialize response to provide behavioral context to MCP clients and agents."
+            },
             "dml-tools": {
               "description": "Configuration for MCP Data Manipulation Language (DML) tools. Set to true/false to enable/disable all tools, or use an object to configure individual tools.",
               "oneOf": [


### PR DESCRIPTION
## Why make this change?

Closes #3282

The issue is that runtime MCP server description exists in code (`McpRuntimeOptions.Description`) but was missing from the JSON schema, so valid config using `runtime.mcp.description` could fail schema validation. This change adds the missing schema entry, so config and schema stay aligned.

## What is this change?

Added `runtime.mcp.description` to `schemas/dab.draft.schema.json` under the `mcp` runtime properties:

- `type: "string"`
- description clarifying it is exposed as the MCP `instructions` field in initialize response

No runtime/CLI code changes were needed because support already exists in config model, converter, CLI configure option, and MCP server response wiring.

## How was this tested?

- [ ] Integration Tests
- [x] Unit Tests

Ran:

- `dotnet test src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj --filter "FullyQualifiedName~McpRuntimeOptionsSerializationTests" -v minimal`

## Sample Request(s)

CLI example:

```bash
dab configure --runtime.mcp.description "Use this MCP for product and inventory questions."
```

Config example:

```json
{
  "runtime": {
    "mcp": {
      "enabled": true,
      "path": "/mcp",
      "description": "Use this MCP for product and inventory questions."
    }
  }
}
```
