### PR TITLE
Return 400 for invalid If-Match values

### DIFF
--- a/src/Service.Tests/SqlTests/RestApiTests/Patch/PatchApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Patch/PatchApiTestBase.cs
@@ -486,6 +486,37 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Patch
         }
 
         /// <summary>
+        /// Tests that a PATCH request with an invalid If-Match header value
+        /// (anything other than "*") returns a 400 Bad Request response
+        /// because ETags are not supported.
+        /// </summary>
+        [TestMethod]
+        public virtual async Task PatchOne_Update_InvalidIfMatchHeader_Returns400_Test()
+        {
+            Dictionary<string, StringValues> headerDictionary = new();
+            headerDictionary.Add("If-Match", "\"abc123\"");
+            string requestBody = @"
+            {
+                ""title"": ""The Hobbit Returns to The Shire"",
+                ""publisher_id"": 1234
+            }";
+
+            await SetupAndRunRestApiTest(
+                    primaryKeyRoute: "id/1",
+                    queryString: null,
+                    entityNameOrPath: _integrationEntityName,
+                    sqlQuery: string.Empty,
+                    operationType: EntityActionOperation.UpsertIncremental,
+                    headers: new HeaderDictionary(headerDictionary),
+                    requestBody: requestBody,
+                    exceptionExpected: true,
+                    expectedErrorMessage: "Etags not supported, use '*'",
+                    expectedStatusCode: HttpStatusCode.BadRequest,
+                    expectedSubStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest.ToString()
+                );
+        }
+
+        /// <summary>
         /// Test to validate successful execution of PATCH operation which satisfies the database policy for the update operation it resolves into.
         /// </summary>
         [TestMethod]

--- a/src/Service.Tests/SqlTests/RestApiTests/Put/PutApiTestBase.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Put/PutApiTestBase.cs
@@ -1115,6 +1115,37 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Put
         }
 
         /// <summary>
+        /// Tests that a PUT request with an invalid If-Match header value
+        /// (anything other than "*") returns a 400 Bad Request response
+        /// because ETags are not supported.
+        /// </summary>
+        [TestMethod]
+        public virtual async Task PutOne_Update_InvalidIfMatchHeader_Returns400_Test()
+        {
+            Dictionary<string, StringValues> headerDictionary = new();
+            headerDictionary.Add("If-Match", "\"abc123\"");
+            string requestBody = @"
+            {
+                ""title"": ""The Return of the King"",
+                ""publisher_id"": 1234
+            }";
+
+            await SetupAndRunRestApiTest(
+                    primaryKeyRoute: "id/1",
+                    queryString: null,
+                    entityNameOrPath: _integrationEntityName,
+                    sqlQuery: string.Empty,
+                    operationType: EntityActionOperation.Upsert,
+                    headers: new HeaderDictionary(headerDictionary),
+                    requestBody: requestBody,
+                    exceptionExpected: true,
+                    expectedErrorMessage: "Etags not supported, use '*'",
+                    expectedStatusCode: HttpStatusCode.BadRequest,
+                    expectedSubStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest.ToString()
+                );
+        }
+
+        /// <summary>
         /// Tests that a PUT request with If-Match header (strict update semantics)
         /// still requires a primary key route. When If-Match is present, the operation
         /// becomes Update (not Upsert), so it cannot be converted to Insert.

--- a/src/Service/Controllers/RestController.cs
+++ b/src/Service/Controllers/RestController.cs
@@ -161,7 +161,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
         {
             return await HandleOperation(
                 route,
-                DeterminePatchPutSemantics(EntityActionOperation.Upsert));
+                EntityActionOperation.Upsert);
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
         {
             return await HandleOperation(
                 route,
-                DeterminePatchPutSemantics(EntityActionOperation.UpsertIncremental));
+                EntityActionOperation.UpsertIncremental);
         }
 
         /// <summary>
@@ -204,6 +204,11 @@ namespace Azure.DataApiBuilder.Service.Controllers
 
             try
             {
+                if (operationType is EntityActionOperation.Upsert or EntityActionOperation.UpsertIncremental)
+                {
+                    operationType = DeterminePatchPutSemantics(operationType);
+                }
+
                 TelemetryMetricsHelper.IncrementActiveRequests(ApiType.REST);
 
                 if (activity is not null)

--- a/src/Service/Controllers/RestController.cs
+++ b/src/Service/Controllers/RestController.cs
@@ -210,7 +210,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
                 {
                     operationType = DeterminePatchPutSemantics(operationType);
                 }
-                
+
                 if (activity is not null)
                 {
                     activity.TrackMainControllerActivityStarted(

--- a/src/Service/Controllers/RestController.cs
+++ b/src/Service/Controllers/RestController.cs
@@ -210,6 +210,7 @@ namespace Azure.DataApiBuilder.Service.Controllers
                 {
                     operationType = DeterminePatchPutSemantics(operationType);
                 }
+                
                 if (activity is not null)
                 {
                     activity.TrackMainControllerActivityStarted(

--- a/src/Service/Controllers/RestController.cs
+++ b/src/Service/Controllers/RestController.cs
@@ -204,13 +204,12 @@ namespace Azure.DataApiBuilder.Service.Controllers
 
             try
             {
+                TelemetryMetricsHelper.IncrementActiveRequests(ApiType.REST);
+
                 if (operationType is EntityActionOperation.Upsert or EntityActionOperation.UpsertIncremental)
                 {
                     operationType = DeterminePatchPutSemantics(operationType);
                 }
-
-                TelemetryMetricsHelper.IncrementActiveRequests(ApiType.REST);
-
                 if (activity is not null)
                 {
                     activity.TrackMainControllerActivityStarted(


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/3397

## What is this change?

When `DeterminePatchPutSemantics` threw a `DataApiBuilderException` for an invalid `If-Match` value, the exception was thrown before entering `HandleOperation` and the `try-catch` block within. This is where we convert `DataApiBuilderException` into structured JSON error response. We therefore move the `DeterminePatchPutSemantics` call inside of the `try-catch` block within `HandleOperation`, gating the function behind a check of the operation type so that it only applies to `Upsert` and `UpsertIncremental` operations.

## How was this tested?

Added a test for `Put` and a test for `Patch` to validate the new behavior.

## Sample Request(s)

Any valid `Put` or `Patch` with headers using `If-Match` with a value other than `*`