### PR TITLE
Fix autoentity validation & CLI/Schema mismatch bugs

### DIFF
--- a/src/Cli.Tests/AutoConfigTests.cs
+++ b/src/Cli.Tests/AutoConfigTests.cs
@@ -80,7 +80,7 @@ public class AutoConfigTests
             definitionName: "test-def",
             templateRestEnabled: true,
             templateGraphqlEnabled: false,
-            templateMcpDmlTool: "true",
+            templateMcpDmlTools: "true",
             templateCacheEnabled: true,
             templateCacheTtlSeconds: 30,
             templateCacheLevel: "L1",
@@ -196,7 +196,7 @@ public class AutoConfigTests
 
         AutoConfigOptions options = new(
             definitionName: "test-def",
-            templateMcpDmlTool: "invalid-value",
+            templateMcpDmlTools: "invalid-value",
             permissions: new[] { "anonymous", "read" },
             config: TEST_RUNTIME_CONFIG_FILE
         );

--- a/src/Cli/Commands/AutoConfigOptions.cs
+++ b/src/Cli/Commands/AutoConfigOptions.cs
@@ -39,7 +39,7 @@ namespace Cli.Commands
             PatternsInclude = patternsInclude;
             PatternsExclude = patternsExclude;
             PatternsName = patternsName;
-            TemplateMcpDmlTool = templateMcpDmlTool;
+            TemplateMcpDmlTools = templateMcpDmlTool;
             TemplateRestEnabled = templateRestEnabled;
             TemplateGraphqlEnabled = templateGraphqlEnabled;
             TemplateCacheEnabled = templateCacheEnabled;
@@ -61,8 +61,8 @@ namespace Cli.Commands
         [Option("patterns.name", Required = false, HelpText = "Interpolation syntax for entity naming (must be unique for each generated entity). Default: '{object}'")]
         public string? PatternsName { get; }
 
-        [Option("template.mcp.dml-tool", Required = false, HelpText = "Enable/disable DML tools for generated entities. Allowed values: true, false. Default: true")]
-        public string? TemplateMcpDmlTool { get; }
+        [Option("template.mcp.dml-tools", Required = false, HelpText = "Enable/disable DML tools for generated entities. Allowed values: true, false. Default: true")]
+        public string? TemplateMcpDmlTools { get; }
 
         [Option("template.rest.enabled", Required = false, HelpText = "Enable/disable REST endpoint for generated entities. Allowed values: true, false. Default: true")]
         public bool? TemplateRestEnabled { get; }

--- a/src/Cli/Commands/AutoConfigOptions.cs
+++ b/src/Cli/Commands/AutoConfigOptions.cs
@@ -24,7 +24,7 @@ namespace Cli.Commands
             IEnumerable<string>? patternsInclude = null,
             IEnumerable<string>? patternsExclude = null,
             string? patternsName = null,
-            string? templateMcpDmlTool = null,
+            string? templateMcpDmlTools = null,
             bool? templateRestEnabled = null,
             bool? templateGraphqlEnabled = null,
             bool? templateCacheEnabled = null,
@@ -39,7 +39,7 @@ namespace Cli.Commands
             PatternsInclude = patternsInclude;
             PatternsExclude = patternsExclude;
             PatternsName = patternsName;
-            TemplateMcpDmlTools = templateMcpDmlTool;
+            TemplateMcpDmlTools = templateMcpDmlTools;
             TemplateRestEnabled = templateRestEnabled;
             TemplateGraphqlEnabled = templateGraphqlEnabled;
             TemplateCacheEnabled = templateCacheEnabled;

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -2646,45 +2646,63 @@ namespace Cli
             ILogger<RuntimeConfigValidator> runtimeConfigValidatorLogger = LoggerFactoryForCli.CreateLogger<RuntimeConfigValidator>();
             RuntimeConfigValidator runtimeConfigValidator = new(runtimeConfigProvider, fileSystem, runtimeConfigValidatorLogger, true);
 
-            bool isValid = runtimeConfigValidator.TryValidateConfig(runtimeConfigFile, LoggerFactoryForCli).Result;
-
-            // Additional validation: warn if fields are missing and MCP is enabled
-            if (isValid)
+            bool isValid = false;
+            try
             {
-                if (runtimeConfigProvider.TryGetConfig(out RuntimeConfig? config) && config is not null)
+                isValid = runtimeConfigValidator.TryValidateConfig(runtimeConfigFile, LoggerFactoryForCli).Result;
+
+                // Additional validation: warn if fields are missing and MCP is enabled
+                if (isValid)
                 {
-                    bool mcpEnabled = config.IsMcpEnabled;
-                    if (mcpEnabled)
+                    if (runtimeConfigProvider.TryGetConfig(out RuntimeConfig? config) && config is not null)
                     {
-                        foreach (KeyValuePair<string, Entity> entity in config.Entities)
+                        bool mcpEnabled = config.IsMcpEnabled;
+                        if (mcpEnabled)
                         {
-                            if (entity.Value.Fields == null || !entity.Value.Fields.Any())
+                            foreach (KeyValuePair<string, Entity> entity in config.Entities)
                             {
-                                _logger.LogWarning($"Entity '{entity.Key}' is missing 'fields' definition while MCP is enabled. " +
-                                    "It's recommended to define fields explicitly to ensure optimal performance with MCP.");
+                                if (entity.Value.Fields == null || !entity.Value.Fields.Any())
+                                {
+                                    _logger.LogWarning($"Entity '{entity.Key}' is missing 'fields' definition while MCP is enabled. " +
+                                        "It's recommended to define fields explicitly to ensure optimal performance with MCP.");
+                                }
+                            }
+                        }
+
+                        // Warn if Unauthenticated provider is used with authenticated or custom roles
+                        if (config.Runtime?.Host?.Authentication?.IsUnauthenticatedAuthenticationProvider() == true)
+                        {
+                            bool hasNonAnonymousRoles = config.Entities
+                                .Where(e => e.Value.Permissions is not null)
+                                .SelectMany(e => e.Value.Permissions!)
+                                .Any(p => !p.Role.Equals("anonymous", StringComparison.OrdinalIgnoreCase));
+
+                            if (hasNonAnonymousRoles)
+                            {
+                                _logger.LogWarning(
+                                    "Authentication provider is 'Unauthenticated' but some entities have permissions configured for non-anonymous roles. " +
+                                    "All requests will be treated as anonymous.");
                             }
                         }
                     }
-
-                    // Warn if Unauthenticated provider is used with authenticated or custom roles
-                    if (config.Runtime?.Host?.Authentication?.IsUnauthenticatedAuthenticationProvider() == true)
-                    {
-                        bool hasNonAnonymousRoles = config.Entities
-                            .Where(e => e.Value.Permissions is not null)
-                            .SelectMany(e => e.Value.Permissions!)
-                            .Any(p => !p.Role.Equals("anonymous", StringComparison.OrdinalIgnoreCase));
-
-                        if (hasNonAnonymousRoles)
-                        {
-                            _logger.LogWarning(
-                                "Authentication provider is 'Unauthenticated' but some entities have permissions configured for non-anonymous roles. " +
-                                "All requests will be treated as anonymous.");
-                        }
-                    }
                 }
-            }
 
-            return isValid;
+                return isValid;
+            }
+            catch (AggregateException ex)
+            {
+                foreach (Exception exception in ex.InnerExceptions)
+                {
+                    _logger.LogError(exception, exception.Message);
+                }
+
+                return isValid;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, ex.Message);
+                return isValid;
+            }
         }
 
         /// <summary>

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -2646,63 +2646,45 @@ namespace Cli
             ILogger<RuntimeConfigValidator> runtimeConfigValidatorLogger = LoggerFactoryForCli.CreateLogger<RuntimeConfigValidator>();
             RuntimeConfigValidator runtimeConfigValidator = new(runtimeConfigProvider, fileSystem, runtimeConfigValidatorLogger, true);
 
-            bool isValid = false;
-            try
+            bool isValid = runtimeConfigValidator.TryValidateConfig(runtimeConfigFile, LoggerFactoryForCli).Result;
+
+            // Additional validation: warn if fields are missing and MCP is enabled
+            if (isValid)
             {
-                isValid = runtimeConfigValidator.TryValidateConfig(runtimeConfigFile, LoggerFactoryForCli).Result;
-
-                // Additional validation: warn if fields are missing and MCP is enabled
-                if (isValid)
+                if (runtimeConfigProvider.TryGetConfig(out RuntimeConfig? config) && config is not null)
                 {
-                    if (runtimeConfigProvider.TryGetConfig(out RuntimeConfig? config) && config is not null)
+                    bool mcpEnabled = config.IsMcpEnabled;
+                    if (mcpEnabled)
                     {
-                        bool mcpEnabled = config.IsMcpEnabled;
-                        if (mcpEnabled)
+                        foreach (KeyValuePair<string, Entity> entity in config.Entities)
                         {
-                            foreach (KeyValuePair<string, Entity> entity in config.Entities)
+                            if (entity.Value.Fields == null || !entity.Value.Fields.Any())
                             {
-                                if (entity.Value.Fields == null || !entity.Value.Fields.Any())
-                                {
-                                    _logger.LogWarning($"Entity '{entity.Key}' is missing 'fields' definition while MCP is enabled. " +
-                                        "It's recommended to define fields explicitly to ensure optimal performance with MCP.");
-                                }
-                            }
-                        }
-
-                        // Warn if Unauthenticated provider is used with authenticated or custom roles
-                        if (config.Runtime?.Host?.Authentication?.IsUnauthenticatedAuthenticationProvider() == true)
-                        {
-                            bool hasNonAnonymousRoles = config.Entities
-                                .Where(e => e.Value.Permissions is not null)
-                                .SelectMany(e => e.Value.Permissions!)
-                                .Any(p => !p.Role.Equals("anonymous", StringComparison.OrdinalIgnoreCase));
-
-                            if (hasNonAnonymousRoles)
-                            {
-                                _logger.LogWarning(
-                                    "Authentication provider is 'Unauthenticated' but some entities have permissions configured for non-anonymous roles. " +
-                                    "All requests will be treated as anonymous.");
+                                _logger.LogWarning($"Entity '{entity.Key}' is missing 'fields' definition while MCP is enabled. " +
+                                    "It's recommended to define fields explicitly to ensure optimal performance with MCP.");
                             }
                         }
                     }
-                }
 
-                return isValid;
-            }
-            catch (AggregateException ex)
-            {
-                foreach (Exception exception in ex.InnerExceptions)
-                {
-                    _logger.LogError(exception, exception.Message);
-                }
+                    // Warn if Unauthenticated provider is used with authenticated or custom roles
+                    if (config.Runtime?.Host?.Authentication?.IsUnauthenticatedAuthenticationProvider() == true)
+                    {
+                        bool hasNonAnonymousRoles = config.Entities
+                            .Where(e => e.Value.Permissions is not null)
+                            .SelectMany(e => e.Value.Permissions!)
+                            .Any(p => !p.Role.Equals("anonymous", StringComparison.OrdinalIgnoreCase));
 
-                return isValid;
+                        if (hasNonAnonymousRoles)
+                        {
+                            _logger.LogWarning(
+                                "Authentication provider is 'Unauthenticated' but some entities have permissions configured for non-anonymous roles. " +
+                                "All requests will be treated as anonymous.");
+                        }
+                    }
+                }
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, ex.Message);
-                return isValid;
-            }
+
+            return isValid;
         }
 
         /// <summary>

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -3109,11 +3109,11 @@ namespace Cli
             bool userProvidedCache = existingAutoentity?.Template.UserProvidedCacheOptions ?? false;
 
             // Update MCP options
-            if (!string.IsNullOrWhiteSpace(options.TemplateMcpDmlTool))
+            if (!string.IsNullOrWhiteSpace(options.TemplateMcpDmlTools))
             {
-                if (!bool.TryParse(options.TemplateMcpDmlTool, out bool mcpDmlToolValue))
+                if (!bool.TryParse(options.TemplateMcpDmlTools, out bool mcpDmlToolValue))
                 {
-                    _logger.LogError("Invalid value for template.mcp.dml-tool: {value}. Valid values are: true, false", options.TemplateMcpDmlTool);
+                    _logger.LogError("Invalid value for template.mcp.dml-tools: {value}. Valid values are: true, false", options.TemplateMcpDmlTools);
                     return null;
                 }
 
@@ -3122,7 +3122,7 @@ namespace Cli
                 bool? dmlToolValue = mcpDmlToolValue;
                 mcp = new EntityMcpOptions(customToolEnabled: customToolEnabled, dmlToolsEnabled: dmlToolValue);
                 userProvidedMcp = true;
-                _logger.LogInformation("Updated template.mcp.dml-tool for definition '{DefinitionName}'", options.DefinitionName);
+                _logger.LogInformation("Updated template.mcp.dml-tools for definition '{DefinitionName}'", options.DefinitionName);
             }
 
             // Update REST options

--- a/src/Core/Services/MetadataProviders/MsSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/MsSqlMetadataProvider.cs
@@ -357,7 +357,7 @@ namespace Azure.DataApiBuilder.Core.Services
                     if (!entities.TryAdd(entityName, generatedEntity) || !runtimeConfig.TryAddGeneratedAutoentityNameToDataSourceName(entityName, autoentityName))
                     {
                         throw new DataApiBuilderException(
-                            message: $"Entity with name '{entityName}' already exists. Cannot create new entity from autoentities definition '{autoentityName}'.",
+                            message: $"Entity '{entityName}' conflicts with autoentity pattern '{autoentityName}'. Use --patterns.exclude to skip it.",
                             statusCode: HttpStatusCode.BadRequest,
                             subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
                     }

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -5611,7 +5611,7 @@ type Planet @model(name:""PlanetAlias"") {
         /// <returns></returns>
         [TestCategory(TestCategory.MSSQL)]
         [DataTestMethod]
-        [DataRow("publishers", "uniqueSingularPublisher", "uniquePluralPublishers", "/unique/publisher", "Entity with name 'publishers' already exists. Cannot create new entity from autoentities definition 'PublisherAutoEntity'.", DisplayName = "Autoentities fail due to entity name")]
+        [DataRow("publishers", "uniqueSingularPublisher", "uniquePluralPublishers", "/unique/publisher", "Entity 'publishers' conflicts with autoentity pattern 'PublisherAutoEntity'. Use --patterns.exclude to skip it.", DisplayName = "Autoentities fail due to entity name")]
         [DataRow("UniquePublisher", "publishers", "uniquePluralPublishers", "/unique/publisher", "Entity publishers generates queries/mutation that already exist", DisplayName = "Autoentities fail due to graphql singular type")]
         [DataRow("UniquePublisher", "uniqueSingularPublisher", "publishers", "/unique/publisher", "Entity publishers generates queries/mutation that already exist", DisplayName = "Autoentities fail due to graphql plural type")]
         [DataRow("UniquePublisher", "uniqueSingularPublisher", "uniquePluralPublishers", "/publishers", "The rest path: publishers specified for entity: publishers is already used by another entity.", DisplayName = "Autoentities fail due to rest path")]


### PR DESCRIPTION
## Why make this change?
- #3375 
  - The CLI and the schema have a mismatch in the `autoentities.<def-name>.template.mcp.dml-tools`, need to ensure that they are the same.
- #3335 
  - Using `dab validate` produces the wrong output message.

## What is this change?
For issue #3375:
- We changed the `AutoConfigOption.cs` file so that it uses the proper name and changed the name of the variable to also match the schema in the `ConfigGenerator.cs`.

For issue #3335:
-  We changed the log message in `MsSqlMetadataProvider.cs` so that it is easier for the user to understand the error.

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests
- [x] Local Testing
The issues were related to mismatches or to the output of log messages that can only be tested locally.

## Sample Request(s)
dab auto-config <def-name> --template.mcp.dml-tools true/false
dab validate --config test.json