### PR TITLE
Changed default authentication provider to "Unauthenticated" in dab.draft.schema.json.

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -436,7 +436,7 @@
                       "description": "Unauthenticated provider where all operations run as anonymous. Use when Data API builder is behind an app gateway or APIM where authentication is handled externally."
                     }
                   ],
-                  "default": "AppService"
+                  "default": "Unauthenticated"
                 },
                 "jwt": {
                   "type": "object",


### PR DESCRIPTION
## Why make this change?

Closes #3392.

The JSON schema default for runtime.host.authentication.provider was set to AppService, while CLI help text and docs indicate the default should be Unauthenticated. This mismatch can confuse users and tooling.

## What is this change?

- Updated the schema default in schemas/dab.draft.schema.json:
  - runtime.host.authentication.provider: AppService -> Unauthenticated
- No runtime behavior changes were introduced beyond aligning the schema default value.

## How was this tested?

- [ ] Integration Tests
- [x] Unit Tests

Ran:

- dotnet test src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~CorsUnitTests.TestCorsConfigReadCorrectly"

## Sample Request(s)

CLI example:

- dab configure --runtime.host.authentication.provider AppService
- This demonstrates overriding the default.

Config example:

- Omit runtime.host.authentication.provider from config.
- Schema default resolves it to Unauthenticated.
