### PR TITLE
Add MCP to bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -54,7 +54,7 @@ body:
       options:
         - REST
         - GraphQL
-        - MCP 
+        - MCP
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -54,6 +54,7 @@ body:
       options:
         - REST
         - GraphQL
+        - MCP 
   - type: textarea
     id: logs
     attributes:


### PR DESCRIPTION
## Why make this change?
Currently the bug report doesn't allow users to choose the option of MCP between the multiple API options.

## What is this change?
Added the MCP option so that users can tell us when a bug related to MCP is occurring.

## How was this tested?
This is a change related to the github page.
