### PR TITLE
lowercase CLI enum values in HelpText and error messages (Group 3)

### DIFF
--- a/src/Cli/Commands/EntityOptions.cs
+++ b/src/Cli/Commands/EntityOptions.cs
@@ -83,13 +83,13 @@ namespace Cli.Commands
         [Option("rest", Required = false, HelpText = "Route for rest api.")]
         public string? RestRoute { get; }
 
-        [Option("rest.methods", Required = false, Separator = ',', HelpText = "HTTP actions to be supported for stored procedure. Specify the actions as a comma separated list. Valid HTTP actions are : [GET, POST, PUT, PATCH, DELETE]")]
+        [Option("rest.methods", Required = false, Separator = ',', HelpText = "HTTP actions to be supported for stored procedure. Specify the actions as a comma separated list. Valid HTTP actions are: [get, post, put, patch, delete]")]
         public IEnumerable<string>? RestMethodsForStoredProcedure { get; }
 
         [Option("graphql", Required = false, HelpText = "Type of graphQL.")]
         public string? GraphQLType { get; }
 
-        [Option("graphql.operation", Required = false, HelpText = $"GraphQL operation to be supported for stored procedure. Valid operations are : [Query, Mutation] ")]
+        [Option("graphql.operation", Required = false, HelpText = "GraphQL operation to be supported for stored procedure. Valid operations are: [query, mutation]")]
         public string? GraphQLOperationForStoredProcedure { get; }
 
         [Option("fields.include", Required = false, Separator = ',', HelpText = "Fields that are allowed access to permission.")]

--- a/src/Cli/Commands/InitOptions.cs
+++ b/src/Cli/Commands/InitOptions.cs
@@ -90,7 +90,7 @@ namespace Cli.Commands
         [Option("set-session-context", Default = false, Required = false, HelpText = "Enable sending data to MsSql using session context.")]
         public bool SetSessionContext { get; }
 
-        [Option("host-mode", Default = HostMode.Production, Required = false, HelpText = "Specify the Host mode - Development or Production")]
+        [Option("host-mode", Default = HostMode.Production, Required = false, HelpText = "Specify the Host mode - development or production")]
         public HostMode HostMode { get; }
 
         [Option("cors-origin", Separator = ',', Required = false, HelpText = "Specify the list of allowed origins.")]

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -602,7 +602,7 @@ namespace Cli
         {
             if (!Enum.TryParse(method, ignoreCase: true, out restMethod))
             {
-                _logger.LogError("Invalid REST Method. Supported methods are {restMethods}.", string.Join(", ", Enum.GetNames<SupportedHttpVerb>()));
+                _logger.LogError("Invalid REST Method. Supported methods are {restMethods}.", string.Join(", ", Enum.GetNames<SupportedHttpVerb>().Select(n => n.ToLowerInvariant())));
                 return false;
             }
 
@@ -652,8 +652,8 @@ namespace Cli
             {
                 _logger.LogError(
                     "Invalid GraphQL Operation. Supported operations are {queryName} and {mutationName}.",
-                    GraphQLOperation.Query,
-                    GraphQLOperation.Mutation);
+                    nameof(GraphQLOperation.Query).ToLowerInvariant(),
+                    nameof(GraphQLOperation.Mutation).ToLowerInvariant());
                 return false;
             }
 


### PR DESCRIPTION
## Summary

- Closes on #3445 

Fixes 4 issues where CLI `--help` text and error messages showed PascalCase or UPPERCASE enum values instead of the lowercase values required by the JSON schema.

The JSON serialization layer already produces lowercase (via `EnumMemberJsonEnumConverterFactory`), so these fixes align the CLI display layer to match.

## Issues Addressed

| Issue | Option | CLI Showed | Schema Requires | Fix |
|-------|--------|-----------|-----------------|-----|
| #3361 | `--host-mode` (init) | `Development or Production` | `development or production` | HelpText lowercased |
| #3362 | `--rest.methods` (add/update) | `[GET, POST, PUT, PATCH, DELETE]` | `[get, post, put, patch, delete]` | HelpText lowercased |
| #3363 | `--graphql.operation` (add/update) | `[Query, Mutation]` | `[query, mutation]` | HelpText lowercased |
| #3364 | `--graphql.operation` (add/update) | Same as #3363 | Same as #3363 | Same fix |

## Files Changed

| File | Changes |
|------|---------|
| `src/Cli/Commands/InitOptions.cs` | `host-mode` HelpText: lowercase enum values |
| `src/Cli/Commands/EntityOptions.cs` | `rest.methods` and `graphql.operation` HelpText: lowercase enum values |
| `src/Cli/Utils.cs` | REST method and GraphQL operation error messages: lowercase enum names |

## Testing

- [x] Unit tests
