### PR TITLE
fix: improve schema descriptions (Group 5)

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -243,7 +243,7 @@
             },
             "depth-limit": {
               "type": [ "integer", "null" ],
-              "description": "Maximum allowed depth of a GraphQL query. Default: null (no limit). Use -1 via CLI to remove a previously set limit.",
+              "description": "Maximum allowed depth of a GraphQL query. Only positive integers are enforced. Default: null (no limit). Use -1 to explicitly remove a previously set limit.",
               "default": null
             },
             "multiple-mutations": {
@@ -950,7 +950,7 @@
                     "description": "The role to which this permission applies (e.g. anonymous, authenticated, or a custom role)."
                   },
                   "actions": {
-                    "description": "The operations permitted for this role. Use \"*\" to allow all, or specify an array of actions.",
+                    "description": "The operations permitted for this role. Use '*' to allow all, or specify an array of actions.",
                     "oneOf": [
                       {
                         "type": "string",
@@ -1345,7 +1345,7 @@
                       "description": "The role to which this permission applies (e.g. anonymous, authenticated, or a custom role)."
                     },
                     "actions": {
-                      "description": "The operations permitted for this role. Use \"*\" to allow all, or specify an array of actions.",
+                      "description": "The operations permitted for this role. Use '*' to allow all, or specify an array of actions.",
                       "oneOf": [
                         {
                           "type": "string",
@@ -1421,7 +1421,7 @@
                       "description": "The role to which this permission applies (e.g. anonymous, authenticated, or a custom role)."
                     },
                     "actions": {
-                      "description": "The operations permitted for this role. Use \"*\" to allow all, or specify an array of actions.",
+                      "description": "The operations permitted for this role. Use '*' to allow all, or specify an array of actions.",
                       "oneOf": [
                         {
                           "type": "string",

--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -32,7 +32,7 @@
           "type": "string"
         },
         "options": {
-          "description": "Database specific properties for the backend database",
+          "description": "Database-specific connection and configuration properties. Available options depend on the database-type.",
           "type": "object"
         },
         "health": {
@@ -42,7 +42,7 @@
           "properties": {
             "enabled": {
               "$ref": "#/$defs/boolean-or-string",
-              "description": "Enable health check endpoint for something",
+              "description": "Enable health check for this data source.",
               "default": true,
               "additionalProperties": false
             },
@@ -97,7 +97,7 @@
           "then": {
             "properties": {
               "options": {
-                "description": "Database specific properties for the backend database",
+                "description": "Database-specific connection and configuration properties. Available options depend on the database-type.",
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
@@ -241,7 +241,7 @@
             },
             "depth-limit": {
               "type": [ "integer", "null" ],
-              "description": "Maximum allowed depth of a GraphQL query.",
+              "description": "Maximum allowed depth of a GraphQL query. Default: null (no limit). Use -1 via CLI to remove a previously set limit.",
               "default": null
             },
             "multiple-mutations": {
@@ -944,9 +944,11 @@
                 "additionalProperties": false,
                 "properties": {
                   "role": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The role to which this permission applies (e.g. anonymous, authenticated, or a custom role)."
                   },
                   "actions": {
+                    "description": "The operations permitted for this role. Use \"*\" to allow all, or specify an array of actions.",
                     "oneOf": [
                       {
                         "type": "string",
@@ -1337,9 +1339,11 @@
                   "additionalProperties": false,
                   "properties": {
                     "role": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "The role to which this permission applies (e.g. anonymous, authenticated, or a custom role)."
                     },
                     "actions": {
+                      "description": "The operations permitted for this role. Use \"*\" to allow all, or specify an array of actions.",
                       "oneOf": [
                         {
                           "type": "string",
@@ -1411,9 +1415,11 @@
                   "additionalProperties": false,
                   "properties": {
                     "role": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "The role to which this permission applies (e.g. anonymous, authenticated, or a custom role)."
                     },
                     "actions": {
+                      "description": "The operations permitted for this role. Use \"*\" to allow all, or specify an array of actions.",
                       "oneOf": [
                         {
                           "type": "string",


### PR DESCRIPTION
## Why make this change?

Closes #3470

Fixes #3365, #3368, #3369, #3370, #3371

Schema descriptions were missing, placeholder, or misleading — affecting VS Code IntelliSense and tooling that reads JSON Schema metadata.

## What is this change?

Updates \schemas/dab.draft.schema.json\ descriptions:

| Issue | Property | Fix |
|-------|----------|-----|
| #3365 | \data-source.health.enabled\ | Updated description |
| #3368 | \permissions[].role\ | Added missing description (3 locations) |
| #3369 | \permissions[].actions\ | Added missing description (3 locations) |
| #3370 | \data-source.options\ | Clarified vague description (2 locations) |
| #3371 | \
untime.graphql.depth-limit\ | Documented null (no limit) and -1 (CLI remove limit) semantics |

## How was this tested?

Schema-only metadata change — no runtime behavior affected. JSON validated.
