### PR TITLE
Change autoentities `patterns.name` default value

### DIFF
--- a/schemas/dab.draft.schema.json
+++ b/schemas/dab.draft.schema.json
@@ -845,8 +845,8 @@
                 },
                 "name": {
                   "type": "string",
-                  "description": "Entity name interpolation pattern using {schema} and {object}. Null defaults to {object}. Must be unique for every entity inside the pattern",
-                  "default": "{object}"
+                  "description": "Entity name interpolation pattern using {schema} and {object}. Null defaults to {schema}_{object}. Must be unique for every entity inside the pattern",
+                  "default": "{schema}_{object}"
                 }
               }
             },

--- a/src/Cli/Commands/AutoConfigOptions.cs
+++ b/src/Cli/Commands/AutoConfigOptions.cs
@@ -58,7 +58,7 @@ namespace Cli.Commands
         [Option("patterns.exclude", Required = false, HelpText = "T-SQL LIKE pattern(s) to exclude database objects. Space-separated array of patterns. Default: null")]
         public IEnumerable<string>? PatternsExclude { get; }
 
-        [Option("patterns.name", Required = false, HelpText = "Interpolation syntax for entity naming (must be unique for each generated entity). Default: '{object}'")]
+        [Option("patterns.name", Required = false, HelpText = "Interpolation syntax for entity naming (must be unique for each generated entity). Default: '{schema}_{object}'")]
         public string? PatternsName { get; }
 
         [Option("template.mcp.dml-tools", Required = false, HelpText = "Enable/disable DML tools for generated entities. Allowed values: true, false. Default: true")]

--- a/src/Config/ObjectModel/AutoentityPatterns.cs
+++ b/src/Config/ObjectModel/AutoentityPatterns.cs
@@ -51,7 +51,7 @@ public record AutoentityPatterns
         }
         else
         {
-            this.Name = "{object}";
+            this.Name = "{schema}_{object}";
         }
     }
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -5592,12 +5592,12 @@ type Planet @model(name:""PlanetAlias"") {
             {
                 // Act
                 RuntimeConfigProvider configProvider = server.Services.GetService<RuntimeConfigProvider>();
-                using HttpRequestMessage restRequest = new(HttpMethod.Get, "/api/publishers");
+                using HttpRequestMessage restRequest = new(HttpMethod.Get, "/api/dbo_publishers");
                 using HttpResponseMessage restResponse = await client.SendAsync(restRequest);
 
                 string graphqlQuery = @"
                 {
-                    publishers {
+                    dbo_publishers {
                         items {
                             id
                             name
@@ -5701,8 +5701,6 @@ type Planet @model(name:""PlanetAlias"") {
             using (HttpClient client = server.CreateClient())
             {
                 // Act
-                RuntimeConfigProvider configProvider = server.Services.GetService<RuntimeConfigProvider>();
-
                 using HttpRequestMessage restFooRequest = new(HttpMethod.Get, "/api/foo_magazines");
                 using HttpResponseMessage restFooResponse = await client.SendAsync(restFooRequest);
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -5751,10 +5751,10 @@ type Planet @model(name:""PlanetAlias"") {
         /// <returns></returns>
         [TestCategory(TestCategory.MSSQL)]
         [DataTestMethod]
-        [DataRow("publishers", "uniqueSingularPublisher", "uniquePluralPublishers", "/unique/publisher", "Entity 'publishers' conflicts with autoentity pattern 'PublisherAutoEntity'. Use --patterns.exclude to skip it.", DisplayName = "Autoentities fail due to entity name")]
-        [DataRow("UniquePublisher", "publishers", "uniquePluralPublishers", "/unique/publisher", "Entity publishers generates queries/mutation that already exist", DisplayName = "Autoentities fail due to graphql singular type")]
-        [DataRow("UniquePublisher", "uniqueSingularPublisher", "publishers", "/unique/publisher", "Entity publishers generates queries/mutation that already exist", DisplayName = "Autoentities fail due to graphql plural type")]
-        [DataRow("UniquePublisher", "uniqueSingularPublisher", "uniquePluralPublishers", "/publishers", "The rest path: publishers specified for entity: publishers is already used by another entity.", DisplayName = "Autoentities fail due to rest path")]
+        [DataRow("dbo_publishers", "uniqueSingularPublisher", "uniquePluralPublishers", "/unique/publisher", "Entity 'dbo_publishers' conflicts with autoentity pattern 'PublisherAutoEntity'. Use --patterns.exclude to skip it.", DisplayName = "Autoentities fail due to entity name")]
+        [DataRow("UniquePublisher", "dbo_publishers", "uniquePluralPublishers", "/unique/publisher", "Entity dbo_publishers generates queries/mutation that already exist", DisplayName = "Autoentities fail due to graphql singular type")]
+        [DataRow("UniquePublisher", "uniqueSingularPublisher", "dbo_publishers", "/unique/publisher", "Entity dbo_publishers generates queries/mutation that already exist", DisplayName = "Autoentities fail due to graphql plural type")]
+        [DataRow("UniquePublisher", "uniqueSingularPublisher", "uniquePluralPublishers", "/dbo_publishers", "The rest path: dbo_publishers specified for entity: dbo_publishers is already used by another entity.", DisplayName = "Autoentities fail due to rest path")]
         public async Task ValidateAutoentityGenerationConflicts(string entityName, string singular, string plural, string path, string exceptionMessage)
         {
             // Arrange

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -5651,7 +5651,7 @@ type Planet @model(name:""PlanetAlias"") {
                     "PublisherAutoEntity", new Autoentity(
                         Patterns: new AutoentityPatterns(
                             Include: null,
-                            Exclude: null,
+                            Exclude: new[] { "dbo.GQLmappings", "dbo.graphql_incompatible", "dbo.brokers" },
                             Name: null
                         ),
                         Template: new AutoentityTemplate(
@@ -5808,13 +5808,14 @@ type Planet @model(name:""PlanetAlias"") {
             using (HttpClient client = server.CreateClient())
             {
                 // Act
-                using HttpRequestMessage restRequest = new(HttpMethod.Get, "/api/magazines");
+                string path = isPatternFoo ? "foo_magazines" : "bar_magazines";
+                using HttpRequestMessage restRequest = new(HttpMethod.Get, $"/api/{path}");
                 using HttpResponseMessage restResponse = await client.SendAsync(restRequest);
 
                 string item = isPatternFoo ? "title" : "comic_name";
                 string graphqlQuery = $@"
                 {{
-                    magazines {{
+                    {path} {{
                         items {{
                             {item}
                         }}

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -5598,6 +5598,113 @@ type Planet @model(name:""PlanetAlias"") {
         }
 
         /// <summary>
+        /// This test validates that multiple autoentities with the same object name
+        /// but different schemas can be generated and accessed properly with the
+        /// default 'property.name' which should generate entities named '{schema}_{object}'.
+        /// </summary>
+        [TestCategory(TestCategory.MSSQL)]
+        [TestMethod]
+        public async Task TestAutoentitiesWithSameObjectDifferentSchemas()
+        {
+            // Arrange
+            Dictionary<string, Autoentity> autoentityMap = new()
+            {
+                {
+                    "PublisherAutoEntity", new Autoentity(
+                        Patterns: new AutoentityPatterns(
+                            Include: null,
+                            Exclude: null,
+                            Name: null
+                        ),
+                        Template: new AutoentityTemplate(
+                            Rest: new EntityRestOptions(Enabled: true),
+                            GraphQL: new EntityGraphQLOptions(
+                                Singular: string.Empty,
+                                Plural: string.Empty,
+                                Enabled: true
+                            ),
+                            Health: null,
+                            Cache: null
+                        ),
+                        Permissions: new[] { GetMinimalPermissionConfig(AuthorizationResolver.ROLE_ANONYMOUS) }
+                    )
+                }
+            };
+
+            // Create DataSource for MSSQL connection
+            DataSource dataSource = new(DatabaseType.MSSQL,
+                GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL), Options: null);
+
+            // Build complete runtime configuration with autoentities
+            RuntimeConfig configuration = new(
+                Schema: "TestAutoentitiesSchema",
+                DataSource: dataSource,
+                Runtime: new(
+                    Rest: new(Enabled: true),
+                    GraphQL: new(Enabled: true),
+                    Mcp: new(Enabled: false),
+                    Host: new(
+                        Cors: null,
+                        Authentication: new Config.ObjectModel.AuthenticationOptions(
+                            Provider: nameof(EasyAuthType.StaticWebApps),
+                            Jwt: null
+                        )
+                    )
+                ),
+                Entities: new(new Dictionary<string, Entity>()),
+                Autoentities: new RuntimeAutoentities(autoentityMap)
+            );
+
+            File.WriteAllText(CUSTOM_CONFIG_FILENAME, configuration.ToJson());
+
+            string[] args = new[] { $"--ConfigFileName={CUSTOM_CONFIG_FILENAME}" };
+
+            using (TestServer server = new(Program.CreateWebHostBuilder(args)))
+            using (HttpClient client = server.CreateClient())
+            {
+                // Act
+                RuntimeConfigProvider configProvider = server.Services.GetService<RuntimeConfigProvider>();
+
+                using HttpRequestMessage restFooRequest = new(HttpMethod.Get, "/api/foo_magazines");
+                using HttpResponseMessage restFooResponse = await client.SendAsync(restFooRequest);
+
+                using HttpRequestMessage restBarRequest = new(HttpMethod.Get, "/api/bar_magazines");
+                using HttpResponseMessage restBarResponse = await client.SendAsync(restBarRequest);
+
+                string graphqlQuery = @"
+                {
+                    foo_magazines {
+                        items {
+                            id
+                            issue_number
+                        }
+                    }
+                    bar_magazines {
+                        items {
+                            comic_name
+                            issue
+                        }
+                    }
+                }";
+
+                object graphqlPayload = new { query = graphqlQuery };
+                HttpRequestMessage graphqlRequest = new(HttpMethod.Post, "/graphql")
+                {
+                    Content = JsonContent.Create(graphqlPayload)
+                };
+                HttpResponseMessage graphqlResponse = await client.SendAsync(graphqlRequest);
+
+                // Assert
+                // Verify REST response
+                Assert.AreEqual(HttpStatusCode.OK, restFooResponse.StatusCode, "REST request to auto-generated entity 'foo_magazines' should succeed");
+                Assert.AreEqual(HttpStatusCode.OK, restBarResponse.StatusCode, "REST request to auto-generated entity 'bar_magazines' should succeed");
+
+                // Verify GraphQL response
+                Assert.AreEqual(HttpStatusCode.OK, graphqlResponse.StatusCode, "GraphQL request to auto-generated entity should succeed");
+            }
+        }
+
+        /// <summary>
         /// 
         /// </summary>
         /// <param name="entityName"></param>


### PR DESCRIPTION
## Why make this change?
- Fixes issue #3455 

## What is this change?
This changes the default value of the `patterns.name` property inside `autoentities` so that it uses both the {schema} and {object} in order to allow users to use multiple objects that have the same name but are from different schemas without the need to do additional changes to the config file.

This PR is dependent on PR #3468.

## How was this tested?

- [X] Integration Tests
- [ ] Unit Tests
- [X] Manual Tests
Used sample below to ensure that different entities with the same object name but different schema name can be created without the need to change the `patterns.name` property.

## Sample Request(s)
```
"AllMagazineObjects": {
  "patterns": {
    "include": [
      "%.magazines"
    ]
  },
  "permissions": [
    {
      "role": "anonymous",
      "actions": [
        {
          "action": "*"
        }
      ]
    }
  ]
}
```
<img width="1060" height="499" alt="image" src="https://github.com/user-attachments/assets/8a8f01ae-a10c-49ba-a3fe-4881c8a2aacd" />
<img width="1075" height="649" alt="image" src="https://github.com/user-attachments/assets/6754b26e-fe24-4f26-adaa-c41c5ee6955f" />
