### PR TITLE
Add Core NuGet package authoring requirements

### DIFF
--- a/nuget/nuget_core/README.md
+++ b/nuget/nuget_core/README.md
@@ -1,0 +1,47 @@
+# Data API builder Core Library for Azure Databases
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+## About
+
+**Microsoft.DataApiBuilder.Core** is the core engine library for [Data API builder](https://learn.microsoft.com/azure/data-api-builder/) (DAB). It provides the runtime components needed to generate and execute secure REST, GraphQL endpoints and MCP tools backed by Azure and other databases.
+
+This package is intended for developers who want to embed or extend the Data API builder engine within their own .NET applications or services.
+
+## Supported Databases
+
+- Azure SQL / SQL Server
+- Azure SQL Data Warehouse
+- Azure Cosmos DB (NoSQL)
+- PostgreSQL
+- MySQL
+
+## Key Capabilities
+
+- **REST API engine** — Automatically generates CRUD endpoints (POST, GET, PUT, PATCH, DELETE) with filtering, sorting, and pagination
+- **GraphQL engine** — Generates queries and mutations with filtering, sorting, pagination, and relationship navigation
+- **MCP tool support** — Exposes DML and custom MCP tools for building SQL MCP Servers
+- **Authentication** — OAuth2/JWT and EasyAuth (Azure App Service / Static Web Apps)
+- **Authorization** — Role-based access control with item-level security via policy expressions
+- **Configuration-driven** — Define entities, permissions, and relationships in a JSON config file; no code required
+- **Multi-database** — Connect to multiple database types from a single instance
+- **Caching** — Built-in response caching with [FusionCache](https://github.com/ZiggyCreatures/FusionCache)
+
+## Installation
+
+```bash
+dotnet add package Microsoft.DataApiBuilder.Core
+```
+
+## Usage
+
+This library provides the core services and middleware used by the Data API builder runtime. Register the DAB services in your application's dependency injection container and configure them using a [DAB configuration file](https://learn.microsoft.com/azure/data-api-builder/reference-configuration).
+
+For a complete, ready-to-run experience, consider using the [`Microsoft.DataApiBuilder`](https://www.nuget.org/packages/Microsoft.DataApiBuilder) NuGet package or the [DAB CLI](https://learn.microsoft.com/azure/data-api-builder/how-to-install-cli).
+
+## Resources
+
+- [Official Documentation](https://learn.microsoft.com/azure/data-api-builder/)
+- [GitHub Repository](https://github.com/Azure/data-api-builder)
+- [Samples](https://aka.ms/dab/samples)
+- [Known Issues](https://learn.microsoft.com/azure/data-api-builder/known-issues)

--- a/nuget/nuget_core/README.md
+++ b/nuget/nuget_core/README.md
@@ -4,7 +4,7 @@
 
 ## About
 
-**Microsoft.DataApiBuilder.Core** is the core engine library for [Data API builder](https://learn.microsoft.com/azure/data-api-builder/) (DAB). It provides the runtime components needed to generate and execute secure REST, GraphQL endpoints and MCP tools backed by Azure and other databases.
+**Microsoft.DataApiBuilder.Core** is the core engine library for [Data API builder](https://learn.microsoft.com/azure/data-api-builder/) (DAB). It provides the runtime components needed to generate and execute secure REST, GraphQL endpoints and MCP tools backed by Azure SQL and other databases.
 
 This package is intended for developers who want to embed or extend the Data API builder engine within their own .NET applications or services.
 

--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -18,9 +18,9 @@
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2224253</PackageProjectUrl>
-    <PackageTags>microsoft rest graphql api azure sql mssql mysql pgsql postgresql azure-sql sqlserver nosql cosmosdb dataApiBuilder</PackageTags>
+    <PackageTags>microsoft rest graphql mcp api azure sql mssql mysql pgsql postgresql azure-sql sqlserver nosql cosmosdb dataApiBuilder</PackageTags>
     <AssemblyName>Microsoft.DataApiBuilder</AssemblyName>
-    <Description>Data API builder for Azure Databases provides modern REST and GraphQL endpoints to your Azure Databases.</Description>
+    <Description>Data API builder for Azure Databases provides modern REST, GraphQL, and MCP endpoints to your Azure Databases.</Description>
     <PackageIcon>nuget_icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -20,7 +20,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2224253</PackageProjectUrl>
     <PackageTags>microsoft rest graphql mcp api azure sql mssql mysql pgsql postgresql azure-sql sqlserver nosql cosmosdb dataApiBuilder</PackageTags>
     <AssemblyName>Microsoft.DataApiBuilder</AssemblyName>
-    <Description>Data API builder for Azure Databases provides modern REST, GraphQL, and MCP endpoints to your Azure Databases.</Description>
+    <Description>Data API builder for Azure Databases provides modern REST, GraphQL endpoints and MCP tools to your Azure Databases.</Description>
     <PackageIcon>nuget_icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -60,10 +60,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\nuget\nuget_core\README.md" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\nuget\nuget_core\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\nuget\nuget_icon.png" Pack="true" PackagePath="\" />
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="\" Condition="Exists('..\..\..\NOTICE.txt')" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
+    <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="\" Condition="Exists('..\..\..\NOTICE.txt')" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -4,7 +4,21 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <PackageId>Microsoft.DataApiBuilder.Core</PackageId>
+    <Title>Microsoft.DataApiBuilder.Core</Title>
+    <Authors>Microsoft</Authors>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2224253</PackageProjectUrl>
+    <PackageTags>microsoft rest graphql mcp api azure sql mssql mysql pgsql postgresql azure-sql sqlserver nosql cosmosdb dataApiBuilder</PackageTags>
+    <AssemblyName>Microsoft.DataApiBuilder.Core</AssemblyName>
+    <Description>Data API builder Core library for Azure Databases provides modern REST, GraphQL, and MCP endpoints to your Azure Databases.</Description>
+    <PackageIcon>nuget_icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <NoWarn>NU1603</NoWarn>
   </PropertyGroup>
 
@@ -43,6 +57,13 @@
     <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj" />
     <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj" />
     <ProjectReference Include="..\Service.GraphQLBuilder\Azure.DataApiBuilder.Service.GraphQLBuilder.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\nuget\README.md" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\nuget\nuget_icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="\" Condition="Exists('..\..\..\NOTICE.txt')" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?linkid=2224253</PackageProjectUrl>
     <PackageTags>microsoft rest graphql mcp api azure sql mssql mysql pgsql postgresql azure-sql sqlserver nosql cosmosdb dataApiBuilder</PackageTags>
     <AssemblyName>Microsoft.DataApiBuilder.Core</AssemblyName>
-    <Description>Data API builder Core library for Azure Databases provides modern REST, GraphQL, and MCP endpoints to your Azure Databases.</Description>
+    <Description>Data API builder Core library for Azure Databases provides modern REST, GraphQL endpoints and MCP tools to your Azure Databases.</Description>
     <PackageIcon>nuget_icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\nuget\README.md" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\nuget\nuget_core\README.md" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\..\nuget\nuget_icon.png" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\..\NOTICE.txt" Pack="true" PackagePath="\" Condition="Exists('..\..\..\NOTICE.txt')" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
## Why make this change?

- Resolves issue #3469

## What is this change?

- `Cli.csproj`: Changes package description and tags to include new MCP endpoint.
- `Core.csproj`: Adds authoring requirements based on the following link https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/11557/Publish-as-Microsoft?anchor=publishing-microsoft-packages-on-nuget.org

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

No tests are necessary for this change

## Sample Request(s)

N/A
