### PR TITLE
Improve Invalid GraphQL Name message

### DIFF
--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1474,7 +1474,7 @@ namespace Azure.DataApiBuilder.Core.Services
                     && IsGraphQLReservedName(entity, columnName, graphQLEnabledGlobally: runtimeConfig.IsGraphQLEnabled))
                 {
                     throw new DataApiBuilderException(
-                       message: $"The column '{columnName}' violates GraphQL name restrictions.",
+                       message: $"The column '{columnName}' from '{entityName}' violates GraphQL name restrictions.",
                        statusCode: HttpStatusCode.ServiceUnavailable,
                        subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
                 }
@@ -1584,7 +1584,8 @@ namespace Azure.DataApiBuilder.Core.Services
                         }
                     }
 
-                    return IsIntrospectionField(databaseColumnName);
+                    // Possible naming violations are if the field starts with '__' or if it contains whitespace characters.
+                    return IsIntrospectionField(databaseColumnName) || IsGraphQLNameWhiteSpace(databaseColumnName);
                 }
             }
 

--- a/src/Service.GraphQLBuilder/GraphQLNaming.cs
+++ b/src/Service.GraphQLBuilder/GraphQLNaming.cs
@@ -28,6 +28,8 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
         /// <seealso cref="https://spec.graphql.org/October2021/#sec-Names.Reserved-Names"/>
         public const string INTROSPECTION_FIELD_PREFIX = "__";
 
+        public const string INVALID_EMPTY_SPACE = " ";
+
         public const string LINKING_OBJECT_PREFIX = "linkingObject";
 
         public const string PK_QUERY_SUFFIX = "_by_pk";
@@ -94,6 +96,20 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
         public static bool IsIntrospectionField(string fieldName)
         {
             return fieldName.StartsWith(INTROSPECTION_FIELD_PREFIX, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Per GraphQL specification:
+        /// A name can only start with a letter or an underscore, and can only
+        /// contain letters, numbers, and underscores. It is not able to contain whitespaces
+        /// This helper function identifies whether the provided name contains whitespaces.
+        /// </summary>
+        /// <seealso cref="https://spec.graphql.org/October2021/#sec-Names"/>
+        /// <param name="fieldName">Field name to evaluate</param>
+        /// <returns>True/False</returns>
+        public static bool IsGraphQLNameWhiteSpace(string fieldName)
+        {
+            return fieldName.Contains(INVALID_EMPTY_SPACE, StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -5651,7 +5651,7 @@ type Planet @model(name:""PlanetAlias"") {
                     "PublisherAutoEntity", new Autoentity(
                         Patterns: new AutoentityPatterns(
                             Include: null,
-                            Exclude: new[] { "dbo.GQLmappings", "dbo.graphql_incompatible", "dbo.brokers" },
+                            Exclude: new[] { "dbo.GQLmappings", "dbo.brokers" },
                             Name: null
                         ),
                         Template: new AutoentityTemplate(


### PR DESCRIPTION
## Why make this change?

- Solves issue #3486

## What is this change?

- Changed the message in `SqlMetadataProvider` so that also shows the entity which has the invalid column
- Added new function to check if the column in an entity has whitespaces which is an invalid format, this issue was being catched by HotChocolate but it is more useful for the user if it is shown with the message in `SqlMetadataProvider`.

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

## Sample Request(s)

- Example REST and/or GraphQL request to demonstrate modifications
- Example of CLI usage to demonstrate modifications
