### PR TITLE
Allow MCP agent to override CLI and Config log levels (Agent > CLI > Config)

### DIFF
--- a/src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs
@@ -261,17 +261,26 @@ namespace Azure.DataApiBuilder.Mcp.Core
         /// <param name="root">The root JSON element of the incoming JSON-RPC request.</param>
         /// <remarks>
         /// Log level precedence (highest to lowest):
-        /// 1. CLI --LogLevel flag - cannot be overridden
-        /// 2. Config runtime.telemetry.log-level - cannot be overridden by MCP
-        /// 3. MCP logging/setLevel - only works if neither CLI nor Config explicitly set a level
-        /// 4. Default: None for MCP stdio mode (silent by default to keep stdout clean for JSON-RPC)
-        /// 
-        /// If CLI or Config set the log level, this method accepts the request but silently ignores it.
-        /// The client won't get an error, but CLI/Config wins.
-        /// 
-        /// When MCP sets a level other than "none", this also restores Console.Error to the real stderr
-        /// stream so that logs become visible (Console may have been redirected to null at startup).
-        /// It also enables MCP log notifications so logs are sent to the client via notifications/message.
+        /// 1. MCP <c>logging/setLevel</c> (Agent) - always wins, overrides CLI and Config.
+        /// 2. CLI <c>--LogLevel</c> flag.
+        /// 3. Config <c>runtime.telemetry.log-level</c>.
+        /// 4. Default: <c>None</c> for MCP stdio mode (silent by default to keep stdout clean for JSON-RPC),
+        ///    <c>Error</c> in Production, <c>Debug</c> in Development.
+        ///
+        /// Per MCP spec the response is always success (empty result object) even when the input is
+        /// an unrecognized level — in that case no side effect runs and no state changes.
+        ///
+        /// Side effects performed in order on a valid request:
+        /// 1. Toggle <see cref="IMcpLogNotificationWriter.IsEnabled"/> based on the level
+        ///    (<c>"none"</c> disables, anything else enables). This is done BEFORE
+        ///    <see cref="ILogLevelController.UpdateFromMcp"/> so the audit log line that
+        ///    <c>UpdateFromMcp</c> emits is forwarded to the agent rather than dropped.
+        /// 2. Call <see cref="ILogLevelController.UpdateFromMcp"/>, which updates the level and
+        ///    flips <see cref="ILogLevelController.IsAgentOverridden"/> so subsequent runtime-config
+        ///    hot-reloads do not clobber the agent's choice.
+        /// 3. Restore <see cref="Console.Error"/> to the real stderr stream when logging is enabled,
+        ///    in case startup redirected it to <see cref="TextWriter.Null"/> (default for
+        ///    <c>--mcp-stdio</c> or <c>--LogLevel none</c>).
         /// </remarks>
         private void HandleSetLogLevel(JsonElement? id, JsonElement root)
         {

--- a/src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs
@@ -299,8 +299,20 @@ namespace Azure.DataApiBuilder.Mcp.Core
                 return;
             }
 
-            // Determine if logging is enabled (level != "none")
-            bool isLoggingEnabled = !string.Equals(level, "none", StringComparison.OrdinalIgnoreCase);
+            // Validate the level BEFORE touching any side-effect (notification writer, stderr).
+            // "none" is the disable signal and is not a recognized MCP level; everything else
+            // must round-trip through McpLogLevelConverter so a typo can't silently turn the
+            // notification stream on while UpdateFromMcp ignores the bad value.
+            bool isDisableRequest = string.Equals(level, "none", StringComparison.OrdinalIgnoreCase);
+            bool isValidLevel = isDisableRequest || McpLogLevelConverter.TryConvertFromMcp(level, out _);
+            if (!isValidLevel)
+            {
+                // Unknown level - return success per MCP spec but make no state changes.
+                WriteResult(id, new { });
+                return;
+            }
+
+            bool isLoggingEnabled = !isDisableRequest;
 
             // Enable or disable MCP log notifications based on the requested level BEFORE updating
             // the level. Doing it in this order means the agent-override Information line emitted
@@ -312,10 +324,9 @@ namespace Azure.DataApiBuilder.Mcp.Core
                 notificationWriter.IsEnabled = isLoggingEnabled;
             }
 
-            // Attempt to update the log level.
-            // The agent always wins over CLI and Config (precedence: Agent > CLI > Config).
-            // The only reason this can return false is an unrecognized level string,
-            // in which case we still return success to the client per MCP spec.
+            // Update the log level. Validation above guarantees this returns true for non-"none"
+            // values; for "none" it returns false (no LogLevel mapping) and we just keep
+            // notifications off without touching the current level.
             bool updated = logLevelController.UpdateFromMcp(level);
 
             // Restore stderr if the agent successfully turned logging on. When `--mcp-stdio` (or

--- a/src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs
@@ -276,8 +276,8 @@ namespace Azure.DataApiBuilder.Mcp.Core
         ///    <see cref="ILogLevelController.UpdateFromMcp"/> so the audit log line that
         ///    <c>UpdateFromMcp</c> emits is forwarded to the agent rather than dropped.
         /// 2. Call <see cref="ILogLevelController.UpdateFromMcp"/>, which updates the level and
-        ///    flips <see cref="ILogLevelController.IsAgentOverridden"/> so subsequent runtime-config
-        ///    hot-reloads do not clobber the agent's choice.
+        ///    flips <see cref="ILogLevelController.IsAgentOverriding"/> so subsequent runtime-config
+        ///    hot-reloads do not overwrite the agent's choice.
         /// 3. Restore <see cref="Console.Error"/> to the real stderr stream when logging is enabled,
         ///    in case startup redirected it to <see cref="TextWriter.Null"/> (default for
         ///    <c>--mcp-stdio</c> or <c>--LogLevel none</c>).

--- a/src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs
@@ -299,33 +299,31 @@ namespace Azure.DataApiBuilder.Mcp.Core
                 return;
             }
 
-            // Attempt to update the log level
-            // If CLI or Config overrode, this returns false but we still return success to the client
-            bool updated = logLevelController.UpdateFromMcp(level);
-
             // Determine if logging is enabled (level != "none")
-            // Note: Even if CLI/Config overrode the level, we still enable notifications
-            // when the client requests logging. They'll get logs at the overridden level.
             bool isLoggingEnabled = !string.Equals(level, "none", StringComparison.OrdinalIgnoreCase);
 
-            // Only restore stderr when this MCP call actually changed the effective level.
-            // If CLI/Config overrode (updated == false), stderr is already in the correct state:
-            //   - CLI/Config level == "none": stderr was redirected to TextWriter.Null at startup
-            //     and must stay that way; restoring it would re-introduce noisy output even
-            //     though the operator explicitly asked for silence.
-            //   - CLI/Config level != "none": stderr was never redirected, so restoring is a no-op.
-            if (updated && isLoggingEnabled)
-            {
-                RestoreStderrIfNeeded();
-            }
-
-            // Enable or disable MCP log notifications based on the requested level
-            // When CLI/Config overrode, notifications are still enabled - client asked for logs,
-            // they just get them at the CLI/Config level instead of the requested level.
+            // Enable or disable MCP log notifications based on the requested level BEFORE updating
+            // the level. Doing it in this order means the agent-override Information line emitted
+            // by UpdateFromMcp is forwarded to the agent (otherwise it would be dropped because
+            // the notification writer was still disabled at the moment of emission).
             IMcpLogNotificationWriter? notificationWriter = _serviceProvider.GetService<IMcpLogNotificationWriter>();
             if (notificationWriter != null)
             {
                 notificationWriter.IsEnabled = isLoggingEnabled;
+            }
+
+            // Attempt to update the log level.
+            // The agent always wins over CLI and Config (precedence: Agent > CLI > Config).
+            // The only reason this can return false is an unrecognized level string,
+            // in which case we still return success to the client per MCP spec.
+            bool updated = logLevelController.UpdateFromMcp(level);
+
+            // Restore stderr if the agent successfully turned logging on. When `--mcp-stdio` (or
+            // `--LogLevel none`) was the startup default, stderr was redirected to TextWriter.Null;
+            // re-enable it now so subsequent logs flow.
+            if (updated && isLoggingEnabled)
+            {
+                RestoreStderrIfNeeded();
             }
 
             // Always return success (empty result object) per MCP spec

--- a/src/Cli.Tests/CustomLoggerTests.cs
+++ b/src/Cli.Tests/CustomLoggerTests.cs
@@ -23,8 +23,8 @@ public class CustomLoggerTests
     public void ResetMcpStaticState()
     {
         Cli.Utils.IsMcpStdioMode = false;
-        Cli.Utils.IsLogLevelOverriddenByCli = false;
-        Cli.Utils.IsLogLevelOverriddenByConfig = false;
+        Cli.Utils.IsCliOverriding = false;
+        Cli.Utils.IsConfigOverriding = false;
         Cli.Utils.CliLogLevel = LogLevel.Information;
         Cli.Utils.ConfigLogLevel = LogLevel.Information;
     }
@@ -114,7 +114,7 @@ public class CustomLoggerTests
     public void Mcp_CliOverride_WritesToStderrAndHonorsCliLevel()
     {
         Cli.Utils.IsMcpStdioMode = true;
-        Cli.Utils.IsLogLevelOverriddenByCli = true;
+        Cli.Utils.IsCliOverriding = true;
         Cli.Utils.CliLogLevel = LogLevel.Warning;
 
         (string stdout, string stderr) = CaptureConsole(() =>
@@ -140,7 +140,7 @@ public class CustomLoggerTests
     public void Mcp_ConfigOverride_WritesToStderrAndHonorsConfigLevel()
     {
         Cli.Utils.IsMcpStdioMode = true;
-        Cli.Utils.IsLogLevelOverriddenByConfig = true;
+        Cli.Utils.IsConfigOverriding = true;
         Cli.Utils.ConfigLogLevel = LogLevel.Information;
 
         (string stdout, string stderr) = CaptureConsole(() =>
@@ -163,9 +163,9 @@ public class CustomLoggerTests
     public void Mcp_CliOverridePrecedesConfigOverride()
     {
         Cli.Utils.IsMcpStdioMode = true;
-        Cli.Utils.IsLogLevelOverriddenByCli = true;
+        Cli.Utils.IsCliOverriding = true;
         Cli.Utils.CliLogLevel = LogLevel.Warning;
-        Cli.Utils.IsLogLevelOverriddenByConfig = true;
+        Cli.Utils.IsConfigOverriding = true;
         Cli.Utils.ConfigLogLevel = LogLevel.Information;
 
         (_, string stderr) = CaptureConsole(() =>

--- a/src/Cli.Tests/EndToEndTests.cs
+++ b/src/Cli.Tests/EndToEndTests.cs
@@ -914,17 +914,17 @@ public class EndToEndTests
         Assert.IsTrue(string.IsNullOrEmpty(engineStdOut), $"Expected no output at LogLevel {logLevelOption}, but got: {engineStdOut}");
     }
 
-    /// Validates that `dab start` correctly sets <see cref="Startup.IsLogLevelOverriddenByCli"/>
+    /// Validates that `dab start` correctly sets <see cref="Startup.IsCliOverriding"/>
     /// based on whether the --LogLevel CLI flag is provided.
     ///
-    /// When the --LogLevel flag is provided, IsLogLevelOverriddenByCli should be true.
-    /// When the --LogLevel flag is omitted (log level comes from the config file), IsLogLevelOverriddenByCli should be false.
+    /// When the --LogLevel flag is provided, IsCliOverriding should be true.
+    /// When the --LogLevel flag is omitted (log level comes from the config file), IsCliOverriding should be false.
     /// </summary>
     /// <param name="cliLogLevel">The --LogLevel CLI flag value, or null to omit the flag.</param>
-    /// <param name="expectedIsOverridden">Expected value of Startup.IsLogLevelOverriddenByCli.</param>
+    /// <param name="expectedIsOverridden">Expected value of Startup.IsCliOverriding.</param>
     [DataTestMethod]
-    [DataRow(null, false, DisplayName = "IsLogLevelOverriddenByCli is false")]
-    [DataRow(LogLevel.Error, true, DisplayName = "IsLogLevelOverriddenByCli is true")]
+    [DataRow(null, false, DisplayName = "IsCliOverriding is false")]
+    [DataRow(LogLevel.Error, true, DisplayName = "IsCliOverriding is true")]
     public async Task TestStartCommandResolvesLogLevelFromConfigOrFlag(
         LogLevel? cliLogLevel,
         bool expectedIsOverridden)
@@ -987,7 +987,7 @@ public class EndToEndTests
         // Wait for the engine to finish loading the config.
         await Task.Delay(TimeSpan.FromSeconds(5));
 
-        Assert.AreEqual(expectedIsOverridden, Startup.IsLogLevelOverriddenByCli);
+        Assert.AreEqual(expectedIsOverridden, Startup.IsCliOverriding);
     }
 
     /// <summary>

--- a/src/Cli/ConfigGenerator.cs
+++ b/src/Cli/ConfigGenerator.cs
@@ -3002,7 +3002,7 @@ namespace Cli
 
             // Reset the config-based override flag so stale state from a prior call
             // (these are static) cannot leak into the current run.
-            Utils.IsLogLevelOverriddenByConfig = false;
+            Utils.IsConfigOverriding = false;
             Utils.ConfigLogLevel = LogLevel.Information;
 
             if (options.LogLevel is not null)
@@ -3029,7 +3029,7 @@ namespace Cli
                 // when the user expressed intent via the config file rather than --LogLevel.
                 if (deserializedRuntimeConfig.HasExplicitLogLevel())
                 {
-                    Utils.IsLogLevelOverriddenByConfig = true;
+                    Utils.IsConfigOverriding = true;
                     Utils.ConfigLogLevel = minimumLogLevel;
                 }
             }

--- a/src/Cli/CustomLoggerProvider.cs
+++ b/src/Cli/CustomLoggerProvider.cs
@@ -34,9 +34,9 @@ public class CustomLoggerProvider : ILoggerProvider
         public CustomConsoleLogger(LogLevel minimumLogLevel = LogLevel.Information)
         {
             _minimumLogLevel = Cli.Utils.IsMcpStdioMode
-                ? (Cli.Utils.IsLogLevelOverriddenByCli
+                ? (Cli.Utils.IsCliOverriding
                     ? Cli.Utils.CliLogLevel
-                    : Cli.Utils.IsLogLevelOverriddenByConfig
+                    : Cli.Utils.IsConfigOverriding
                         ? Cli.Utils.ConfigLogLevel
                         : LogLevel.None)
                 : minimumLogLevel;
@@ -103,7 +103,7 @@ public class CustomLoggerProvider : ILoggerProvider
             // In that case, write to stderr to keep stdout clean for JSON-RPC.
             if (Cli.Utils.IsMcpStdioMode)
             {
-                if (!Cli.Utils.IsLogLevelOverriddenByCli && !Cli.Utils.IsLogLevelOverriddenByConfig)
+                if (!Cli.Utils.IsCliOverriding && !Cli.Utils.IsConfigOverriding)
                 {
                     return; // Suppress entirely when no explicit log level
                 }

--- a/src/Cli/Program.cs
+++ b/src/Cli/Program.cs
@@ -62,7 +62,7 @@ namespace Cli
                 }
                 else if (string.Equals(arg, "--LogLevel", StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
                 {
-                    Utils.IsLogLevelOverriddenByCli = true;
+                    Utils.IsCliOverriding = true;
                     if (Enum.TryParse<LogLevel>(args[i + 1], ignoreCase: true, out LogLevel cliLogLevel))
                     {
                         Utils.CliLogLevel = cliLogLevel;

--- a/src/Cli/Utils.cs
+++ b/src/Cli/Utils.cs
@@ -29,26 +29,27 @@ namespace Cli
         public static bool IsMcpStdioMode { get; set; }
 
         /// <summary>
-        /// When true, user explicitly set --LogLevel via CLI (even in MCP mode).
+        /// When true, the CLI is the source overriding the log level (i.e., <c>--LogLevel</c> was supplied).
         /// This allows logs to be written to stderr instead of being completely suppressed.
         /// </summary>
-        public static bool IsLogLevelOverriddenByCli { get; set; }
+        public static bool IsCliOverriding { get; set; }
 
         /// <summary>
         /// The log level specified via CLI --LogLevel flag.
-        /// Only valid when IsLogLevelOverriddenByCli is true.
+        /// Only valid when IsCliOverriding is true.
         /// </summary>
         public static LogLevel CliLogLevel { get; set; } = LogLevel.Information;
 
         /// <summary>
-        /// When true, the runtime config file explicitly set a log-level value.
+        /// When true, the runtime config is the source overriding the log level
+        /// (i.e., <c>runtime.telemetry.log-level</c> was explicitly set).
         /// This allows CLI logs to be written to stderr in MCP mode even when no --LogLevel flag was provided.
         /// </summary>
-        public static bool IsLogLevelOverriddenByConfig { get; set; }
+        public static bool IsConfigOverriding { get; set; }
 
         /// <summary>
         /// The log level specified via runtime config file's log-level setting.
-        /// Only valid when IsLogLevelOverriddenByConfig is true.
+        /// Only valid when IsConfigOverriding is true.
         /// </summary>
         public static LogLevel ConfigLogLevel { get; set; } = LogLevel.Information;
 

--- a/src/Core/Telemetry/ILogLevelController.cs
+++ b/src/Core/Telemetry/ILogLevelController.cs
@@ -11,22 +11,24 @@ namespace Azure.DataApiBuilder.Core.Telemetry
     public interface ILogLevelController
     {
         /// <summary>
-        /// Gets a value indicating whether the log level was overridden by CLI arguments.
-        /// When true, runtime-config (hot-reload) updates are ignored.
+        /// Gets a value indicating whether the CLI is the source overriding the log level
+        /// (i.e., <c>--LogLevel</c> was supplied). When true, runtime-config (hot-reload)
+        /// updates are ignored.
         /// </summary>
-        bool IsCliOverridden { get; }
+        bool IsCliOverriding { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the log level was explicitly set in the config file.
+        /// Gets a value indicating whether the runtime config is the source overriding the log
+        /// level (i.e., <c>runtime.telemetry.log-level</c> was explicitly set).
         /// </summary>
-        bool IsConfigOverridden { get; }
+        bool IsConfigOverriding { get; }
 
         /// <summary>
-        /// Gets a value indicating whether the log level has been overridden by an MCP
-        /// <c>logging/setLevel</c> request from the agent. When true, runtime-config (hot-reload)
-        /// updates are ignored so the agent's choice remains in effect.
+        /// Gets a value indicating whether the agent is the source overriding the log level via
+        /// an MCP <c>logging/setLevel</c> request. When true, runtime-config (hot-reload) updates
+        /// are ignored so the agent's choice remains in effect.
         /// </summary>
-        bool IsAgentOverridden { get; }
+        bool IsAgentOverriding { get; }
 
         /// <summary>
         /// Updates the log level from an MCP logging/setLevel request.

--- a/src/Core/Telemetry/ILogLevelController.cs
+++ b/src/Core/Telemetry/ILogLevelController.cs
@@ -12,26 +12,33 @@ namespace Azure.DataApiBuilder.Core.Telemetry
     {
         /// <summary>
         /// Gets a value indicating whether the log level was overridden by CLI arguments.
-        /// When true, MCP and config-based log level changes are ignored.
+        /// When true, runtime-config (hot-reload) updates are ignored.
         /// </summary>
         bool IsCliOverridden { get; }
 
         /// <summary>
         /// Gets a value indicating whether the log level was explicitly set in the config file.
-        /// When true along with IsCliOverridden being false, MCP log level changes are ignored.
         /// </summary>
         bool IsConfigOverridden { get; }
 
         /// <summary>
+        /// Gets a value indicating whether the log level has been overridden by an MCP
+        /// <c>logging/setLevel</c> request from the agent. When true, runtime-config (hot-reload)
+        /// updates are ignored so the agent's choice remains in effect.
+        /// </summary>
+        bool IsAgentOverridden { get; }
+
+        /// <summary>
         /// Updates the log level from an MCP logging/setLevel request.
         /// The MCP level string is mapped to the appropriate LogLevel.
-        /// Log level precedence (highest to lowest):
-        /// 1. CLI --LogLevel flag (IsCliOverridden = true)
-        /// 2. Config runtime.telemetry.log-level (IsConfigOverridden = true)
-        /// 3. MCP logging/setLevel (only works if neither CLI nor Config set a level)
+        /// Log-level precedence (highest to lowest):
+        /// 1. Agent (MCP <c>logging/setLevel</c>) — always wins.
+        /// 2. CLI <c>--LogLevel</c> flag.
+        /// 3. Config <c>runtime.telemetry.log-level</c>.
+        /// 4. Defaults.
         /// </summary>
         /// <param name="mcpLevel">The MCP log level string (e.g., "debug", "info", "warning", "error").</param>
-        /// <returns>True if the level was changed; false if CLI or Config override prevented the change.</returns>
+        /// <returns>True if the level was changed; false if the input was an unrecognized level.</returns>
         bool UpdateFromMcp(string mcpLevel);
     }
 }

--- a/src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs
+++ b/src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs
@@ -3,7 +3,9 @@
 
 #nullable enable
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Service.Telemetry;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -12,16 +14,17 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 {
     /// <summary>
     /// Unit tests for the DynamicLogLevelProvider class.
-    /// Tests the MCP logging/setLevel support.
+    /// Locks the runtime log-level precedence: Agent (MCP) > CLI > Config > defaults.
     /// </summary>
     [TestClass]
     public class DynamicLogLevelProviderTests
     {
         [DataTestMethod]
         [DataRow(LogLevel.Error, false, false, "debug", true, LogLevel.Debug, DisplayName = "Valid level change succeeds")]
-        [DataRow(LogLevel.Error, true, false, "debug", false, LogLevel.Error, DisplayName = "CLI override blocks MCP change")]
-        [DataRow(LogLevel.Warning, false, true, "debug", false, LogLevel.Warning, DisplayName = "Config override blocks MCP change")]
-        [DataRow(LogLevel.Error, false, false, "invalid", false, LogLevel.Error, DisplayName = "Invalid level returns false")]
+        [DataRow(LogLevel.Error, true, false, "debug", true, LogLevel.Debug, DisplayName = "Agent overrides CLI")]
+        [DataRow(LogLevel.Warning, false, true, "debug", true, LogLevel.Debug, DisplayName = "Agent overrides Config")]
+        [DataRow(LogLevel.Error, true, true, "debug", true, LogLevel.Debug, DisplayName = "Agent overrides CLI + Config")]
+        [DataRow(LogLevel.Error, false, false, "invalid", false, LogLevel.Error, DisplayName = "Invalid level returns false and leaves level untouched")]
         public void UpdateFromMcp_ReturnsExpectedResult(
             LogLevel initialLevel,
             bool isCliOverridden,
@@ -40,6 +43,10 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             // Assert
             Assert.AreEqual(expectedResult, result);
             Assert.AreEqual(expectedFinalLevel, provider.CurrentLogLevel);
+
+            // Successful agent updates must flip IsAgentOverridden so hot-reloads of Config
+            // don't clobber the agent's choice.
+            Assert.AreEqual(expectedResult, provider.IsAgentOverridden);
         }
 
         [TestMethod]
@@ -113,27 +120,83 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
-        /// CLI override is sticky: once the CLI flag pins the level, no number
-        /// of MCP <c>logging/setLevel</c> requests (even concurrent) may change
+        /// The agent always wins. Even when the CLI flag has pinned the level, every MCP
+        /// <c>logging/setLevel</c> call must succeed and update
         /// <see cref="DynamicLogLevelProvider.CurrentLogLevel"/>. Validates the
-        /// precedence guarantee under contention.
+        /// new precedence guarantee under contention.
         /// </summary>
         [TestMethod]
-        public void UpdateFromMcp_CliOverride_StaysStickyUnderConcurrency()
+        public void UpdateFromMcp_AgentAlwaysWins_UnderConcurrency()
         {
             // Arrange — CLI pins level to Warning.
             DynamicLogLevelProvider provider = new();
             provider.SetInitialLogLevel(LogLevel.Warning, isCliOverridden: true, isConfigOverridden: false);
 
-            // Act — flood with MCP setLevel requests trying to flip it.
+            // Act — flood with MCP setLevel requests; every one must succeed.
             Parallel.For(0, 2_000, _ =>
             {
                 bool changed = provider.UpdateFromMcp("debug");
-                Assert.IsFalse(changed, "CLI override must block all MCP changes.");
+                Assert.IsTrue(changed, "Agent must override CLI and Config.");
             });
 
-            // Assert — level never moved off Warning.
-            Assert.AreEqual(LogLevel.Warning, provider.CurrentLogLevel);
+            // Assert — final level is the agent-set Debug, and the agent flag is set.
+            Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
+            Assert.IsTrue(provider.IsAgentOverridden);
+            // CLI flag is informational and stays as set by startup; precedence is enforced
+            // via IsAgentOverridden in UpdateFromRuntimeConfig.
+            Assert.IsTrue(provider.IsCliOverridden);
+        }
+
+        /// <summary>
+        /// Hot-reloading the runtime config must not clobber an agent-set level. After the
+        /// agent moves the level via <see cref="DynamicLogLevelProvider.UpdateFromMcp"/>, a
+        /// subsequent <see cref="DynamicLogLevelProvider.UpdateFromRuntimeConfig"/> with a
+        /// different config-pinned level must be ignored.
+        /// </summary>
+        [TestMethod]
+        public void UpdateFromRuntimeConfig_RespectsAgentOverride()
+        {
+            // Arrange — start at Error (no CLI / Config override), agent then asks for Debug.
+            DynamicLogLevelProvider provider = new();
+            provider.SetInitialLogLevel(LogLevel.Error, isCliOverridden: false, isConfigOverridden: false);
+            Assert.IsTrue(provider.UpdateFromMcp("debug"));
+            Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
+
+            // Build a hot-reloaded RuntimeConfig that explicitly pins log-level to Warning.
+            RuntimeConfig hotReloadedConfig = BuildRuntimeConfigWithLogLevel(LogLevel.Warning);
+
+            // Act — the hot-reload guard must skip applying Warning because the agent already won.
+            provider.UpdateFromRuntimeConfig(hotReloadedConfig);
+
+            // Assert — agent's Debug survives.
+            Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
+            Assert.IsTrue(provider.IsAgentOverridden);
+        }
+
+        /// <summary>
+        /// Builds a minimal <see cref="RuntimeConfig"/> whose
+        /// <c>runtime.telemetry.log-level</c> dictionary explicitly pins the default level.
+        /// Used by hot-reload tests; not intended to model a complete production config.
+        /// </summary>
+        private static RuntimeConfig BuildRuntimeConfigWithLogLevel(LogLevel level)
+        {
+            TelemetryOptions telemetry = new(
+                LoggerLevel: new Dictionary<string, LogLevel?> { ["default"] = level });
+
+            RuntimeOptions runtime = new(
+                Rest: null,
+                GraphQL: null,
+                Mcp: null,
+                Host: new HostOptions(Cors: null, Authentication: null, Mode: HostMode.Production),
+                Telemetry: telemetry);
+
+            DataSource dataSource = new(DatabaseType.MSSQL, "Server=tcp:localhost,1433;", Options: null);
+
+            return new RuntimeConfig(
+                Schema: null,
+                DataSource: dataSource,
+                Entities: new RuntimeEntities(new Dictionary<string, Entity>()),
+                Runtime: runtime);
         }
     }
 }

--- a/src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs
+++ b/src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs
@@ -174,6 +174,51 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
+        /// Race regression: a runtime-config hot-reload must never overwrite an agent-set
+        /// level even when both calls execute concurrently. Without a shared lock, a
+        /// <see cref="DynamicLogLevelProvider.UpdateFromRuntimeConfig"/> caller could pass
+        /// the <c>IsAgentOverridden</c> guard before <see cref="DynamicLogLevelProvider.UpdateFromMcp"/>
+        /// flips the flag, then write the config-pinned level on top of the agent's choice.
+        /// </summary>
+        [TestMethod]
+        public void UpdateFromMcp_BeatsConcurrentConfigHotReload()
+        {
+            // Arrange — start at Error, then let the agent pin Debug so the flag is set.
+            DynamicLogLevelProvider provider = new();
+            provider.SetInitialLogLevel(LogLevel.Error, isCliOverridden: false, isConfigOverridden: false);
+            Assert.IsTrue(provider.UpdateFromMcp("debug"));
+
+            RuntimeConfig warningConfig = BuildRuntimeConfigWithLogLevel(LogLevel.Warning);
+
+            // Act — flood both update paths in parallel. Every interleaving must end
+            // with the agent's Debug because IsAgentOverridden is sticky-true.
+            const int iterations = 2_000;
+            Task hotReloads = Task.Run(() =>
+            {
+                for (int i = 0; i < iterations; i++)
+                {
+                    provider.UpdateFromRuntimeConfig(warningConfig);
+                }
+            });
+
+            Task agentSetLevels = Task.Run(() =>
+            {
+                for (int i = 0; i < iterations; i++)
+                {
+                    Assert.IsTrue(provider.UpdateFromMcp("debug"));
+                }
+            });
+
+            Task.WaitAll(new[] { hotReloads, agentSetLevels }, millisecondsTimeout: 5_000);
+            Assert.IsTrue(hotReloads.IsCompletedSuccessfully, $"Hot-reload task failed: {hotReloads.Exception?.Message}");
+            Assert.IsTrue(agentSetLevels.IsCompletedSuccessfully, $"Agent task failed: {agentSetLevels.Exception?.Message}");
+
+            // Assert — the agent's level survives every race.
+            Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
+            Assert.IsTrue(provider.IsAgentOverridden);
+        }
+
+        /// <summary>
         /// Builds a minimal <see cref="RuntimeConfig"/> whose
         /// <c>runtime.telemetry.log-level</c> dictionary explicitly pins the default level.
         /// Used by hot-reload tests; not intended to model a complete production config.

--- a/src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs
+++ b/src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs
@@ -27,15 +27,15 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         [DataRow(LogLevel.Error, false, false, "invalid", false, LogLevel.Error, DisplayName = "Invalid level returns false and leaves level untouched")]
         public void UpdateFromMcp_ReturnsExpectedResult(
             LogLevel initialLevel,
-            bool isCliOverridden,
-            bool isConfigOverridden,
+            bool isCliOverriding,
+            bool isConfigOverriding,
             string mcpLevel,
             bool expectedResult,
             LogLevel expectedFinalLevel)
         {
             // Arrange
             DynamicLogLevelProvider provider = new();
-            provider.SetInitialLogLevel(initialLevel, isCliOverridden, isConfigOverridden);
+            provider.SetInitialLogLevel(initialLevel, isCliOverriding, isConfigOverriding);
 
             // Act
             bool result = provider.UpdateFromMcp(mcpLevel);
@@ -44,9 +44,9 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             Assert.AreEqual(expectedResult, result);
             Assert.AreEqual(expectedFinalLevel, provider.CurrentLogLevel);
 
-            // Successful agent updates must flip IsAgentOverridden so hot-reloads of Config
-            // don't clobber the agent's choice.
-            Assert.AreEqual(expectedResult, provider.IsAgentOverridden);
+            // Successful agent updates must flip IsAgentOverriding so hot-reloads of Config
+            // don't overwrite the agent's choice.
+            Assert.AreEqual(expectedResult, provider.IsAgentOverriding);
         }
 
         [TestMethod]
@@ -54,7 +54,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             // Arrange
             DynamicLogLevelProvider provider = new();
-            provider.SetInitialLogLevel(LogLevel.Warning, isCliOverridden: false);
+            provider.SetInitialLogLevel(LogLevel.Warning, isCliOverriding: false);
 
             // Assert - logs at or above Warning should pass
             Assert.IsTrue(provider.ShouldLog(LogLevel.Warning));
@@ -76,7 +76,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             // Arrange
             DynamicLogLevelProvider provider = new();
-            provider.SetInitialLogLevel(LogLevel.Information, isCliOverridden: false, isConfigOverridden: false);
+            provider.SetInitialLogLevel(LogLevel.Information, isCliOverriding: false, isConfigOverriding: false);
 
             const int iterations = 5_000;
 
@@ -130,7 +130,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             // Arrange — CLI pins level to Warning.
             DynamicLogLevelProvider provider = new();
-            provider.SetInitialLogLevel(LogLevel.Warning, isCliOverridden: true, isConfigOverridden: false);
+            provider.SetInitialLogLevel(LogLevel.Warning, isCliOverriding: true, isConfigOverriding: false);
 
             // Act — flood with MCP setLevel requests; every one must succeed.
             Parallel.For(0, 2_000, _ =>
@@ -141,14 +141,14 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             // Assert — final level is the agent-set Debug, and the agent flag is set.
             Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
-            Assert.IsTrue(provider.IsAgentOverridden);
+            Assert.IsTrue(provider.IsAgentOverriding);
             // CLI flag is informational and stays as set by startup; precedence is enforced
-            // via IsAgentOverridden in UpdateFromRuntimeConfig.
-            Assert.IsTrue(provider.IsCliOverridden);
+            // via IsAgentOverriding in UpdateFromRuntimeConfig.
+            Assert.IsTrue(provider.IsCliOverriding);
         }
 
         /// <summary>
-        /// Hot-reloading the runtime config must not clobber an agent-set level. After the
+        /// Hot-reloading the runtime config must not overwrite an agent-set level. After the
         /// agent moves the level via <see cref="DynamicLogLevelProvider.UpdateFromMcp"/>, a
         /// subsequent <see cref="DynamicLogLevelProvider.UpdateFromRuntimeConfig"/> with a
         /// different config-pinned level must be ignored.
@@ -158,7 +158,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             // Arrange — start at Error (no CLI / Config override), agent then asks for Debug.
             DynamicLogLevelProvider provider = new();
-            provider.SetInitialLogLevel(LogLevel.Error, isCliOverridden: false, isConfigOverridden: false);
+            provider.SetInitialLogLevel(LogLevel.Error, isCliOverriding: false, isConfigOverriding: false);
             Assert.IsTrue(provider.UpdateFromMcp("debug"));
             Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
 
@@ -170,52 +170,33 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             // Assert — agent's Debug survives.
             Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
-            Assert.IsTrue(provider.IsAgentOverridden);
+            Assert.IsTrue(provider.IsAgentOverriding);
         }
 
         /// <summary>
-        /// Race regression: a runtime-config hot-reload must never overwrite an agent-set
-        /// level even when both calls execute concurrently. Without a shared lock, a
-        /// <see cref="DynamicLogLevelProvider.UpdateFromRuntimeConfig"/> caller could pass
-        /// the <c>IsAgentOverridden</c> guard before <see cref="DynamicLogLevelProvider.UpdateFromMcp"/>
-        /// flips the flag, then write the config-pinned level on top of the agent's choice.
+        /// Hot-reloading the runtime config must not overwrite a CLI-set level. The CLI
+        /// <c>--LogLevel</c> flag is the operator's deliberate startup choice, so a
+        /// subsequent <see cref="DynamicLogLevelProvider.UpdateFromRuntimeConfig"/> with a
+        /// different config-pinned level must be ignored.
         /// </summary>
         [TestMethod]
-        public void UpdateFromMcp_BeatsConcurrentConfigHotReload()
+        public void UpdateFromRuntimeConfig_RespectsCliOverride()
         {
-            // Arrange — start at Error, then let the agent pin Debug so the flag is set.
+            // Arrange — CLI pins level to Warning at startup; no agent override.
             DynamicLogLevelProvider provider = new();
-            provider.SetInitialLogLevel(LogLevel.Error, isCliOverridden: false, isConfigOverridden: false);
-            Assert.IsTrue(provider.UpdateFromMcp("debug"));
+            provider.SetInitialLogLevel(LogLevel.Warning, isCliOverriding: true, isConfigOverriding: false);
 
-            RuntimeConfig warningConfig = BuildRuntimeConfigWithLogLevel(LogLevel.Warning);
+            // Build a hot-reloaded RuntimeConfig that explicitly pins log-level to Information.
+            RuntimeConfig hotReloadedConfig = BuildRuntimeConfigWithLogLevel(LogLevel.Information);
 
-            // Act — flood both update paths in parallel. Every interleaving must end
-            // with the agent's Debug because IsAgentOverridden is sticky-true.
-            const int iterations = 2_000;
-            Task hotReloads = Task.Run(() =>
-            {
-                for (int i = 0; i < iterations; i++)
-                {
-                    provider.UpdateFromRuntimeConfig(warningConfig);
-                }
-            });
+            // Act — the hot-reload guard must skip applying Information because CLI already won.
+            provider.UpdateFromRuntimeConfig(hotReloadedConfig);
 
-            Task agentSetLevels = Task.Run(() =>
-            {
-                for (int i = 0; i < iterations; i++)
-                {
-                    Assert.IsTrue(provider.UpdateFromMcp("debug"));
-                }
-            });
-
-            Task.WaitAll(new[] { hotReloads, agentSetLevels }, millisecondsTimeout: 5_000);
-            Assert.IsTrue(hotReloads.IsCompletedSuccessfully, $"Hot-reload task failed: {hotReloads.Exception?.Message}");
-            Assert.IsTrue(agentSetLevels.IsCompletedSuccessfully, $"Agent task failed: {agentSetLevels.Exception?.Message}");
-
-            // Assert — the agent's level survives every race.
-            Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
-            Assert.IsTrue(provider.IsAgentOverridden);
+            // Assert — CLI's Warning survives, and IsConfigOverriding is not flipped because
+            // the hot-reload short-circuited before reading the config's log level.
+            Assert.AreEqual(LogLevel.Warning, provider.CurrentLogLevel);
+            Assert.IsTrue(provider.IsCliOverriding);
+            Assert.IsFalse(provider.IsConfigOverriding);
         }
 
         /// <summary>

--- a/src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs
+++ b/src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs
@@ -200,6 +200,39 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
+        /// Successive agent calls must each succeed and overwrite the previous agent-set level
+        /// — covering the full range from <see cref="LogLevel.Debug"/> (most verbose) to
+        /// <see cref="LogLevel.Critical"/> (most restrictive). This locks in the sticky
+        /// behavior of <see cref="DynamicLogLevelProvider.IsAgentOverriding"/>: once the agent
+        /// has taken control, every subsequent agent call wins, the flag stays set, and no
+        /// hot-reload of the runtime config can sneak in between calls to silently flip the
+        /// level back. The MCP spec doesn't define a "none" level, so the strictest valid
+        /// MCP level <c>"emergency"</c> (which maps to <see cref="LogLevel.Critical"/>) is
+        /// used as the high-end of the range.
+        /// </summary>
+        [TestMethod]
+        public void UpdateFromMcp_SuccessiveCalls_OverwriteAndKeepAgentOverriding()
+        {
+            // Arrange — start in the "no overrides" state.
+            DynamicLogLevelProvider provider = new();
+            provider.SetInitialLogLevel(LogLevel.Information, isCliOverriding: false, isConfigOverriding: false);
+
+            // Act + Assert — Debug → Critical (verbose to most-restrictive).
+            Assert.IsTrue(provider.UpdateFromMcp("debug"));
+            Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
+            Assert.IsTrue(provider.IsAgentOverriding);
+
+            Assert.IsTrue(provider.UpdateFromMcp("emergency"));
+            Assert.AreEqual(LogLevel.Critical, provider.CurrentLogLevel);
+            Assert.IsTrue(provider.IsAgentOverriding, "Agent override must remain sticky across successive agent calls.");
+
+            // Act + Assert — Critical → Debug (reverse direction).
+            Assert.IsTrue(provider.UpdateFromMcp("debug"));
+            Assert.AreEqual(LogLevel.Debug, provider.CurrentLogLevel);
+            Assert.IsTrue(provider.IsAgentOverriding);
+        }
+
+        /// <summary>
         /// Builds a minimal <see cref="RuntimeConfig"/> whose
         /// <c>runtime.telemetry.log-level</c> dictionary explicitly pins the default level.
         /// Used by hot-reload tests; not intended to model a complete production config.

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -212,7 +212,7 @@ namespace Azure.DataApiBuilder.Service
                     // LogLevelProvider was already initialized in StartEngine before CreateHostBuilder.
                     // Use the already-set values to avoid re-parsing args.
                     Startup.MinimumLogLevel = LogLevelProvider.CurrentLogLevel;
-                    Startup.IsLogLevelOverriddenByCli = LogLevelProvider.IsCliOverriding;
+                    Startup.IsCliOverriding = LogLevelProvider.IsCliOverriding;
                     ILoggerFactory loggerFactory = GetLoggerFactoryForLogLevel(Startup.MinimumLogLevel, stdio: runMcpStdio);
                     ILogger<Startup> startupLogger = loggerFactory.CreateLogger<Startup>();
                     DisableHttpsRedirectionIfNeeded(args);

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -98,9 +98,9 @@ namespace Azure.DataApiBuilder.Service
                 // Initialize log level EARLY, before building the host.
                 // This ensures logging filters are effective during the entire host build process.
                 // For MCP mode, we also read the config file early to check for log level override.
-                LogLevel initialLogLevel = GetLogLevelFromCommandLineArgsOrConfig(args, runMcpStdio, out bool isCliOverridden, out bool isConfigOverridden);
+                LogLevel initialLogLevel = GetLogLevelFromCommandLineArgsOrConfig(args, runMcpStdio, out bool isCliOverriding, out bool isConfigOverriding);
 
-                LogLevelProvider.SetInitialLogLevel(initialLogLevel, isCliOverridden, isConfigOverridden);
+                LogLevelProvider.SetInitialLogLevel(initialLogLevel, isCliOverriding, isConfigOverriding);
 
                 // For MCP stdio mode, redirect Console.Out to keep stdout clean for JSON-RPC.
                 // MCP SDK uses Console.OpenStandardOutput() which gets the real stdout, unaffected by this redirect.
@@ -212,7 +212,7 @@ namespace Azure.DataApiBuilder.Service
                     // LogLevelProvider was already initialized in StartEngine before CreateHostBuilder.
                     // Use the already-set values to avoid re-parsing args.
                     Startup.MinimumLogLevel = LogLevelProvider.CurrentLogLevel;
-                    Startup.IsLogLevelOverriddenByCli = LogLevelProvider.IsCliOverridden;
+                    Startup.IsLogLevelOverriddenByCli = LogLevelProvider.IsCliOverriding;
                     ILoggerFactory loggerFactory = GetLoggerFactoryForLogLevel(Startup.MinimumLogLevel, stdio: runMcpStdio);
                     ILogger<Startup> startupLogger = loggerFactory.CreateLogger<Startup>();
                     DisableHttpsRedirectionIfNeeded(args);
@@ -229,13 +229,13 @@ namespace Azure.DataApiBuilder.Service
         /// </summary>
         /// <param name="args">Array that may contain log level information.</param>
         /// <param name="runMcpStdio">Whether running in MCP stdio mode.</param>
-        /// <param name="isLogLevelOverridenByCli">Sets if log level is found in the args from CLI.</param>
-        /// <param name="isConfigOverridden">Sets if log level is found in the config file (MCP mode only).</param>
+        /// <param name="isCliOverriding">Set to true if log level is supplied via CLI args.</param>
+        /// <param name="isConfigOverriding">Set to true if log level is supplied via the config file (MCP mode only).</param>
         /// <returns>Appropriate log level.</returns>
-        private static LogLevel GetLogLevelFromCommandLineArgsOrConfig(string[] args, bool runMcpStdio, out bool isLogLevelOverridenByCli, out bool isConfigOverridden)
+        private static LogLevel GetLogLevelFromCommandLineArgsOrConfig(string[] args, bool runMcpStdio, out bool isCliOverriding, out bool isConfigOverriding)
         {
             LogLevel logLevel;
-            isConfigOverridden = false;
+            isConfigOverriding = false;
 
             // Check if --LogLevel was explicitly specified via CLI (case-insensitive parsing)
             int logLevelIndex = Array.FindIndex(args, a => string.Equals(a, "--LogLevel", StringComparison.OrdinalIgnoreCase));
@@ -245,12 +245,12 @@ namespace Azure.DataApiBuilder.Service
             {
                 // User explicitly set --LogLevel via CLI (highest priority)
                 logLevel = cliLogLevel;
-                isLogLevelOverridenByCli = true;
+                isCliOverriding = true;
             }
             else if (runMcpStdio)
             {
                 // MCP stdio mode without explicit --LogLevel: check config for log level (second priority)
-                isLogLevelOverridenByCli = false;
+                isCliOverriding = false;
                 logLevel = LogLevel.None; // Default if config doesn't have log level
 
                 // Find --config or --ConfigFileName argument, or use default dab-config.json
@@ -264,7 +264,7 @@ namespace Azure.DataApiBuilder.Service
                 if (!string.IsNullOrWhiteSpace(configFilePath) && TryGetLogLevelFromConfig(configFilePath, out LogLevel configLogLevel))
                 {
                     logLevel = configLogLevel;
-                    isConfigOverridden = true;
+                    isConfigOverriding = true;
                 }
             }
             else
@@ -274,7 +274,7 @@ namespace Azure.DataApiBuilder.Service
                 // adjust based on config: Debug for Development mode, Error for Production mode.
                 // This initial value is used before config is loaded.
                 logLevel = LogLevel.Error;
-                isLogLevelOverridenByCli = false;
+                isCliOverriding = false;
             }
 
             if (logLevel is > LogLevel.None or < LogLevel.Trace)

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -80,7 +80,7 @@ namespace Azure.DataApiBuilder.Service
     {
         public static LogLevel MinimumLogLevel = LogLevel.Error;
 
-        public static bool IsLogLevelOverriddenByCli;
+        public static bool IsCliOverriding;
 
         public static AzureLogAnalyticsCustomLogCollector CustomLogCollector = new();
         public static ApplicationInsightsOptions AppInsightsOptions = new();
@@ -972,7 +972,7 @@ namespace Azure.DataApiBuilder.Service
         /// </summary>
         public static ILoggerFactory CreateLoggerFactoryForHostedAndNonHostedScenario(IServiceProvider serviceProvider, LogLevelInitializer logLevelInitializer)
         {
-            if (!IsLogLevelOverriddenByCli)
+            if (!IsCliOverriding)
             {
                 // If the log level is not overridden by command line arguments specified through CLI,
                 // attempt to get the runtime config to determine the loglevel based on host.mode.

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -761,6 +761,13 @@ namespace Azure.DataApiBuilder.Service
                     DynamicLogLevelProvider logLevelProvider = app.ApplicationServices.GetRequiredService<DynamicLogLevelProvider>();
                     logLevelProvider.UpdateFromRuntimeConfig(runtimeConfig);
 
+                    // Wire a logger so agent (MCP) overrides surface in the standard logging pipeline.
+                    ILoggerFactory? logLevelLoggerFactory = app.ApplicationServices.GetService<ILoggerFactory>();
+                    if (logLevelLoggerFactory is not null)
+                    {
+                        logLevelProvider.Logger = logLevelLoggerFactory.CreateLogger<DynamicLogLevelProvider>();
+                    }
+
                     // Configure Telemetry
                     // TODO: Issue #3239. Refactor this methods so that they are all called before creating the new logger factory.
                     ConfigureApplicationInsightsTelemetry(app, runtimeConfig, logLevelInit);
@@ -795,6 +802,13 @@ namespace Azure.DataApiBuilder.Service
                         RuntimeConfig runtimeConfig = runtimeConfigProvider.GetConfig();
                         DynamicLogLevelProvider logLevelProvider = app.ApplicationServices.GetRequiredService<DynamicLogLevelProvider>();
                         logLevelProvider.UpdateFromRuntimeConfig(runtimeConfig);
+
+                        // Wire a logger so agent (MCP) overrides surface in the standard logging pipeline.
+                        ILoggerFactory? logLevelLoggerFactory = app.ApplicationServices.GetService<ILoggerFactory>();
+                        if (logLevelLoggerFactory is not null)
+                        {
+                            logLevelProvider.Logger = logLevelLoggerFactory.CreateLogger<DynamicLogLevelProvider>();
+                        }
 
                         //Flush all logs that were buffered before setting the LogLevel.
                         // Important: All logs set before this point should use _logBuffer.

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -750,6 +750,17 @@ namespace Azure.DataApiBuilder.Service
             bool isRuntimeReady = false;
             RuntimeConfig? runtimeConfig = null;
 
+            // Wire a logger on the DynamicLogLevelProvider as soon as ILoggerFactory is available
+            // — ahead of any config-load branch — so an early MCP logging/setLevel call (which can
+            // arrive before runtime config in the late-configured path) still surfaces its audit
+            // log line through the standard logging pipeline.
+            DynamicLogLevelProvider? logLevelProviderForAudit = app.ApplicationServices.GetService<DynamicLogLevelProvider>();
+            ILoggerFactory? earlyLoggerFactory = app.ApplicationServices.GetService<ILoggerFactory>();
+            if (logLevelProviderForAudit is not null && earlyLoggerFactory is not null)
+            {
+                logLevelProviderForAudit.Logger = earlyLoggerFactory.CreateLogger<DynamicLogLevelProvider>();
+            }
+
             try
             {
                 if (runtimeConfigProvider.TryGetConfig(out runtimeConfig))
@@ -760,13 +771,6 @@ namespace Azure.DataApiBuilder.Service
                     // Set LogLevel based on RuntimeConfig
                     DynamicLogLevelProvider logLevelProvider = app.ApplicationServices.GetRequiredService<DynamicLogLevelProvider>();
                     logLevelProvider.UpdateFromRuntimeConfig(runtimeConfig);
-
-                    // Wire a logger so agent (MCP) overrides surface in the standard logging pipeline.
-                    ILoggerFactory? logLevelLoggerFactory = app.ApplicationServices.GetService<ILoggerFactory>();
-                    if (logLevelLoggerFactory is not null)
-                    {
-                        logLevelProvider.Logger = logLevelLoggerFactory.CreateLogger<DynamicLogLevelProvider>();
-                    }
 
                     // Configure Telemetry
                     // TODO: Issue #3239. Refactor this methods so that they are all called before creating the new logger factory.
@@ -802,13 +806,6 @@ namespace Azure.DataApiBuilder.Service
                         RuntimeConfig runtimeConfig = runtimeConfigProvider.GetConfig();
                         DynamicLogLevelProvider logLevelProvider = app.ApplicationServices.GetRequiredService<DynamicLogLevelProvider>();
                         logLevelProvider.UpdateFromRuntimeConfig(runtimeConfig);
-
-                        // Wire a logger so agent (MCP) overrides surface in the standard logging pipeline.
-                        ILoggerFactory? logLevelLoggerFactory = app.ApplicationServices.GetService<ILoggerFactory>();
-                        if (logLevelLoggerFactory is not null)
-                        {
-                            logLevelProvider.Logger = logLevelLoggerFactory.CreateLogger<DynamicLogLevelProvider>();
-                        }
 
                         //Flush all logs that were buffered before setting the LogLevel.
                         // Important: All logs set before this point should use _logBuffer.

--- a/src/Service/Telemetry/DynamicLogLevelProvider.cs
+++ b/src/Service/Telemetry/DynamicLogLevelProvider.cs
@@ -104,7 +104,14 @@ namespace Azure.DataApiBuilder.Service.Telemetry
 
             // Surface the override so operators can see the agent moved the level.
             // Logged outside the lock so logger sinks can't deadlock with state mutations.
-            Logger?.LogInformation(
+            //
+            // Emit at max(Information, newLevel) so the audit line is never filtered by the
+            // freshly-applied level. Without this, an agent that raised the floor to Warning
+            // / Error / Critical would never see its own confirmation message because the
+            // Information line would fall below the new minimum.
+            LogLevel auditLevel = logLevel > LogLevel.Information ? logLevel : LogLevel.Information;
+            Logger?.Log(
+                auditLevel,
                 "Log level updated to {LogLevel} via MCP logging/setLevel (agent override).",
                 logLevel);
 

--- a/src/Service/Telemetry/DynamicLogLevelProvider.cs
+++ b/src/Service/Telemetry/DynamicLogLevelProvider.cs
@@ -6,6 +6,7 @@ namespace Azure.DataApiBuilder.Service.Telemetry
 {
     /// <summary>
     /// Provides dynamic log level control with support for CLI override, runtime config, and MCP.
+    /// Precedence (highest to lowest): Agent (MCP) > CLI > Config > defaults.
     /// </summary>
     public class DynamicLogLevelProvider : ILogLevelController
     {
@@ -15,10 +16,20 @@ namespace Azure.DataApiBuilder.Service.Telemetry
 
         public bool IsConfigOverridden { get; private set; }
 
+        public bool IsAgentOverridden { get; private set; }
+
         /// <summary>
-        /// Sets the initial log level, which can be passed from the CLI or the Config file,
-        /// if not specified, it defaults to None if flag --mcp-stdio, to Error if in Production mode or Debug if in Development mode.
-        /// Also sets whether the log level was overridden by the CLI, which will prevent updates from runtime config changes. 
+        /// Optional logger used to emit an Information line when the agent successfully overrides
+        /// the log level. Wired by host startup once the logging pipeline is available; safe to
+        /// leave unset (e.g. in unit tests).
+        /// </summary>
+        public ILogger? Logger { get; set; }
+
+        /// <summary>
+        /// Sets the initial log level from CLI args or the config file. When not specified the level
+        /// defaults to None for <c>--mcp-stdio</c>, Error in Production, or Debug in Development.
+        /// The CLI/Config flags drive runtime-config hot-reload behavior; they no longer block
+        /// agent (MCP) overrides — see <see cref="UpdateFromMcp"/>.
         /// </summary>
         /// <param name="logLevel">The initial log level to set.</param>
         /// <param name="isCliOverridden">Indicates whether the log level was overridden by the CLI.</param>
@@ -31,63 +42,54 @@ namespace Azure.DataApiBuilder.Service.Telemetry
         }
 
         /// <summary>
-        /// Updates the current log level based on the runtime configuration, unless it was overridden by the CLI.
+        /// Updates the current log level from a runtime-config (hot-reload) change.
+        /// Skipped when the CLI or the agent has already overridden, so neither is clobbered.
         /// </summary>
         /// <param name="runtimeConfig">The runtime configuration to use for updating the log level.</param>
         /// <param name="loggerFilter">Optional logger filter to apply when determining the log level.</param>
         public void UpdateFromRuntimeConfig(RuntimeConfig runtimeConfig, string? loggerFilter = null)
         {
-            // Only update if CLI didn't override
-            if (!IsCliOverridden)
+            // Agent override and CLI override both win over a hot-reloaded Config value.
+            if (IsAgentOverridden || IsCliOverridden)
             {
-                if (loggerFilter is null)
-                {
-                    loggerFilter = string.Empty;
-                }
-
-                CurrentLogLevel = runtimeConfig.GetConfiguredLogLevel(loggerFilter);
-
-                // Track if config explicitly set a non-null log level value.
-                // This ensures MCP logging/setLevel is only blocked when config
-                // actually pins a log level, not just when the dictionary exists.
-                IsConfigOverridden = runtimeConfig.HasExplicitLogLevel();
+                return;
             }
+
+            if (loggerFilter is null)
+            {
+                loggerFilter = string.Empty;
+            }
+
+            CurrentLogLevel = runtimeConfig.GetConfiguredLogLevel(loggerFilter);
+
+            // Track if config explicitly set a non-null log level value, so callers can
+            // distinguish a config-pinned level from defaults.
+            IsConfigOverridden = runtimeConfig.HasExplicitLogLevel();
         }
 
-        /// Updates the log level from an MCP logging/setLevel request.
-        /// Precedence (highest to lowest):
-        /// 1. CLI --LogLevel flag (IsCliOverridden = true)
-        /// 2. Config runtime.telemetry.log-level (IsConfigOverridden = true)
-        /// 3. MCP logging/setLevel
-        /// 
-        /// If CLI or Config overrode, this method accepts the request silently but does not change the level.
+        /// <summary>
+        /// Updates the log level from an MCP <c>logging/setLevel</c> request.
+        /// The agent always wins over CLI and Config; only an unrecognized level is rejected.
         /// </summary>
         /// <param name="mcpLevel">The MCP log level string (e.g., "debug", "info", "warning", "error").</param>
-        /// <returns>True if the level was changed; false if CLI/Config override prevented the change or level was invalid.</returns>
+        /// <returns>True if the level was changed; false only if the input was an unrecognized level.</returns>
         public bool UpdateFromMcp(string mcpLevel)
         {
-            // If CLI overrode the log level, accept the request but don't change anything.
-            // This prevents MCP clients from getting errors, but CLI wins.
-            if (IsCliOverridden)
+            if (!McpLogLevelConverter.TryConvertFromMcp(mcpLevel, out LogLevel logLevel))
             {
+                // Unknown level - don't change, but don't fail the MCP call either.
                 return false;
             }
 
-            // If Config explicitly set the log level, accept the request but don't change anything.
-            // Config has second precedence after CLI.
-            if (IsConfigOverridden)
-            {
-                return false;
-            }
+            CurrentLogLevel = logLevel;
+            IsAgentOverridden = true;
 
-            if (McpLogLevelConverter.TryConvertFromMcp(mcpLevel, out LogLevel logLevel))
-            {
-                CurrentLogLevel = logLevel;
-                return true;
-            }
+            // Surface the override so operators can see the agent moved the level.
+            Logger?.LogInformation(
+                "Log level updated to {LogLevel} via MCP logging/setLevel (agent override).",
+                logLevel);
 
-            // Unknown level - don't change, but don't fail either
-            return false;
+            return true;
         }
 
         /// <summary>

--- a/src/Service/Telemetry/DynamicLogLevelProvider.cs
+++ b/src/Service/Telemetry/DynamicLogLevelProvider.cs
@@ -19,11 +19,11 @@ namespace Azure.DataApiBuilder.Service.Telemetry
 
         public LogLevel CurrentLogLevel { get; private set; }
 
-        public bool IsCliOverridden { get; private set; }
+        public bool IsCliOverriding { get; private set; }
 
-        public bool IsConfigOverridden { get; private set; }
+        public bool IsConfigOverriding { get; private set; }
 
-        public bool IsAgentOverridden { get; private set; }
+        public bool IsAgentOverriding { get; private set; }
 
         /// <summary>
         /// Optional logger used to emit an Information line when the agent successfully overrides
@@ -39,21 +39,21 @@ namespace Azure.DataApiBuilder.Service.Telemetry
         /// agent (MCP) overrides — see <see cref="UpdateFromMcp"/>.
         /// </summary>
         /// <param name="logLevel">The initial log level to set.</param>
-        /// <param name="isCliOverridden">Indicates whether the log level was overridden by the CLI.</param>
-        /// <param name="isConfigOverridden">Indicates whether the log level was overridden by the runtime config.</param>
-        public void SetInitialLogLevel(LogLevel logLevel = LogLevel.Error, bool isCliOverridden = false, bool isConfigOverridden = false)
+        /// <param name="isCliOverriding">Indicates whether the CLI is overriding the log level.</param>
+        /// <param name="isConfigOverriding">Indicates whether the runtime config is overriding the log level.</param>
+        public void SetInitialLogLevel(LogLevel logLevel = LogLevel.Error, bool isCliOverriding = false, bool isConfigOverriding = false)
         {
             lock (_stateLock)
             {
                 CurrentLogLevel = logLevel;
-                IsCliOverridden = isCliOverridden;
-                IsConfigOverridden = isConfigOverridden;
+                IsCliOverriding = isCliOverriding;
+                IsConfigOverriding = isConfigOverriding;
             }
         }
 
         /// <summary>
         /// Updates the current log level from a runtime-config (hot-reload) change.
-        /// Skipped when the CLI or the agent has already overridden, so neither is clobbered.
+        /// Skipped when the CLI or the agent has already overridden, so neither is overwritten.
         /// </summary>
         /// <param name="runtimeConfig">The runtime configuration to use for updating the log level.</param>
         /// <param name="loggerFilter">Optional logger filter to apply when determining the log level.</param>
@@ -64,7 +64,7 @@ namespace Azure.DataApiBuilder.Service.Telemetry
                 // Agent override and CLI override both win over a hot-reloaded Config value.
                 // The check + assignment must be inside the lock so a concurrent UpdateFromMcp
                 // cannot slip in between the guard and the write.
-                if (IsAgentOverridden || IsCliOverridden)
+                if (IsAgentOverriding || IsCliOverriding)
                 {
                     return;
                 }
@@ -78,7 +78,7 @@ namespace Azure.DataApiBuilder.Service.Telemetry
 
                 // Track if config explicitly set a non-null log level value, so callers can
                 // distinguish a config-pinned level from defaults.
-                IsConfigOverridden = runtimeConfig.HasExplicitLogLevel();
+                IsConfigOverriding = runtimeConfig.HasExplicitLogLevel();
             }
         }
 
@@ -99,19 +99,15 @@ namespace Azure.DataApiBuilder.Service.Telemetry
             lock (_stateLock)
             {
                 CurrentLogLevel = logLevel;
-                IsAgentOverridden = true;
+                IsAgentOverriding = true;
             }
 
             // Surface the override so operators can see the agent moved the level.
             // Logged outside the lock so logger sinks can't deadlock with state mutations.
-            //
-            // Emit at max(Information, newLevel) so the audit line is never filtered by the
-            // freshly-applied level. Without this, an agent that raised the floor to Warning
-            // / Error / Critical would never see its own confirmation message because the
-            // Information line would fall below the new minimum.
-            LogLevel auditLevel = logLevel > LogLevel.Information ? logLevel : LogLevel.Information;
-            Logger?.Log(
-                auditLevel,
+            // Emitted at Information and subject to the operator's configured filter, like
+            // any other log line — the JSON-RPC request/response itself is the protocol-level
+            // audit, so there's no need to bypass the filter here.
+            Logger?.LogInformation(
                 "Log level updated to {LogLevel} via MCP logging/setLevel (agent override).",
                 logLevel);
 

--- a/src/Service/Telemetry/DynamicLogLevelProvider.cs
+++ b/src/Service/Telemetry/DynamicLogLevelProvider.cs
@@ -10,6 +10,13 @@ namespace Azure.DataApiBuilder.Service.Telemetry
     /// </summary>
     public class DynamicLogLevelProvider : ILogLevelController
     {
+        /// <summary>
+        /// Guards mutations of <see cref="CurrentLogLevel"/> and the override flags so
+        /// concurrent <see cref="UpdateFromMcp"/> and <see cref="UpdateFromRuntimeConfig"/>
+        /// calls cannot interleave and break the Agent &gt; CLI &gt; Config precedence.
+        /// </summary>
+        private readonly object _stateLock = new();
+
         public LogLevel CurrentLogLevel { get; private set; }
 
         public bool IsCliOverridden { get; private set; }
@@ -36,9 +43,12 @@ namespace Azure.DataApiBuilder.Service.Telemetry
         /// <param name="isConfigOverridden">Indicates whether the log level was overridden by the runtime config.</param>
         public void SetInitialLogLevel(LogLevel logLevel = LogLevel.Error, bool isCliOverridden = false, bool isConfigOverridden = false)
         {
-            CurrentLogLevel = logLevel;
-            IsCliOverridden = isCliOverridden;
-            IsConfigOverridden = isConfigOverridden;
+            lock (_stateLock)
+            {
+                CurrentLogLevel = logLevel;
+                IsCliOverridden = isCliOverridden;
+                IsConfigOverridden = isConfigOverridden;
+            }
         }
 
         /// <summary>
@@ -49,22 +59,27 @@ namespace Azure.DataApiBuilder.Service.Telemetry
         /// <param name="loggerFilter">Optional logger filter to apply when determining the log level.</param>
         public void UpdateFromRuntimeConfig(RuntimeConfig runtimeConfig, string? loggerFilter = null)
         {
-            // Agent override and CLI override both win over a hot-reloaded Config value.
-            if (IsAgentOverridden || IsCliOverridden)
+            lock (_stateLock)
             {
-                return;
+                // Agent override and CLI override both win over a hot-reloaded Config value.
+                // The check + assignment must be inside the lock so a concurrent UpdateFromMcp
+                // cannot slip in between the guard and the write.
+                if (IsAgentOverridden || IsCliOverridden)
+                {
+                    return;
+                }
+
+                if (loggerFilter is null)
+                {
+                    loggerFilter = string.Empty;
+                }
+
+                CurrentLogLevel = runtimeConfig.GetConfiguredLogLevel(loggerFilter);
+
+                // Track if config explicitly set a non-null log level value, so callers can
+                // distinguish a config-pinned level from defaults.
+                IsConfigOverridden = runtimeConfig.HasExplicitLogLevel();
             }
-
-            if (loggerFilter is null)
-            {
-                loggerFilter = string.Empty;
-            }
-
-            CurrentLogLevel = runtimeConfig.GetConfiguredLogLevel(loggerFilter);
-
-            // Track if config explicitly set a non-null log level value, so callers can
-            // distinguish a config-pinned level from defaults.
-            IsConfigOverridden = runtimeConfig.HasExplicitLogLevel();
         }
 
         /// <summary>
@@ -81,10 +96,14 @@ namespace Azure.DataApiBuilder.Service.Telemetry
                 return false;
             }
 
-            CurrentLogLevel = logLevel;
-            IsAgentOverridden = true;
+            lock (_stateLock)
+            {
+                CurrentLogLevel = logLevel;
+                IsAgentOverridden = true;
+            }
 
             // Surface the override so operators can see the agent moved the level.
+            // Logged outside the lock so logger sinks can't deadlock with state mutations.
             Logger?.LogInformation(
                 "Log level updated to {LogLevel} via MCP logging/setLevel (agent override).",
                 logLevel);


### PR DESCRIPTION
## Why make this change?

Closes #3533— *Log-level precedence should be Agent > CLI > Config; MCP `logging/setLevel` is silently ignored when CLI/Config set a level.*

The runtime today implements **CLI > Config > Agent**: once `--LogLevel` is passed or `runtime.telemetry.log-level` is set, the agent's request silently no-ops. There is no way for an agent to dial verbosity up or down at runtime, which defeats the purpose of MCP `logging/setLevel`.

The team locked the corrected precedence on 5/1 : **Agent > CLI > Config > defaults**. The agent must always be able to override; CLI still beats Config when the agent doesn't speak up; defaults (Production = Error, Development = Debug, `--mcp-stdio` = None) are unchanged.

## What is this change?

[`DynamicLogLevelProvider`](src/Service/Telemetry/DynamicLogLevelProvider.cs) is the single chokepoint for all log-level updates. The fix:

- `UpdateFromMcp` no longer rejects when CLI or Config has set a level. It updates the level, flips a new `IsAgentOverriding` flag, and emits an `Information` audit log ("Log level updated to {Level} via MCP logging/setLevel (agent override).").
- `UpdateFromRuntimeConfig` is guarded so a config hot-reload won't overwrite an Agent- or CLI-set level.
- [`ILogLevelController`](src/Core/Telemetry/ILogLevelController.cs) gains `IsAgentOverriding` and updated XML docs.
- [`Startup.cs`](src/Service/Startup.cs) wires a logger on the provider once `ILoggerFactory` exists, so the audit log reaches the standard pipeline.
- [`McpStdioServer.HandleSetLevel`](src/Azure.DataApiBuilder.Mcp/Core/McpStdioServer.cs) enables the MCP notification writer **before** calling `UpdateFromMcp` so the audit log surfaces to the agent.

CLI > Config, default levels, and the `--mcp-stdio` default of `None` are unchanged.

## How was this tested?

- [ ] Integration Tests
- [x] Unit Tests
- [x] Manual end-to-end test against live SQL Server with the MCP Inspector

### Unit tests

Added 1 new test and updated existing ones in [`DynamicLogLevelProviderTests`](src/Service.Tests/UnitTests/DynamicLogLevelProviderTests.cs) to lock Agent > CLI > Config under both single-call and concurrent paths. All 9 tests pass.

### Manual end-to-end test

Started the engine with `--mcp-stdio --LogLevel Error` and drove it from the MCP Inspector against a live SQL Server.

| # | What | How | Result |
| --- | --- | --- | --- |
| 1 | Agent sets level to debug | Send `logging/setLevel { level: "debug" }` | Success response ✅ |
| 2 | Audit log surfaces | Watch MCP notifications | Info notification with override message received ✅ |
| 3 | Debug logs flow despite `--LogLevel Error` | Trigger activity (e.g. `tools/list`) | Debug notifications received ✅ |

Also spot-checked HTTP mode: Config-only, CLI-over-Config, and Config-alone all behave as before.

## Sample Request(s)

### MCP `logging/setLevel` from the agent

Request:

```json
{
  "jsonrpc": "2.0",
  "id": 2,
  "method": "logging/setLevel",
  "params": { "level": "debug" }
}
```

Response:

```json
{ "jsonrpc": "2.0", "id": 2, "result": {} }
```

Followed by the new visibility notification:

```json
{
  "jsonrpc": "2.0",
  "method": "notifications/message",
  "params": {
    "level": "info",
    "logger": "Azure.DataApiBuilder.Service.Telemetry.DynamicLogLevelProvider",
    "data": "Log level updated to Debug via MCP logging/setLevel (agent override)."
  }
}
```

### CLI usage (precedence still works as expected)

```bash
# Agent can override even when CLI pins the level:
dab start --mcp-stdio --LogLevel Error
# → agent sends logging/setLevel debug → debug logs flow

# CLI still beats Config when no agent is involved:
dab start --LogLevel Warning --config dab-config.json   # config has log-level: Information
# → only Warning and above appear

# Config alone, no CLI, no agent — unchanged:
dab start --config dab-config.json                      # config has log-level: Information
# → info: lines visible, debug: filtered out
```
