### PR TITLE
Add column-level authorization check for GraphQL orderBy arguments

### DIFF
--- a/src/Config/DataApiBuilderException.cs
+++ b/src/Config/DataApiBuilderException.cs
@@ -18,6 +18,7 @@ public class DataApiBuilderException : Exception
     public const string GRAPHQL_FILTER_FIELD_AUTHZ_FAILURE = "Access forbidden to a field referenced in the filter.";
     public const string AUTHORIZATION_FAILURE = "Authorization Failure: Access Not Allowed.";
     public const string GRAPHQL_MUTATION_FIELD_AUTHZ_FAILURE = "Unauthorized due to one or more fields in this mutation.";
+    public const string GRAPHQL_ORDERBY_FIELD_AUTHZ_FAILURE = "Access forbidden to a field referenced in the orderBy argument.";
     public const string GRAPHQL_GROUPBY_FIELD_AUTHZ_FAILURE = "Access forbidden to field '{0}' referenced in the groupBy argument.";
     public const string GRAPHQL_AGGREGATION_FIELD_AUTHZ_FAILURE = "Access forbidden to field '{0}' referenced in the aggregation function '{1}'.";
     public const string OBO_IDENTITY_CLAIMS_MISSING = "User-delegated authentication failed: Neither 'oid' nor 'sub' claim found in the access token.";

--- a/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -1142,6 +1142,21 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                         subStatusCode: DataApiBuilderException.SubStatusCodes.UnexpectedError);
                 }
 
+                // Validate that the current role has read access to the column referenced in orderBy.
+                // Without this check, protected column values could leak through the pagination endCursor.
+                string roleName = Authorization.AuthorizationResolver.GetRoleOfGraphQLRequest(_ctx);
+                if (!AuthorizationResolver.AreColumnsAllowedForOperation(
+                        entityName: EntityName,
+                        roleName: roleName,
+                        operation: EntityActionOperation.Read,
+                        columns: new[] { backingColumnName }))
+                {
+                    throw new DataApiBuilderException(
+                        message: DataApiBuilderException.GRAPHQL_ORDERBY_FIELD_AUTHZ_FAILURE,
+                        statusCode: HttpStatusCode.Forbidden,
+                        subStatusCode: DataApiBuilderException.SubStatusCodes.AuthorizationCheckFailed);
+                }
+
                 // Validate that the orderBy field is present in the groupBy fields if it's a groupBy query
                 if (isGroupByQuery && !GroupByMetadata.Fields.ContainsKey(backingColumnName))
                 {

--- a/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -1144,12 +1144,14 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
                 // Validate that the current role has read access to the column referenced in orderBy.
                 // Without this check, protected column values could leak through the pagination endCursor.
+                // Pass the exposed field name (fieldName), not the backing column name, since
+                // AreColumnsAllowedForOperation resolves exposed names to backing columns internally.
                 string roleName = Authorization.AuthorizationResolver.GetRoleOfGraphQLRequest(_ctx);
                 if (!AuthorizationResolver.AreColumnsAllowedForOperation(
                         entityName: EntityName,
                         roleName: roleName,
                         operation: EntityActionOperation.Read,
-                        columns: new[] { backingColumnName }))
+                        columns: new[] { fieldName }))
                 {
                     throw new DataApiBuilderException(
                         message: DataApiBuilderException.GRAPHQL_ORDERBY_FIELD_AUTHZ_FAILURE,

--- a/src/Service.Tests/SqlTests/GraphQLPaginationTests/GraphQLPaginationTestBase.cs
+++ b/src/Service.Tests/SqlTests/GraphQLPaginationTests/GraphQLPaginationTestBase.cs
@@ -1268,6 +1268,51 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLPaginationTests
             SqlTestHelper.TestForErrorInGraphQLResponse(result.ToString(), statusCode: $"{DataApiBuilderException.SubStatusCodes.BadRequest}");
         }
 
+        /// <summary>
+        /// Validates column-level authorization on orderBy arguments.
+        /// Without this check, protected column values leak through the base64-encoded endCursor
+        /// returned in pagination responses.
+        /// Book entity has publisher_id excluded for role test_role_with_excluded_fields on read.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("publisher_id", true, DataApiBuilderException.GRAPHQL_ORDERBY_FIELD_AUTHZ_FAILURE,
+            DisplayName = "Excluded column in orderBy, AuthZ failure")]
+        [DataRow("title", false, "",
+            DisplayName = "Allowed column in orderBy, no AuthZ error")]
+        public async Task TestOrderByColumnAuthorization(string orderByColumn, bool expectsError, string errorMessageFragment)
+        {
+            string graphQLQueryName = "books";
+            string graphQLQuery = @"{
+                books(first: 1 orderBy: {" + orderByColumn + @": ASC}) {
+                    items {
+                        id
+                        title
+                    }
+                    endCursor
+                    hasNextPage
+                }
+            }";
+
+            JsonElement result = await ExecuteGraphQLRequestAsync(
+                graphQLQuery,
+                graphQLQueryName,
+                isAuthenticated: true,
+                clientRoleHeader: "test_role_with_excluded_fields",
+                expectsError: expectsError);
+
+            if (expectsError)
+            {
+                SqlTestHelper.TestForErrorInGraphQLResponse(
+                    result.ToString(),
+                    message: errorMessageFragment,
+                    statusCode: $"{DataApiBuilderException.SubStatusCodes.AuthorizationCheckFailed}");
+            }
+            else
+            {
+                Assert.IsTrue(result.GetProperty("items").GetArrayLength() > 0);
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## Why make this change?

- Column-level authorization was not enforced on GraphQL `orderBy` arguments, allowing protected column values to leak through the base64-encoded `endCursor` in pagination responses.
- The filter path (`GQLFilterParser.Parse`) and groupBy path already enforce column-level authorization, but `ProcessGqlOrderByArg` did not.

## What is this change?

- Adds an `AreColumnsAllowedForOperation` check in `SqlQueryStructure.ProcessGqlOrderByArg` after resolving the backing column name, mirroring the existing check in `GQLFilterParser.Parse`.
- Adds a new `GRAPHQL_ORDERBY_FIELD_AUTHZ_FAILURE` error constant.
- Returns `403 Forbidden` with `AuthorizationCheckFailed` when a role attempts to use an excluded column in `orderBy`.

### Behaviour

Previously (before the fix):

```
# Request as role "test_role_with_excluded_fields" (publisher_id is excluded)

# 1. Direct projection — correctly blocked
{ books { items { publisher_id } } }
# 403: "AUTH_NOT_AUTHENTICATED"

# 2. Filter on excluded column — correctly blocked
{ books(filter: { publisher_id: { eq: 1234 } }) { items { id } } }
# 403: "Access forbidden to a field referenced in the filter."

# 3. OrderBy on excluded column — NOT blocked, leaks data
{ books(first: 1, orderBy: { publisher_id: ASC }) { items { id title } endCursor hasNextPage } }
# 200 OK
# endCursor: "W3siRW50aXR5TmFtZSI6IkJvb2siLCJGaWVsZE5hbWUiOiJwdWJsaXNoZXJfaWQiLCJGaWVsZFZhbHVlIjoxMjM0LC4uLn1d"
# base64-decode → [{"EntityName":"Book","FieldName":"publisher_id","FieldValue":1234,...}]
#                                                                   ^^^^^^^^^^^^^
#                                                          protected value leaked in plaintext
```

Now (after fix)

```
# 3. OrderBy on excluded column — now blocked
{ books(first: 1, orderBy: { publisher_id: ASC }) { items { id title } endCursor hasNextPage } }
# 403: "Access forbidden to a field referenced in the orderBy argument."
```

## How was this tested?

- [ ] Integration Tests
- [x] Unit Tests

## Sample Request(s)

NA
