### PR TITLE
Cherry-pick: Add column-level authorization check for GraphQL orderBy arguments

### DIFF
--- a/src/Config/DataApiBuilderException.cs
+++ b/src/Config/DataApiBuilderException.cs
@@ -18,6 +18,7 @@ public class DataApiBuilderException : Exception
     public const string GRAPHQL_FILTER_FIELD_AUTHZ_FAILURE = "Access forbidden to a field referenced in the filter.";
     public const string AUTHORIZATION_FAILURE = "Authorization Failure: Access Not Allowed.";
     public const string GRAPHQL_MUTATION_FIELD_AUTHZ_FAILURE = "Unauthorized due to one or more fields in this mutation.";
+    public const string GRAPHQL_ORDERBY_FIELD_AUTHZ_FAILURE = "Access forbidden to a field referenced in the orderBy argument.";
     public const string GRAPHQL_GROUPBY_FIELD_AUTHZ_FAILURE = "Access forbidden to field '{0}' referenced in the groupBy argument.";
     public const string GRAPHQL_AGGREGATION_FIELD_AUTHZ_FAILURE = "Access forbidden to field '{0}' referenced in the aggregation function '{1}'.";
     public const string OBO_IDENTITY_CLAIMS_MISSING = "User-delegated authentication failed: Neither 'oid' nor 'sub' claim found in the access token.";

--- a/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlQueryStructure.cs
@@ -1142,6 +1142,23 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                         subStatusCode: DataApiBuilderException.SubStatusCodes.UnexpectedError);
                 }
 
+                // Validate that the current role has read access to the column referenced in orderBy.
+                // Without this check, protected column values could leak through the pagination endCursor.
+                // Pass the exposed field name (fieldName), not the backing column name, since
+                // AreColumnsAllowedForOperation resolves exposed names to backing columns internally.
+                string roleName = Authorization.AuthorizationResolver.GetRoleOfGraphQLRequest(_ctx);
+                if (!AuthorizationResolver.AreColumnsAllowedForOperation(
+                        entityName: EntityName,
+                        roleName: roleName,
+                        operation: EntityActionOperation.Read,
+                        columns: new[] { fieldName }))
+                {
+                    throw new DataApiBuilderException(
+                        message: DataApiBuilderException.GRAPHQL_ORDERBY_FIELD_AUTHZ_FAILURE,
+                        statusCode: HttpStatusCode.Forbidden,
+                        subStatusCode: DataApiBuilderException.SubStatusCodes.AuthorizationCheckFailed);
+                }
+
                 // Validate that the orderBy field is present in the groupBy fields if it's a groupBy query
                 if (isGroupByQuery && !GroupByMetadata.Fields.ContainsKey(backingColumnName))
                 {

--- a/src/Service.Tests/SqlTests/GraphQLPaginationTests/GraphQLPaginationTestBase.cs
+++ b/src/Service.Tests/SqlTests/GraphQLPaginationTests/GraphQLPaginationTestBase.cs
@@ -1268,6 +1268,51 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLPaginationTests
             SqlTestHelper.TestForErrorInGraphQLResponse(result.ToString(), statusCode: $"{DataApiBuilderException.SubStatusCodes.BadRequest}");
         }
 
+        /// <summary>
+        /// Validates column-level authorization on orderBy arguments.
+        /// Without this check, protected column values leak through the base64-encoded endCursor
+        /// returned in pagination responses.
+        /// Book entity has publisher_id excluded for role test_role_with_excluded_fields on read.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("publisher_id", true, DataApiBuilderException.GRAPHQL_ORDERBY_FIELD_AUTHZ_FAILURE,
+            DisplayName = "Excluded column in orderBy, AuthZ failure")]
+        [DataRow("title", false, "",
+            DisplayName = "Allowed column in orderBy, no AuthZ error")]
+        public async Task TestOrderByColumnAuthorization(string orderByColumn, bool expectsError, string errorMessageFragment)
+        {
+            string graphQLQueryName = "books";
+            string graphQLQuery = @"{
+                books(first: 1 orderBy: {" + orderByColumn + @": ASC}) {
+                    items {
+                        id
+                        title
+                    }
+                    endCursor
+                    hasNextPage
+                }
+            }";
+
+            JsonElement result = await ExecuteGraphQLRequestAsync(
+                graphQLQuery,
+                graphQLQueryName,
+                isAuthenticated: true,
+                clientRoleHeader: "test_role_with_excluded_fields",
+                expectsError: expectsError);
+
+            if (expectsError)
+            {
+                SqlTestHelper.TestForErrorInGraphQLResponse(
+                    result.ToString(),
+                    message: errorMessageFragment,
+                    statusCode: $"{DataApiBuilderException.SubStatusCodes.AuthorizationCheckFailed}");
+            }
+            else
+            {
+                Assert.IsTrue(result.GetProperty("items").GetArrayLength() > 0);
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
- Cherry-pick of #3553 to release/2.0

This contains the fix for the issue related to GraphQL orderby not restricting unauthorized columns.