### PR TITLE
DynamicCustomTool: Align tool input schema with DB metadata at runtime

### DIFF
--- a/src/Azure.DataApiBuilder.Mcp/Core/DynamicCustomTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/DynamicCustomTool.cs
@@ -81,6 +81,7 @@ namespace Azure.DataApiBuilder.Mcp.Core
         /// <param name="serviceProvider">The application service provider with initialized metadata providers.</param>
         public void InitializeMetadata(IServiceProvider serviceProvider)
         {
+            ArgumentNullException.ThrowIfNull(serviceProvider);
             _cachedInputSchema = BuildInputSchemaFromDbMetadata(serviceProvider);
         }
 
@@ -453,10 +454,11 @@ namespace Azure.DataApiBuilder.Mcp.Core
 
         /// <summary>
         /// Builds a description string for a parameter using DB metadata.
+        /// Uses ParameterDefinition.Description when available, falling back to generic text.
         /// </summary>
         private static string BuildParameterDescription(string paramName, ParameterDefinition paramDef)
         {
-            string description = $"Parameter {paramName}";
+            string description = paramDef.Description ?? $"Parameter {paramName}";
             if (paramDef.HasConfigDefault)
             {
                 description += $" (default: {paramDef.ConfigDefaultValue})";

--- a/src/Azure.DataApiBuilder.Mcp/Core/DynamicCustomTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/DynamicCustomTool.cs
@@ -39,6 +39,7 @@ namespace Azure.DataApiBuilder.Mcp.Core
     public class DynamicCustomTool : IMcpTool
     {
         private readonly Entity _entity;
+        private JsonElement? _cachedInputSchema;
 
         /// <summary>
         /// Initializes a new instance of DynamicCustomTool.
@@ -70,6 +71,18 @@ namespace Azure.DataApiBuilder.Mcp.Core
         /// Gets the entity name associated with this custom tool.
         /// </summary>
         public string EntityName { get; }
+
+        /// <summary>
+        /// Initializes the tool's input schema using DB metadata from the service provider.
+        /// Called after DI initialization to enrich the tool schema with DB-discovered parameters
+        /// and type information that aren't available at construction time.
+        /// Falls back silently to config-based schema if DB metadata is unavailable.
+        /// </summary>
+        /// <param name="serviceProvider">The application service provider with initialized metadata providers.</param>
+        public void InitializeMetadata(IServiceProvider serviceProvider)
+        {
+            _cachedInputSchema = BuildInputSchemaFromDbMetadata(serviceProvider);
+        }
 
         /// <summary>
         /// Gets the metadata for this custom tool, including name, description, and input schema.
@@ -291,9 +304,87 @@ namespace Azure.DataApiBuilder.Mcp.Core
         }
 
         /// <summary>
-        /// Builds the input schema for the tool based on entity parameters.
+        /// Builds the input schema for the tool. Returns cached DB-metadata-based schema
+        /// if available (set by InitializeMetadata), otherwise falls back to config-based schema.
         /// </summary>
         private JsonElement BuildInputSchema()
+        {
+            if (_cachedInputSchema.HasValue)
+            {
+                return _cachedInputSchema.Value;
+            }
+
+            return BuildInputSchemaFromConfig();
+        }
+
+        /// <summary>
+        /// Builds the input schema from DB metadata (StoredProcedureDefinition.Parameters).
+        /// Returns null if metadata cannot be resolved (caller should fall back to config-based schema).
+        /// </summary>
+        private JsonElement? BuildInputSchemaFromDbMetadata(IServiceProvider serviceProvider)
+        {
+            RuntimeConfigProvider? configProvider = serviceProvider.GetService<RuntimeConfigProvider>();
+            if (configProvider is null)
+            {
+                return null;
+            }
+
+            RuntimeConfig config = configProvider.GetConfig();
+
+            if (!McpMetadataHelper.TryResolveMetadata(
+                    EntityName,
+                    config,
+                    serviceProvider,
+                    out _,
+                    out DatabaseObject dbObject,
+                    out _,
+                    out _))
+            {
+                return null;
+            }
+
+            if (dbObject is not DatabaseStoredProcedure storedProcedure)
+            {
+                return null;
+            }
+
+            StoredProcedureDefinition spDefinition = storedProcedure.StoredProcedureDefinition;
+            if (spDefinition.Parameters is null || spDefinition.Parameters.Count == 0)
+            {
+                // Zero-param SP: return empty properties schema
+                return JsonSerializer.SerializeToElement(new Dictionary<string, object>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object>()
+                });
+            }
+
+            Dictionary<string, object> properties = new();
+            foreach ((string paramName, ParameterDefinition paramDef) in spDefinition.Parameters)
+            {
+                Dictionary<string, object> paramSchema = new()
+                {
+                    ["type"] = MapSystemTypeToJsonSchemaType(paramDef.SystemType),
+                    ["description"] = BuildParameterDescription(paramName, paramDef)
+                };
+
+                properties[paramName] = paramSchema;
+            }
+
+            Dictionary<string, object> schema = new()
+            {
+                ["type"] = "object",
+                ["properties"] = properties
+            };
+
+            return JsonSerializer.SerializeToElement(schema);
+        }
+
+        /// <summary>
+        /// Builds the input schema from config-side ParameterMetadata.
+        /// Used as fallback when DB metadata is not available.
+        /// </summary>
+        private JsonElement BuildInputSchemaFromConfig()
         {
             Dictionary<string, object> schema = new()
             {
@@ -307,9 +398,6 @@ namespace Azure.DataApiBuilder.Mcp.Core
 
                 foreach (ParameterMetadata param in _entity.Source.Parameters)
                 {
-                    // Note: Parameter type information is not available in ParameterMetadata,
-                    // so we allow multiple JSON types to match the behavior of GetParameterValue
-                    // that handles string, number, boolean, and null values.
                     properties[param.Name] = new Dictionary<string, object>
                     {
                         ["type"] = new[] { "string", "number", "boolean", "null" },
@@ -319,6 +407,62 @@ namespace Azure.DataApiBuilder.Mcp.Core
             }
 
             return JsonSerializer.SerializeToElement(schema);
+        }
+
+        /// <summary>
+        /// Maps a .NET System.Type to the appropriate JSON Schema type string.
+        /// </summary>
+        private static object MapSystemTypeToJsonSchemaType(Type? systemType)
+        {
+            if (systemType is null)
+            {
+                return new[] { "string", "number", "boolean", "null" };
+            }
+
+            // Handle nullable types
+            Type underlyingType = Nullable.GetUnderlyingType(systemType) ?? systemType;
+
+            if (underlyingType == typeof(int) || underlyingType == typeof(long) ||
+                underlyingType == typeof(short) || underlyingType == typeof(byte) ||
+                underlyingType == typeof(sbyte) || underlyingType == typeof(uint) ||
+                underlyingType == typeof(ulong) || underlyingType == typeof(ushort))
+            {
+                return "integer";
+            }
+
+            if (underlyingType == typeof(float) || underlyingType == typeof(double) ||
+                underlyingType == typeof(decimal))
+            {
+                return "number";
+            }
+
+            if (underlyingType == typeof(bool))
+            {
+                return "boolean";
+            }
+
+            if (underlyingType == typeof(string) || underlyingType == typeof(Guid) ||
+                underlyingType == typeof(DateTime) || underlyingType == typeof(DateTimeOffset))
+            {
+                return "string";
+            }
+
+            // Default: permissive multi-type
+            return new[] { "string", "number", "boolean", "null" };
+        }
+
+        /// <summary>
+        /// Builds a description string for a parameter using DB metadata.
+        /// </summary>
+        private static string BuildParameterDescription(string paramName, ParameterDefinition paramDef)
+        {
+            string description = $"Parameter {paramName}";
+            if (paramDef.HasConfigDefault)
+            {
+                description += $" (default: {paramDef.ConfigDefaultValue})";
+            }
+
+            return description;
         }
 
         /// <summary>

--- a/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistry.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistry.cs
@@ -78,5 +78,25 @@ namespace Azure.DataApiBuilder.Mcp.Core
         {
             return _tools.TryGetValue(toolName, out tool);
         }
+
+        /// <summary>
+        /// Initializes and registers all MCP tools, enriching custom tools with DB metadata schemas.
+        /// Shared by both HTTP hosted-service and stdio startup paths.
+        /// </summary>
+        public static void InitializeAndRegisterTools(
+            IEnumerable<IMcpTool> tools,
+            McpToolRegistry registry,
+            IServiceProvider serviceProvider)
+        {
+            foreach (IMcpTool tool in tools)
+            {
+                if (tool is DynamicCustomTool customTool)
+                {
+                    customTool.InitializeMetadata(serviceProvider);
+                }
+
+                registry.RegisterTool(tool);
+            }
+        }
     }
 }

--- a/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistryInitializer.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistryInitializer.cs
@@ -27,6 +27,13 @@ namespace Azure.DataApiBuilder.Mcp.Core
             IEnumerable<IMcpTool> tools = _serviceProvider.GetServices<IMcpTool>();
             foreach (IMcpTool tool in tools)
             {
+                // Initialize DB-metadata-based schema for custom tools before registration,
+                // so GetToolMetadata() returns the enriched schema from the start.
+                if (tool is DynamicCustomTool customTool)
+                {
+                    customTool.InitializeMetadata(_serviceProvider);
+                }
+
                 _toolRegistry.RegisterTool(tool);
             }
 

--- a/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistryInitializer.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistryInitializer.cs
@@ -23,20 +23,8 @@ namespace Azure.DataApiBuilder.Mcp.Core
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            // Register all IMcpTool implementations
             IEnumerable<IMcpTool> tools = _serviceProvider.GetServices<IMcpTool>();
-            foreach (IMcpTool tool in tools)
-            {
-                // Initialize DB-metadata-based schema for custom tools before registration,
-                // so GetToolMetadata() returns the enriched schema from the start.
-                if (tool is DynamicCustomTool customTool)
-                {
-                    customTool.InitializeMetadata(_serviceProvider);
-                }
-
-                _toolRegistry.RegisterTool(tool);
-            }
-
+            McpToolRegistry.InitializeAndRegisterTools(tools, _toolRegistry, _serviceProvider);
             return Task.CompletedTask;
         }
 

--- a/src/Service.Tests/Mcp/DynamicCustomToolMsSqlIntegrationTests.cs
+++ b/src/Service.Tests/Mcp/DynamicCustomToolMsSqlIntegrationTests.cs
@@ -121,6 +121,80 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
             StringAssert.Contains(content, paramName);
         }
 
+        #region Schema Alignment Integration Tests
+
+        /// <summary>
+        /// Validates that InitializeMetadata maps DB parameter types to JSON Schema types.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("GetBook", "id", "integer", DisplayName = "int param maps to integer")]
+        [DataRow("InsertBook", "title", "string", DisplayName = "varchar param maps to string")]
+        [DataRow("InsertBook", "publisher_id", "integer", DisplayName = "int param maps to integer (multi-param SP)")]
+        public void InitializeMetadata_SchemaReflectsDbParameterTypes(string entityName, string paramName, string expectedType)
+        {
+            IServiceProvider serviceProvider = BuildServiceProvider();
+            RuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<RuntimeConfigProvider>();
+            Entity entity = configProvider.GetConfig().Entities[entityName];
+
+            DynamicCustomTool tool = new(entityName, entity);
+            tool.InitializeMetadata(serviceProvider);
+
+            JsonElement properties = tool.GetToolMetadata().InputSchema.GetProperty("properties");
+
+            Assert.IsTrue(properties.TryGetProperty(paramName, out JsonElement paramProp),
+                $"Schema should contain '{paramName}' property.");
+            Assert.AreEqual(expectedType, paramProp.GetProperty("type").GetString(),
+                $"'{paramName}' should map to JSON Schema type '{expectedType}'.");
+        }
+
+        /// <summary>
+        /// Validates that zero-param SP produces an empty properties object.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_ZeroParamSP_HasEmptyProperties()
+        {
+            IServiceProvider serviceProvider = BuildServiceProvider();
+            RuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<RuntimeConfigProvider>();
+            Entity entity = configProvider.GetConfig().Entities["GetBooks"];
+
+            DynamicCustomTool tool = new("GetBooks", entity);
+            tool.InitializeMetadata(serviceProvider);
+
+            JsonElement properties = tool.GetToolMetadata().InputSchema.GetProperty("properties");
+
+            int paramCount = 0;
+            foreach (JsonProperty _ in properties.EnumerateObject())
+            {
+                paramCount++;
+            }
+
+            Assert.AreEqual(0, paramCount, "Zero-param SP should produce empty properties.");
+        }
+
+        /// <summary>
+        /// Validates that config default values appear in parameter descriptions.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("InsertBook", "title", "randomX", DisplayName = "title description includes default 'randomX'")]
+        [DataRow("InsertBook", "publisher_id", "1234", DisplayName = "publisher_id description includes default '1234'")]
+        public void InitializeMetadata_DescriptionIncludesConfigDefaults(string entityName, string paramName, string expectedDefault)
+        {
+            IServiceProvider serviceProvider = BuildServiceProvider();
+            RuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<RuntimeConfigProvider>();
+            Entity entity = configProvider.GetConfig().Entities[entityName];
+
+            DynamicCustomTool tool = new(entityName, entity);
+            tool.InitializeMetadata(serviceProvider);
+
+            JsonElement properties = tool.GetToolMetadata().InputSchema.GetProperty("properties");
+            string description = properties.GetProperty(paramName).GetProperty("description").GetString()!;
+
+            StringAssert.Contains(description, expectedDefault,
+                $"'{paramName}' description should mention config default '{expectedDefault}'.");
+        }
+
+        #endregion
+
         /// <summary>
         /// Executes a DynamicCustomTool for the given entity using the shared test fixture.
         /// </summary>

--- a/src/Service.Tests/Mcp/DynamicCustomToolTests.cs
+++ b/src/Service.Tests/Mcp/DynamicCustomToolTests.cs
@@ -733,8 +733,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
         /// </summary>
         private static JsonElement ParseSchemaProperties(ModelContextProtocol.Protocol.Tool metadata)
         {
-            JsonDocument schemaObj = JsonDocument.Parse(metadata.InputSchema.GetRawText());
-            return schemaObj.RootElement.GetProperty("properties");
+            return metadata.InputSchema.GetProperty("properties");
         }
 
         /// <summary>

--- a/src/Service.Tests/Mcp/DynamicCustomToolTests.cs
+++ b/src/Service.Tests/Mcp/DynamicCustomToolTests.cs
@@ -537,5 +537,272 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
                 Mcp: new EntityMcpOptions(customToolEnabled: true, dmlToolsEnabled: null)
             );
         }
+
+        #region Schema Alignment Tests (DB Metadata)
+
+        /// <summary>
+        /// After InitializeMetadata is called with valid DB metadata,
+        /// GetToolMetadata returns a schema with typed parameters from SP definition.
+        /// </summary>
+        [TestMethod]
+        public void GetToolMetadata_UsesDbMetadata_WhenInitialized()
+        {
+            // Arrange
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new() { SystemType = typeof(int) },
+                ["name"] = new() { SystemType = typeof(string) }
+            };
+
+            // Act
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert
+            Assert.AreEqual("integer", props.GetProperty("id").GetProperty("type").GetString());
+            Assert.AreEqual("string", props.GetProperty("name").GetProperty("type").GetString());
+        }
+
+        /// <summary>
+        /// When InitializeMetadata cannot resolve DB metadata, tool falls back to config schema.
+        /// </summary>
+        [TestMethod]
+        public void GetToolMetadata_FallsBackToConfig_WhenDbMetadataUnavailable()
+        {
+            // Arrange - use a service provider without metadata factory
+            ParameterMetadata[] parameters = new[]
+            {
+                new ParameterMetadata { Name = "userId", Description = "User ID" }
+            };
+            Entity entity = CreateTestStoredProcedureEntity(parameters: parameters);
+            DynamicCustomTool tool = new("GetUser", entity);
+
+            ServiceCollection services = new();
+            services.AddLogging();
+
+            // Act
+            tool.InitializeMetadata(services.BuildServiceProvider());
+            JsonElement props = ParseSchemaProperties(tool.GetToolMetadata());
+
+            // Assert - should use config-based permissive type array
+            Assert.AreEqual(JsonValueKind.Array, props.GetProperty("userId").GetProperty("type").ValueKind,
+                "Fallback schema should use multi-type array.");
+        }
+
+        /// <summary>
+        /// Without calling InitializeMetadata, tool uses config-based schema.
+        /// </summary>
+        [TestMethod]
+        public void GetToolMetadata_UsesConfigSchema_WhenNotInitialized()
+        {
+            // Arrange
+            ParameterMetadata[] parameters = new[]
+            {
+                new ParameterMetadata { Name = "bookId", Description = "Book identifier" }
+            };
+            Entity entity = CreateTestStoredProcedureEntity(parameters: parameters);
+            DynamicCustomTool tool = new("GetBook", entity);
+
+            // Act - no InitializeMetadata call
+            JsonElement props = ParseSchemaProperties(tool.GetToolMetadata());
+
+            // Assert
+            JsonElement param = props.GetProperty("bookId");
+            Assert.AreEqual(JsonValueKind.Array, param.GetProperty("type").ValueKind, "Config schema uses multi-type array.");
+            Assert.AreEqual("Book identifier", param.GetProperty("description").GetString());
+        }
+
+        /// <summary>
+        /// DB metadata parameters NOT in config are still discovered and included in schema.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_IncludesAllDbDiscoveredParams()
+        {
+            // Arrange - config has no parameters, but DB has them
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new() { SystemType = typeof(int) },
+                ["title"] = new() { SystemType = typeof(string) },
+                ["price"] = new() { SystemType = typeof(decimal) }
+            };
+
+            // Act
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert - all 3 DB-discovered params should appear
+            Assert.AreEqual(3, props.EnumerateObject().Count());
+            Assert.IsTrue(props.TryGetProperty("id", out _));
+            Assert.IsTrue(props.TryGetProperty("title", out _));
+            Assert.IsTrue(props.TryGetProperty("price", out _));
+        }
+
+        /// <summary>
+        /// Verifies type mapping for common .NET types to JSON Schema types.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(typeof(int), "integer")]
+        [DataRow(typeof(long), "integer")]
+        [DataRow(typeof(short), "integer")]
+        [DataRow(typeof(byte), "integer")]
+        [DataRow(typeof(float), "number")]
+        [DataRow(typeof(double), "number")]
+        [DataRow(typeof(decimal), "number")]
+        [DataRow(typeof(bool), "boolean")]
+        [DataRow(typeof(string), "string")]
+        [DataRow(typeof(Guid), "string")]
+        [DataRow(typeof(DateTime), "string")]
+        [DataRow(typeof(DateTimeOffset), "string")]
+        public void InitializeMetadata_MapsSystemTypesToJsonSchemaTypes(Type systemType, string expectedJsonType)
+        {
+            // Arrange & Act
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["param1"] = new() { SystemType = systemType }
+            };
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert
+            Assert.AreEqual(expectedJsonType, props.GetProperty("param1").GetProperty("type").GetString());
+        }
+
+        /// <summary>
+        /// When SystemType is null, schema uses a permissive multi-type array.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_UsesPermissiveType_WhenSystemTypeIsNull()
+        {
+            // Arrange & Act
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["unknown_param"] = new() { SystemType = null! }
+            };
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert
+            Assert.AreEqual(JsonValueKind.Array, props.GetProperty("unknown_param").GetProperty("type").ValueKind);
+        }
+
+        /// <summary>
+        /// When a parameter has HasConfigDefault=true, the description includes the default value.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_IncludesDefaultInDescription()
+        {
+            // Arrange & Act
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["tenant"] = new() { SystemType = typeof(string), HasConfigDefault = true, ConfigDefaultValue = "default_tenant" }
+            };
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert
+            string desc = props.GetProperty("tenant").GetProperty("description").GetString()!;
+            StringAssert.Contains(desc, "default: default_tenant");
+        }
+
+        /// <summary>
+        /// Zero-parameter SP with DB metadata returns empty properties object.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_ZeroParamSP_ReturnsEmptyProperties()
+        {
+            // Arrange & Act
+            JsonElement props = InitializeAndGetSchemaProperties(new Dictionary<string, ParameterDefinition>());
+
+            // Assert
+            Assert.AreEqual(0, props.EnumerateObject().Count());
+        }
+
+        /// <summary>
+        /// Helper: Creates a DynamicCustomTool, initializes it with mocked DB metadata, and returns
+        /// the "properties" element from the resulting input schema.
+        /// </summary>
+        private static JsonElement InitializeAndGetSchemaProperties(
+            Dictionary<string, ParameterDefinition> dbParameters,
+            string entityName = "TestSP")
+        {
+            Entity entity = CreateTestStoredProcedureEntity();
+            DynamicCustomTool tool = new(entityName, entity);
+            IServiceProvider sp = BuildServiceProviderForMetadata(entityName, dbParameters);
+
+            tool.InitializeMetadata(sp);
+            return ParseSchemaProperties(tool.GetToolMetadata());
+        }
+
+        /// <summary>
+        /// Helper: Parses the "properties" element from a tool's input schema.
+        /// </summary>
+        private static JsonElement ParseSchemaProperties(ModelContextProtocol.Protocol.Tool metadata)
+        {
+            JsonDocument schemaObj = JsonDocument.Parse(metadata.InputSchema.GetRawText());
+            return schemaObj.RootElement.GetProperty("properties");
+        }
+
+        /// <summary>
+        /// Builds a service provider with mocked metadata infrastructure for schema tests.
+        /// </summary>
+        private static IServiceProvider BuildServiceProviderForMetadata(
+            string entityName,
+            Dictionary<string, ParameterDefinition> dbParameters)
+        {
+            Entity entity = new(
+                Source: new("test_procedure", EntitySourceType.StoredProcedure, Parameters: null, KeyFields: null),
+                GraphQL: new(entityName, entityName),
+                Rest: new(Enabled: true),
+                Fields: null,
+                Permissions: new[]
+                {
+                    new EntityPermission(
+                        Role: "anonymous",
+                        Actions: new[] { new EntityAction(Action: EntityActionOperation.Execute, Fields: null, Policy: null) })
+                },
+                Relationships: null,
+                Mappings: null,
+                Mcp: new EntityMcpOptions(customToolEnabled: true, dmlToolsEnabled: null));
+
+            Dictionary<string, Entity> entities = new() { [entityName] = entity };
+
+            RuntimeConfig config = new(
+                Schema: "test-schema",
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, ConnectionString: "", Options: null),
+                Runtime: new(
+                    Rest: new(),
+                    GraphQL: new(),
+                    Mcp: new(Enabled: true, Path: "/mcp", DmlTools: null),
+                    Host: new(Cors: null, Authentication: null, Mode: HostMode.Development)
+                ),
+                Entities: new(entities));
+
+            ServiceCollection services = new();
+
+            RuntimeConfigProvider configProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(config);
+            services.AddSingleton(configProvider);
+
+            // Mock metadata provider with DB object
+            DatabaseStoredProcedure dbObject = new("dbo", "test_procedure")
+            {
+                SourceType = EntitySourceType.StoredProcedure,
+                StoredProcedureDefinition = new StoredProcedureDefinition
+                {
+                    Parameters = dbParameters
+                }
+            };
+
+            Mock<ISqlMetadataProvider> mockSqlMetadataProvider = new();
+            mockSqlMetadataProvider
+                .Setup(x => x.EntityToDatabaseObject)
+                .Returns(new Dictionary<string, DatabaseObject> { [entityName] = dbObject });
+
+            Mock<IMetadataProviderFactory> mockMetadataProviderFactory = new();
+            mockMetadataProviderFactory
+                .Setup(x => x.GetMetadataProvider(It.IsAny<string>()))
+                .Returns(mockSqlMetadataProvider.Object);
+            services.AddSingleton(mockMetadataProviderFactory.Object);
+
+            services.AddLogging();
+
+            return services.BuildServiceProvider();
+        }
+
+        #endregion
     }
 }

--- a/src/Service/Utilities/McpStdioHelper.cs
+++ b/src/Service/Utilities/McpStdioHelper.cs
@@ -85,6 +85,13 @@ namespace Azure.DataApiBuilder.Service.Utilities
 
             foreach (Mcp.Model.IMcpTool tool in tools)
             {
+                // Initialize DB-metadata-based schema for custom tools before registration,
+                // so GetToolMetadata() returns the enriched schema from the start.
+                if (tool is Mcp.Core.DynamicCustomTool customTool)
+                {
+                    customTool.InitializeMetadata(host.Services);
+                }
+
                 registry.RegisterTool(tool);
             }
 

--- a/src/Service/Utilities/McpStdioHelper.cs
+++ b/src/Service/Utilities/McpStdioHelper.cs
@@ -83,17 +83,7 @@ namespace Azure.DataApiBuilder.Service.Utilities
             IEnumerable<Mcp.Model.IMcpTool> tools =
                 host.Services.GetServices<Mcp.Model.IMcpTool>();
 
-            foreach (Mcp.Model.IMcpTool tool in tools)
-            {
-                // Initialize DB-metadata-based schema for custom tools before registration,
-                // so GetToolMetadata() returns the enriched schema from the start.
-                if (tool is Mcp.Core.DynamicCustomTool customTool)
-                {
-                    customTool.InitializeMetadata(host.Services);
-                }
-
-                registry.RegisterTool(tool);
-            }
+            Mcp.Core.McpToolRegistry.InitializeAndRegisterTools(tools, registry, host.Services);
 
             IHostApplicationLifetime lifetime =
                 host.Services.GetRequiredService<IHostApplicationLifetime>();


### PR DESCRIPTION
﻿## Why make this change?

- Closes #3615

Custom MCP tools used a permissive multi-type array for all parameters in the input schema. MCP clients had no type information to guide users or validate inputs before execution.

## What is this change?

- **InitializeMetadata**: Resolves StoredProcedureDefinition.Parameters from the metadata provider and builds a typed JSON Schema (integer/number/boolean/string) for each DB-discovered parameter.
- **Fallback**: Falls back to config-based permissive schema when DB metadata is unavailable.
- **Both modes**: Applied in HTTP mode (McpToolRegistryInitializer) and stdio mode (McpStdioHelper) via shared `McpToolRegistry.InitializeAndRegisterTools` helper.
- **Default descriptions**: Surfaces `(default: value)` in parameter descriptions when HasConfigDefault is set.

## How was this tested?

- [x] Unit Tests

| Test | Scenario |
|------|----------|
| UsesDbMetadata_WhenInitialized | Schema uses typed params after InitializeMetadata |
| FallsBackToConfig_WhenDbMetadataUnavailable | Permissive array when no metadata factory |
| UsesConfigSchema_WhenNotInitialized | Config schema used without InitializeMetadata call |
| IncludesAllDbDiscoveredParams | Params not in config but in DB appear in schema |
| MapsSystemTypesToJsonSchemaTypes (x12) | int/long/short/byte to integer, float/double/decimal to number, bool to boolean, string/Guid/DateTime to string |
| UsesPermissiveType_WhenSystemTypeIsNull | Null SystemType falls back to multi-type array |
| IncludesDefaultInDescription | (default: value) in description |
| ZeroParamSP_ReturnsEmptyProperties | Empty properties for zero-param SP |

- [x] Integration Tests

| Test | Scenario |
|------|----------|
| InitializeMetadata_SchemaReflectsDbParameterTypes (x3) | int->integer, varchar->string mapping against live DB |
| InitializeMetadata_ZeroParamSP_HasEmptyProperties | Zero-param SP has empty properties from DB metadata |
| InitializeMetadata_DescriptionIncludesConfigDefaults (x2) | Config defaults (randomX, 1234) in descriptions |

- [x] Manual Testing

| Tool | Before | After |
|------|--------|-------|
| get_book(id) | type: [...] | type: integer |
| insert_book(title, publisher_id) | permissive | string, integer + defaults in desc |
| update_book_title(id, title) | permissive | integer, string + defaults in desc |
| get_books (zero-param) | empty | empty |
| End-to-end execution get_book(id=1) | N/A | returns book record |

## Sample Request(s)

tools/list response (get_book schema after fix):
```json
{ "name": "get_book", "inputSchema": { "type": "object", "properties": { "id": { "type": "integer", "description": "Parameter id" } } } }
```
