### PR TITLE
Fix Package Requirements for Nuget Core Package

### DIFF
--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -22,7 +22,7 @@
     <NoWarn>NU1603</NoWarn>
 
     <!-- Run custom target during pack to add dependency files into the package. -->
-    <TargetsForTfmSpecificContentInPackage>IncludeInternalDependenciesInPackage</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludeInternalDependenciesInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -57,13 +57,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj">
-        <PrivateAssets Condition="'$(PackRelease)' == 'true'">all</PrivateAssets>
+      <PrivateAssets Condition="'$(PRIVATIZE_ASSETS)' == 'true'">all</PrivateAssets>
     </ProjectReference>
     <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj">
-        <PrivateAssets Condition="'$(PackRelease)' == 'true'">all</PrivateAssets>
+      <PrivateAssets Condition="'$(PRIVATIZE_ASSETS)' == 'true'">all</PrivateAssets>
     </ProjectReference>
     <ProjectReference Include="..\Service.GraphQLBuilder\Azure.DataApiBuilder.Service.GraphQLBuilder.csproj">
-        <PrivateAssets Condition="'$(PackRelease)' == 'true'">all</PrivateAssets>
+      <PrivateAssets Condition="'$(PRIVATIZE_ASSETS)' == 'true'">all</PrivateAssets>
     </ProjectReference>
   </ItemGroup>
 
@@ -76,7 +76,12 @@
 
   <Target Name="IncludeInternalDependenciesInPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" PackagePath="lib/$(TargetFramework)" Condition="'%(ReferenceCopyLocalPaths.Extension)' != '.pdb'" />
+      <_InternalAssembly Include="$(OutputPath)Azure.DataApiBuilder.Auth.dll" />
+      <_InternalAssembly Include="$(OutputPath)Azure.DataApiBuilder.Config.dll" />
+      <_InternalAssembly Include="$(OutputPath)Azure.DataApiBuilder.Service.GraphQLBuilder.dll" />
+      <_InternalAssembly Include="$(OutputPath)Azure.DataApiBuilder.Product.dll" />
+
+      <TfmSpecificPackageFile Include="@(_InternalAssembly)" PackagePath="lib/$(TargetFramework)" />
     </ItemGroup>
   </Target>
 

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -56,9 +56,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj" PrivateAssets="all" />
-    <ProjectReference Include="..\Service.GraphQLBuilder\Azure.DataApiBuilder.Service.GraphQLBuilder.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj">
+        <PrivateAssets Condition="'$(PackRelease)' == 'true'">all</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj">
+        <PrivateAssets Condition="'$(PackRelease)' == 'true'">all</PrivateAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\Service.GraphQLBuilder\Azure.DataApiBuilder.Service.GraphQLBuilder.csproj">
+        <PrivateAssets Condition="'$(PackRelease)' == 'true'">all</PrivateAssets>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -69,8 +75,8 @@
   </ItemGroup>
 
   <Target Name="IncludeInternalDependenciesInPackage">
-      <ItemGroup>
-        <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" PackagePath="lib/$(TargetFramework)" Condition="'%(ReferenceCopyLocalPaths.Extension)' != '.pdb'" />
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" PackagePath="lib/$(TargetFramework)" Condition="'%(ReferenceCopyLocalPaths.Extension)' != '.pdb'" />
     </ItemGroup>
   </Target>
 

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -57,13 +57,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj">
-      <PrivateAssets Condition="'$(PRIVATIZE_ASSETS)' == 'true'">all</PrivateAssets>
+      <PrivateAssets Condition="'$(PrivatizeAssets)' == 'true'">all</PrivateAssets>
     </ProjectReference>
     <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj">
-      <PrivateAssets Condition="'$(PRIVATIZE_ASSETS)' == 'true'">all</PrivateAssets>
+      <PrivateAssets Condition="'$(PrivatizeAssets)' == 'true'">all</PrivateAssets>
     </ProjectReference>
     <ProjectReference Include="..\Service.GraphQLBuilder\Azure.DataApiBuilder.Service.GraphQLBuilder.csproj">
-      <PrivateAssets Condition="'$(PRIVATIZE_ASSETS)' == 'true'">all</PrivateAssets>
+      <PrivateAssets Condition="'$(PrivatizeAssets)' == 'true'">all</PrivateAssets>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -20,6 +20,9 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <NoWarn>NU1603</NoWarn>
+
+    <!-- Run custom target during pack to add dependency files into the package. -->
+    <TargetsForTfmSpecificContentInPackage>IncludeInternalDependenciesInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,9 +56,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj" />
-    <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj" />
-    <ProjectReference Include="..\Service.GraphQLBuilder\Azure.DataApiBuilder.Service.GraphQLBuilder.csproj" />
+    <ProjectReference Include="..\Auth\Azure.DataApiBuilder.Auth.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Config\Azure.DataApiBuilder.Config.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Service.GraphQLBuilder\Azure.DataApiBuilder.Service.GraphQLBuilder.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,5 +67,11 @@
     <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="..\..\nuget_core\NOTICE.txt" Pack="true" PackagePath="\" Condition="Exists('..\..\nuget_core\NOTICE.txt')" />
   </ItemGroup>
+
+  <Target Name="IncludeInternalDependenciesInPackage">
+      <ItemGroup>
+        <TfmSpecificPackageFile Include="@(ReferenceCopyLocalPaths)" PackagePath="lib/$(TargetFramework)" Condition="'%(ReferenceCopyLocalPaths.Extension)' != '.pdb'" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
## Why make this change?

- Solves issue #3618

## What is this change?

This adds `TargetsForTfmSpecificContentInPackage` and `IncludeInternalDependenciesInPackage` to create the dependencies from the Core project as dlls. And uses the `PrivateAssets` to ensure that those dependencies are not added to the nuspec file.

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests
- [X] Manual Tests
Tested by using command `dotnet pack .\Azure.DataApiBuilder.Core.csproj -c Release` to build nuget package and ensure that all the dependencies are created as expected.

<img width="828" height="355" alt="image" src="https://github.com/user-attachments/assets/cb3a72c1-1984-4869-aece-4f1d17bc7519" />

## Sample Request(s)

N/A
