### PR TITLE
[Cherry-pick] DB metadata based parameter support for MCP tools (#3600, #3601, #3619)

### DIFF
--- a/config-generators/mssql-commands.txt
+++ b/config-generators/mssql-commands.txt
@@ -41,11 +41,11 @@ add User_AutogenRelationshipColumn --config "dab-config.MsSql.json" --source "us
 add User_AutogenToNonAutogenRelationshipColumn --config "dab-config.MsSql.json" --source "users" --permissions "anonymous:*" --rest true --graphql true
 add User_RepeatedReferencingColumnToOneEntity --config "dab-config.MsSql.json" --source "users" --permissions "anonymous:*" --rest true --graphql true
 add UserProfile_RepeatedReferencingColumnToTwoEntities --config "dab-config.MsSql.json" --source "user_profiles" --permissions "anonymous:*" --rest true --graphql true
-add GetBooks --config "dab-config.MsSql.json" --source "get_books" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql true
-add GetBook --config "dab-config.MsSql.json" --source "get_book_by_id" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql false
-add GetPublisher --config "dab-config.MsSql.json" --source "get_publisher_by_id" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql true --graphql.operation "query"
-add InsertBook --config "dab-config.MsSql.json" --source "insert_book" --source.type "stored-procedure" --source.params "title:randomX,publisher_id:1234" --permissions "anonymous:execute" --rest true --graphql true
-add CountBooks --config "dab-config.MsSql.json" --source "count_books" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql true
+add GetBooks --config "dab-config.MsSql.json" --source "get_books" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql true --mcp.custom-tool true
+add GetBook --config "dab-config.MsSql.json" --source "get_book_by_id" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql false --mcp.custom-tool true
+add GetPublisher --config "dab-config.MsSql.json" --source "get_publisher_by_id" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql true --graphql.operation "query" --mcp.custom-tool true
+add InsertBook --config "dab-config.MsSql.json" --source "insert_book" --source.type "stored-procedure" --source.params "title:randomX,publisher_id:1234" --permissions "anonymous:execute" --rest true --graphql true --mcp.custom-tool true
+add CountBooks --config "dab-config.MsSql.json" --source "count_books" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql true --mcp.custom-tool true
 add DeleteLastInsertedBook --config "dab-config.MsSql.json" --source "delete_last_inserted_book" --source.type "stored-procedure" --permissions "anonymous:execute" --rest true --graphql true
 add UpdateBookTitle --config "dab-config.MsSql.json" --source "update_book_title" --source.type "stored-procedure" --source.params "id:1,title:Testing Tonight" --permissions "anonymous:execute" --rest true --graphql true
 add GetAuthorsHistoryByFirstName --config "dab-config.MsSql.json" --source "get_authors_history_by_first_name" --source.type "stored-procedure" --source.params "firstName:Aaron" --permissions "anonymous:execute" --rest true --graphql SearchAuthorByFirstName

--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ExecuteEntityTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ExecuteEntityTool.cs
@@ -164,13 +164,22 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                     return McpErrorHelpers.PermissionDenied(toolName, entity, "execute", authError, logger);
                 }
 
-                // 7) Validate parameters against metadata
-                if (parameters != null && entityConfig.Source.Parameters != null)
+                // 7) Validate parameters against DB metadata (StoredProcedureDefinition.Parameters),
+                // which is the source of truth for parameter names. The upstream merge performed by
+                // FillSchemaForStoredProcedureAsync ensures this dictionary contains all valid parameters.
+                // Note: Comparison is case-sensitive (default Dictionary<string,...> comparer),
+                // consistent with the existing REST/GraphQL SP execution path.
+                if (dbObject is not DatabaseStoredProcedure storedProcedure)
                 {
-                    // Validate all provided parameters exist in metadata
+                    return McpResponseBuilder.BuildErrorResult(toolName, "InvalidEntity", $"Entity '{entity}' is not a stored procedure.", logger);
+                }
+
+                StoredProcedureDefinition spDefinition = storedProcedure.StoredProcedureDefinition;
+                if (parameters != null && spDefinition.Parameters is not null)
+                {
                     foreach (KeyValuePair<string, object?> param in parameters)
                     {
-                        if (!entityConfig.Source.Parameters.Any(p => p.Name == param.Key))
+                        if (!spDefinition.Parameters.ContainsKey(param.Key))
                         {
                             return McpResponseBuilder.BuildErrorResult(toolName, "InvalidArguments", $"Invalid parameter: {param.Key}", logger);
                         }
@@ -203,14 +212,16 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                     }
                 }
 
-                // Then, add default parameters from configuration (only if not already provided by user)
-                if ((parameters == null || parameters.Count == 0) && entityConfig.Source.Parameters != null)
+                // Apply config-declared defaults from the merged ParameterDefinitions.
+                // This covers all parameters (including DB-discovered ones with config defaults)
+                // and applies them when the user didn't supply a value.
+                if (spDefinition.Parameters is not null)
                 {
-                    foreach (ParameterMetadata param in entityConfig.Source.Parameters)
+                    foreach ((string paramName, ParameterDefinition paramDef) in spDefinition.Parameters)
                     {
-                        if (!context.FieldValuePairsInBody.ContainsKey(param.Name))
+                        if (!context.FieldValuePairsInBody.ContainsKey(paramName) && paramDef.HasConfigDefault)
                         {
-                            context.FieldValuePairsInBody[param.Name] = param.Default;
+                            context.FieldValuePairsInBody[paramName] = paramDef.ConfigDefaultValue;
                         }
                     }
                 }

--- a/src/Azure.DataApiBuilder.Mcp/Core/DynamicCustomTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/DynamicCustomTool.cs
@@ -170,7 +170,28 @@ namespace Azure.DataApiBuilder.Mcp.Core
                     return McpErrorHelpers.PermissionDenied(toolName, EntityName, "execute", authError, logger);
                 }
 
-                // 6) Build request payload
+                // 6) Validate parameters against DB metadata (StoredProcedureDefinition.Parameters),
+                // which is the source of truth for parameter names.
+                // Note: Comparison is case-sensitive (default Dictionary<string,...> comparer),
+                // consistent with the existing REST/GraphQL SP execution path.
+                if (dbObject is not DatabaseStoredProcedure storedProcedure)
+                {
+                    return McpResponseBuilder.BuildErrorResult(toolName, "InvalidEntity", $"Entity '{EntityName}' is not a stored procedure.", logger);
+                }
+
+                StoredProcedureDefinition spDefinition = storedProcedure.StoredProcedureDefinition;
+                if (parameters.Count > 0 && spDefinition.Parameters is not null)
+                {
+                    foreach (KeyValuePair<string, object?> param in parameters)
+                    {
+                        if (!spDefinition.Parameters.ContainsKey(param.Key))
+                        {
+                            return McpResponseBuilder.BuildErrorResult(toolName, "InvalidArguments", $"Invalid parameter: {param.Key}", logger);
+                        }
+                    }
+                }
+
+                // 7) Build request payload
                 JsonElement? requestPayloadRoot = null;
                 if (parameters.Count > 0)
                 {
@@ -195,14 +216,16 @@ namespace Azure.DataApiBuilder.Mcp.Core
                     }
                 }
 
-                // Add default parameters from configuration if not provided
-                if (entityConfig.Source.Parameters != null)
+                // Apply config-declared defaults from the merged ParameterDefinitions.
+                // This covers all parameters (including DB-discovered ones with config defaults)
+                // and applies them per-missing-parameter when the user didn't supply a value.
+                if (spDefinition.Parameters is not null)
                 {
-                    foreach (ParameterMetadata param in entityConfig.Source.Parameters)
+                    foreach ((string paramName, ParameterDefinition paramDef) in spDefinition.Parameters)
                     {
-                        if (!context.FieldValuePairsInBody.ContainsKey(param.Name))
+                        if (!context.FieldValuePairsInBody.ContainsKey(paramName) && paramDef.HasConfigDefault)
                         {
-                            context.FieldValuePairsInBody[param.Name] = param.Default;
+                            context.FieldValuePairsInBody[paramName] = paramDef.ConfigDefaultValue;
                         }
                     }
                 }

--- a/src/Azure.DataApiBuilder.Mcp/Core/DynamicCustomTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/DynamicCustomTool.cs
@@ -39,6 +39,7 @@ namespace Azure.DataApiBuilder.Mcp.Core
     public class DynamicCustomTool : IMcpTool
     {
         private readonly Entity _entity;
+        private JsonElement? _cachedInputSchema;
 
         /// <summary>
         /// Initializes a new instance of DynamicCustomTool.
@@ -70,6 +71,19 @@ namespace Azure.DataApiBuilder.Mcp.Core
         /// Gets the entity name associated with this custom tool.
         /// </summary>
         public string EntityName { get; }
+
+        /// <summary>
+        /// Initializes the tool's input schema using DB metadata from the service provider.
+        /// Called after DI initialization to enrich the tool schema with DB-discovered parameters
+        /// and type information that aren't available at construction time.
+        /// Falls back silently to config-based schema if DB metadata is unavailable.
+        /// </summary>
+        /// <param name="serviceProvider">The application service provider with initialized metadata providers.</param>
+        public void InitializeMetadata(IServiceProvider serviceProvider)
+        {
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+            _cachedInputSchema = BuildInputSchemaFromDbMetadata(serviceProvider);
+        }
 
         /// <summary>
         /// Gets the metadata for this custom tool, including name, description, and input schema.
@@ -291,9 +305,87 @@ namespace Azure.DataApiBuilder.Mcp.Core
         }
 
         /// <summary>
-        /// Builds the input schema for the tool based on entity parameters.
+        /// Builds the input schema for the tool. Returns cached DB-metadata-based schema
+        /// if available (set by InitializeMetadata), otherwise falls back to config-based schema.
         /// </summary>
         private JsonElement BuildInputSchema()
+        {
+            if (_cachedInputSchema.HasValue)
+            {
+                return _cachedInputSchema.Value;
+            }
+
+            return BuildInputSchemaFromConfig();
+        }
+
+        /// <summary>
+        /// Builds the input schema from DB metadata (StoredProcedureDefinition.Parameters).
+        /// Returns null if metadata cannot be resolved (caller should fall back to config-based schema).
+        /// </summary>
+        private JsonElement? BuildInputSchemaFromDbMetadata(IServiceProvider serviceProvider)
+        {
+            RuntimeConfigProvider? configProvider = serviceProvider.GetService<RuntimeConfigProvider>();
+            if (configProvider is null)
+            {
+                return null;
+            }
+
+            RuntimeConfig config = configProvider.GetConfig();
+
+            if (!McpMetadataHelper.TryResolveMetadata(
+                    EntityName,
+                    config,
+                    serviceProvider,
+                    out _,
+                    out DatabaseObject dbObject,
+                    out _,
+                    out _))
+            {
+                return null;
+            }
+
+            if (dbObject is not DatabaseStoredProcedure storedProcedure)
+            {
+                return null;
+            }
+
+            StoredProcedureDefinition spDefinition = storedProcedure.StoredProcedureDefinition;
+            if (spDefinition.Parameters is null || spDefinition.Parameters.Count == 0)
+            {
+                // Zero-param SP: return empty properties schema
+                return JsonSerializer.SerializeToElement(new Dictionary<string, object>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object>()
+                });
+            }
+
+            Dictionary<string, object> properties = new();
+            foreach ((string paramName, ParameterDefinition paramDef) in spDefinition.Parameters)
+            {
+                Dictionary<string, object> paramSchema = new()
+                {
+                    ["type"] = MapSystemTypeToJsonSchemaType(paramDef.SystemType),
+                    ["description"] = BuildParameterDescription(paramName, paramDef)
+                };
+
+                properties[paramName] = paramSchema;
+            }
+
+            Dictionary<string, object> schema = new()
+            {
+                ["type"] = "object",
+                ["properties"] = properties
+            };
+
+            return JsonSerializer.SerializeToElement(schema);
+        }
+
+        /// <summary>
+        /// Builds the input schema from config-side ParameterMetadata.
+        /// Used as fallback when DB metadata is not available.
+        /// </summary>
+        private JsonElement BuildInputSchemaFromConfig()
         {
             Dictionary<string, object> schema = new()
             {
@@ -307,9 +399,6 @@ namespace Azure.DataApiBuilder.Mcp.Core
 
                 foreach (ParameterMetadata param in _entity.Source.Parameters)
                 {
-                    // Note: Parameter type information is not available in ParameterMetadata,
-                    // so we allow multiple JSON types to match the behavior of GetParameterValue
-                    // that handles string, number, boolean, and null values.
                     properties[param.Name] = new Dictionary<string, object>
                     {
                         ["type"] = new[] { "string", "number", "boolean", "null" },
@@ -319,6 +408,63 @@ namespace Azure.DataApiBuilder.Mcp.Core
             }
 
             return JsonSerializer.SerializeToElement(schema);
+        }
+
+        /// <summary>
+        /// Maps a .NET System.Type to the appropriate JSON Schema type string.
+        /// </summary>
+        private static object MapSystemTypeToJsonSchemaType(Type? systemType)
+        {
+            if (systemType is null)
+            {
+                return new[] { "string", "number", "boolean", "null" };
+            }
+
+            // Handle nullable types
+            Type underlyingType = Nullable.GetUnderlyingType(systemType) ?? systemType;
+
+            if (underlyingType == typeof(int) || underlyingType == typeof(long) ||
+                underlyingType == typeof(short) || underlyingType == typeof(byte) ||
+                underlyingType == typeof(sbyte) || underlyingType == typeof(uint) ||
+                underlyingType == typeof(ulong) || underlyingType == typeof(ushort))
+            {
+                return "integer";
+            }
+
+            if (underlyingType == typeof(float) || underlyingType == typeof(double) ||
+                underlyingType == typeof(decimal))
+            {
+                return "number";
+            }
+
+            if (underlyingType == typeof(bool))
+            {
+                return "boolean";
+            }
+
+            if (underlyingType == typeof(string) || underlyingType == typeof(Guid) ||
+                underlyingType == typeof(DateTime) || underlyingType == typeof(DateTimeOffset))
+            {
+                return "string";
+            }
+
+            // Default: permissive multi-type
+            return new[] { "string", "number", "boolean", "null" };
+        }
+
+        /// <summary>
+        /// Builds a description string for a parameter using DB metadata.
+        /// Uses ParameterDefinition.Description when available, falling back to generic text.
+        /// </summary>
+        private static string BuildParameterDescription(string paramName, ParameterDefinition paramDef)
+        {
+            string description = paramDef.Description ?? $"Parameter {paramName}";
+            if (paramDef.HasConfigDefault)
+            {
+                description += $" (default: {paramDef.ConfigDefaultValue})";
+            }
+
+            return description;
         }
 
         /// <summary>

--- a/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistry.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistry.cs
@@ -78,5 +78,25 @@ namespace Azure.DataApiBuilder.Mcp.Core
         {
             return _tools.TryGetValue(toolName, out tool);
         }
+
+        /// <summary>
+        /// Initializes and registers all MCP tools, enriching custom tools with DB metadata schemas.
+        /// Shared by both HTTP hosted-service and stdio startup paths.
+        /// </summary>
+        public static void InitializeAndRegisterTools(
+            IEnumerable<IMcpTool> tools,
+            McpToolRegistry registry,
+            IServiceProvider serviceProvider)
+        {
+            foreach (IMcpTool tool in tools)
+            {
+                if (tool is DynamicCustomTool customTool)
+                {
+                    customTool.InitializeMetadata(serviceProvider);
+                }
+
+                registry.RegisterTool(tool);
+            }
+        }
     }
 }

--- a/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistryInitializer.cs
+++ b/src/Azure.DataApiBuilder.Mcp/Core/McpToolRegistryInitializer.cs
@@ -23,13 +23,8 @@ namespace Azure.DataApiBuilder.Mcp.Core
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            // Register all IMcpTool implementations
             IEnumerable<IMcpTool> tools = _serviceProvider.GetServices<IMcpTool>();
-            foreach (IMcpTool tool in tools)
-            {
-                _toolRegistry.RegisterTool(tool);
-            }
-
+            McpToolRegistry.InitializeAndRegisterTools(tools, _toolRegistry, _serviceProvider);
             return Task.CompletedTask;
         }
 

--- a/src/Service.Tests/Mcp/DynamicCustomToolMsSqlIntegrationTests.cs
+++ b/src/Service.Tests/Mcp/DynamicCustomToolMsSqlIntegrationTests.cs
@@ -121,6 +121,80 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
             StringAssert.Contains(content, paramName);
         }
 
+        #region Schema Alignment Integration Tests
+
+        /// <summary>
+        /// Validates that InitializeMetadata maps DB parameter types to JSON Schema types.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("GetBook", "id", "integer", DisplayName = "int param maps to integer")]
+        [DataRow("InsertBook", "title", "string", DisplayName = "varchar param maps to string")]
+        [DataRow("InsertBook", "publisher_id", "integer", DisplayName = "int param maps to integer (multi-param SP)")]
+        public void InitializeMetadata_SchemaReflectsDbParameterTypes(string entityName, string paramName, string expectedType)
+        {
+            IServiceProvider serviceProvider = BuildServiceProvider();
+            RuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<RuntimeConfigProvider>();
+            Entity entity = configProvider.GetConfig().Entities[entityName];
+
+            DynamicCustomTool tool = new(entityName, entity);
+            tool.InitializeMetadata(serviceProvider);
+
+            JsonElement properties = tool.GetToolMetadata().InputSchema.GetProperty("properties");
+
+            Assert.IsTrue(properties.TryGetProperty(paramName, out JsonElement paramProp),
+                $"Schema should contain '{paramName}' property.");
+            Assert.AreEqual(expectedType, paramProp.GetProperty("type").GetString(),
+                $"'{paramName}' should map to JSON Schema type '{expectedType}'.");
+        }
+
+        /// <summary>
+        /// Validates that zero-param SP produces an empty properties object.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_ZeroParamSP_HasEmptyProperties()
+        {
+            IServiceProvider serviceProvider = BuildServiceProvider();
+            RuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<RuntimeConfigProvider>();
+            Entity entity = configProvider.GetConfig().Entities["GetBooks"];
+
+            DynamicCustomTool tool = new("GetBooks", entity);
+            tool.InitializeMetadata(serviceProvider);
+
+            JsonElement properties = tool.GetToolMetadata().InputSchema.GetProperty("properties");
+
+            int paramCount = 0;
+            foreach (JsonProperty _ in properties.EnumerateObject())
+            {
+                paramCount++;
+            }
+
+            Assert.AreEqual(0, paramCount, "Zero-param SP should produce empty properties.");
+        }
+
+        /// <summary>
+        /// Validates that config default values appear in parameter descriptions.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("InsertBook", "title", "randomX", DisplayName = "title description includes default 'randomX'")]
+        [DataRow("InsertBook", "publisher_id", "1234", DisplayName = "publisher_id description includes default '1234'")]
+        public void InitializeMetadata_DescriptionIncludesConfigDefaults(string entityName, string paramName, string expectedDefault)
+        {
+            IServiceProvider serviceProvider = BuildServiceProvider();
+            RuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<RuntimeConfigProvider>();
+            Entity entity = configProvider.GetConfig().Entities[entityName];
+
+            DynamicCustomTool tool = new(entityName, entity);
+            tool.InitializeMetadata(serviceProvider);
+
+            JsonElement properties = tool.GetToolMetadata().InputSchema.GetProperty("properties");
+            string description = properties.GetProperty(paramName).GetProperty("description").GetString()!;
+
+            StringAssert.Contains(description, expectedDefault,
+                $"'{paramName}' description should mention config default '{expectedDefault}'.");
+        }
+
+        #endregion
+
         /// <summary>
         /// Executes a DynamicCustomTool for the given entity using the shared test fixture.
         /// </summary>

--- a/src/Service.Tests/Mcp/DynamicCustomToolMsSqlIntegrationTests.cs
+++ b/src/Service.Tests/Mcp/DynamicCustomToolMsSqlIntegrationTests.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Core.Resolvers;
+using Azure.DataApiBuilder.Core.Resolvers.Factories;
+using Azure.DataApiBuilder.Core.Services.Cache;
+using Azure.DataApiBuilder.Mcp.Core;
+using Azure.DataApiBuilder.Service.Tests.SqlTests;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Protocol;
+using Moq;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Azure.DataApiBuilder.Service.Tests.Mcp
+{
+    /// <summary>
+    /// Integration tests for DynamicCustomTool's parameter validation and default application.
+    /// Verifies the same execution-time fixes applied to ExecuteEntityTool also work correctly
+    /// for per-entity custom tools:
+    /// - Parameters are validated against StoredProcedureDefinition.Parameters (DB metadata).
+    /// - Config defaults are applied from ParameterDefinition.HasConfigDefault/ConfigDefaultValue.
+    ///
+    /// Uses SPs defined in DatabaseSchema-MsSql.sql / dab-config.MsSql.json:
+    ///   - GetBook   -> SP get_book_by_id(@id int)
+    ///   - InsertBook -> SP insert_book(@title, @publisher_id), config defaults title=randomX, publisher_id=1234
+    ///   - GetBooks  -> SP get_books, zero params
+    /// </summary>
+    [TestClass, TestCategory(TestCategory.MSSQL)]
+    public class DynamicCustomToolMsSqlIntegrationTests : SqlTestBase
+    {
+        [ClassInitialize]
+        public static async Task SetupAsync(TestContext context)
+        {
+            DatabaseEngine = TestCategory.MSSQL;
+            await InitializeTestFixture();
+        }
+
+        /// <summary>
+        /// Data-driven test validating successful SP execution via DynamicCustomTool.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("GetBook", "{\"id\": 1}", DisplayName = "DB-discovered param accepted")]
+        [DataRow("InsertBook", null, DisplayName = "Config defaults applied when no params supplied")]
+        [DataRow("InsertBook", "{\"title\": \"Custom Tool Test\", \"publisher_id\": 2345}", DisplayName = "User params override defaults")]
+        [DataRow("GetBooks", null, DisplayName = "Zero-param SP succeeds")]
+        public async Task DynamicCustomTool_SuccessfulExecution(string entityName, string? parametersJson)
+        {
+            Dictionary<string, object>? parameters = parametersJson != null
+                ? JsonSerializer.Deserialize<Dictionary<string, object>>(parametersJson)
+                : null;
+
+            CallToolResult result = await ExecuteCustomToolAsync(entityName, parameters);
+
+            AssertSuccess(result,
+                $"Custom tool failed for entity '{entityName}' with params '{parametersJson}'.");
+
+            string content = GetFirstTextContent(result);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(content), $"Expected non-empty result for entity '{entityName}'.");
+
+            using JsonDocument doc = JsonDocument.Parse(content);
+            JsonElement root = doc.RootElement;
+            Assert.AreEqual(entityName, root.GetProperty("entity").GetString());
+            Assert.AreEqual("Stored procedure executed successfully", root.GetProperty("message").GetString());
+        }
+
+        /// <summary>
+        /// Verify GetBook with id=1 returns a matching record through DynamicCustomTool.
+        /// Unlike SuccessfulExecution data rows (which validate response structure only),
+        /// this test validates the actual returned data content (id field in the result).
+        /// </summary>
+        [TestMethod]
+        public async Task DynamicCustomTool_GetBookById_ReturnsMatchingRecord()
+        {
+            Dictionary<string, object> parameters = new() { { "id", 1 } };
+            CallToolResult result = await ExecuteCustomToolAsync("GetBook", parameters);
+
+            AssertSuccess(result, "GetBook with id=1 should succeed.");
+
+            using JsonDocument doc = JsonDocument.Parse(GetFirstTextContent(result));
+            JsonElement root = doc.RootElement;
+
+            Assert.IsTrue(root.TryGetProperty("value", out JsonElement valueWrapper), "Response should contain 'value' property.");
+
+            JsonElement records = valueWrapper.ValueKind == JsonValueKind.Object
+                ? valueWrapper.GetProperty("value")
+                : valueWrapper;
+
+            Assert.AreEqual(JsonValueKind.Array, records.ValueKind);
+            Assert.IsTrue(records.GetArrayLength() > 0, "Expected at least one book record.");
+            Assert.AreEqual(1, records[0].GetProperty("id").GetInt32());
+        }
+
+        /// <summary>
+        /// Reject a parameter name that does not exist in the DB metadata.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("GetBook", "nonexistent_param", "value", DisplayName = "Rejects unknown param on single-param SP")]
+        [DataRow("GetBooks", "bogus", "123", DisplayName = "Rejects any param on zero-param SP")]
+        public async Task DynamicCustomTool_InvalidParamName_ReturnsError(string entityName, string paramName, string paramValue)
+        {
+            Dictionary<string, object> parameters = new() { { paramName, paramValue } };
+            CallToolResult result = await ExecuteCustomToolAsync(entityName, parameters);
+
+            Assert.IsTrue(result.IsError == true,
+                $"Custom tool should reject parameter '{paramName}' not in DB metadata for '{entityName}'.");
+            string content = GetFirstTextContent(result);
+            StringAssert.Contains(content, paramName);
+        }
+
+        /// <summary>
+        /// Executes a DynamicCustomTool for the given entity using the shared test fixture.
+        /// </summary>
+        private static async Task<CallToolResult> ExecuteCustomToolAsync(string entityName, Dictionary<string, object>? parameters)
+        {
+            IServiceProvider serviceProvider = BuildServiceProvider();
+
+            // Resolve the entity config from the runtime config
+            RuntimeConfigProvider configProvider = serviceProvider.GetRequiredService<RuntimeConfigProvider>();
+            RuntimeConfig config = configProvider.GetConfig();
+            Entity entity = config.Entities[entityName];
+
+            DynamicCustomTool tool = new(entityName, entity);
+
+            // DynamicCustomTool expects parameters as top-level JSON properties (no "entity" wrapper)
+            string argsJson = parameters != null
+                ? JsonSerializer.Serialize(parameters)
+                : "{}";
+            using JsonDocument arguments = JsonDocument.Parse(argsJson);
+
+            return await tool.ExecuteAsync(arguments, serviceProvider, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Builds a service provider wired to the shared fixture's real providers.
+        /// Uses the same pattern as ExecuteEntityToolMsSqlIntegrationTests.
+        /// </summary>
+        private static IServiceProvider BuildServiceProvider()
+        {
+            ServiceCollection services = new();
+
+            RuntimeConfigProvider configProvider = _application.Services.GetRequiredService<RuntimeConfigProvider>();
+            services.AddSingleton(configProvider);
+
+            services.AddSingleton(_metadataProviderFactory.Object);
+            services.AddSingleton(_authorizationResolver);
+
+            DefaultHttpContext httpContext = new();
+            httpContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER] = AuthorizationResolver.ROLE_ANONYMOUS;
+            ClaimsIdentity identity = new(
+                authenticationType: "TestAuth",
+                nameType: null,
+                roleType: AuthenticationOptions.ROLE_CLAIM_TYPE);
+            identity.AddClaim(new Claim(AuthenticationOptions.ROLE_CLAIM_TYPE, AuthorizationResolver.ROLE_ANONYMOUS));
+            httpContext.User = new ClaimsPrincipal(identity);
+            IHttpContextAccessor httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+            services.AddSingleton(httpContextAccessor);
+
+            Mock<IFusionCache> cache = new();
+            DabCacheService cacheService = new(cache.Object, logger: null, httpContextAccessor);
+
+            SqlQueryEngine queryEngine = new(
+                _queryManagerFactory.Object,
+                _metadataProviderFactory.Object,
+                httpContextAccessor,
+                _authorizationResolver,
+                _gqlFilterParser,
+                new Mock<ILogger<IQueryEngine>>().Object,
+                configProvider,
+                cacheService);
+
+            Mock<IQueryEngineFactory> queryEngineFactory = new();
+            queryEngineFactory
+                .Setup(f => f.GetQueryEngine(It.IsAny<DatabaseType>()))
+                .Returns(queryEngine);
+            services.AddSingleton(queryEngineFactory.Object);
+
+            services.AddLogging();
+
+            return services.BuildServiceProvider();
+        }
+
+        private static string GetFirstTextContent(CallToolResult result)
+        {
+            if (result.Content is null || result.Content.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return result.Content[0] is TextContentBlock textBlock
+                ? textBlock.Text ?? string.Empty
+                : string.Empty;
+        }
+
+        private static void AssertSuccess(CallToolResult result, string message)
+        {
+            Assert.IsTrue(result.IsError != true,
+                $"{message} Content: {GetFirstTextContent(result)}");
+        }
+    }
+}

--- a/src/Service.Tests/Mcp/DynamicCustomToolTests.cs
+++ b/src/Service.Tests/Mcp/DynamicCustomToolTests.cs
@@ -4,11 +4,28 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Auth;
+using Azure.DataApiBuilder.Config.DatabasePrimitives;
 using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Core.Models;
+using Azure.DataApiBuilder.Core.Resolvers;
+using Azure.DataApiBuilder.Core.Resolvers.Factories;
+using Azure.DataApiBuilder.Core.Services;
+using Azure.DataApiBuilder.Core.Services.MetadataProviders;
 using Azure.DataApiBuilder.Mcp.Core;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Protocol;
+using Moq;
 
 namespace Azure.DataApiBuilder.Service.Tests.Mcp
 {
@@ -199,6 +216,293 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
             Assert.IsTrue(userIdParam.TryGetProperty("description", out JsonElement desc));
             Assert.IsTrue(desc.GetString()!.Contains("userId"));
         }
+
+        #region Parameter Validation Tests (ExecuteAsync)
+
+        /// <summary>
+        /// A parameter that exists in DB metadata is accepted during execution.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteAsync_AcceptsDbDiscoveredParam()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new()
+            };
+
+            CallToolResult result = await ExecuteCustomToolAsync(
+                dbParameters: dbParams,
+                userParameters: new() { { "id", 1 } });
+
+            AssertSuccess(result, "Should accept DB-discovered param 'id'.");
+        }
+
+        /// <summary>
+        /// A parameter name NOT in StoredProcedureDefinition.Parameters is rejected.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("nonexistent", DisplayName = "Unknown param")]
+        [DataRow("ID", DisplayName = "Case-sensitive mismatch")]
+        public async Task ExecuteAsync_RejectsInvalidParamName(string invalidParamName)
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new()
+            };
+
+            CallToolResult result = await ExecuteCustomToolAsync(
+                dbParameters: dbParams,
+                userParameters: new() { { invalidParamName, "value" } });
+
+            Assert.IsTrue(result.IsError == true,
+                $"Should reject param '{invalidParamName}' not in DB metadata.");
+            string content = GetFirstText(result);
+            StringAssert.Contains(content, invalidParamName);
+        }
+
+        /// <summary>
+        /// Config defaults from ParameterDefinition.HasConfigDefault are applied for missing params.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteAsync_AppliesConfigDefaults_ForMissingParams()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["title"] = new() { HasConfigDefault = true, ConfigDefaultValue = "defaultTitle" },
+                ["publisher_id"] = new() { HasConfigDefault = true, ConfigDefaultValue = "999" }
+            };
+
+            StoredProcedureRequestContext? capturedContext = null;
+            CallToolResult result = await ExecuteCustomToolAsync(
+                dbParameters: dbParams,
+                userParameters: null,
+                captureContext: ctx => capturedContext = ctx);
+
+            AssertSuccess(result, "Should succeed with config defaults.");
+            Assert.IsNotNull(capturedContext);
+            Assert.AreEqual("defaultTitle", capturedContext!.ResolvedParameters["title"]);
+            Assert.AreEqual("999", capturedContext.ResolvedParameters["publisher_id"]);
+        }
+
+        /// <summary>
+        /// User-supplied parameters override config defaults.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteAsync_UserParams_OverrideConfigDefaults()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["title"] = new() { HasConfigDefault = true, ConfigDefaultValue = "defaultTitle" },
+                ["publisher_id"] = new() { HasConfigDefault = true, ConfigDefaultValue = "999" }
+            };
+
+            StoredProcedureRequestContext? capturedContext = null;
+            CallToolResult result = await ExecuteCustomToolAsync(
+                dbParameters: dbParams,
+                userParameters: new() { { "title", "UserTitle" } },
+                captureContext: ctx => capturedContext = ctx);
+
+            AssertSuccess(result, "Should succeed with user-supplied params.");
+            Assert.IsNotNull(capturedContext);
+            Assert.AreEqual("UserTitle", capturedContext!.ResolvedParameters["title"]);
+            Assert.AreEqual("999", capturedContext.ResolvedParameters["publisher_id"]);
+        }
+
+        /// <summary>
+        /// Parameters without HasConfigDefault are NOT injected.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteAsync_DoesNotInjectParams_WithoutConfigDefault()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new(),
+                ["tenant"] = new() { HasConfigDefault = true, ConfigDefaultValue = "default_tenant" }
+            };
+
+            StoredProcedureRequestContext? capturedContext = null;
+            CallToolResult result = await ExecuteCustomToolAsync(
+                dbParameters: dbParams,
+                userParameters: new() { { "id", 42 } },
+                captureContext: ctx => capturedContext = ctx);
+
+            AssertSuccess(result, "Should succeed with partial params.");
+            Assert.IsNotNull(capturedContext);
+            Assert.IsTrue(capturedContext!.ResolvedParameters.ContainsKey("id"));
+            Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("tenant"));
+            Assert.AreEqual("default_tenant", capturedContext.ResolvedParameters["tenant"]);
+        }
+
+        /// <summary>
+        /// Zero-param SP with no user params passes empty parameters.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteAsync_ZeroParamSP_PassesEmptyParams()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new();
+
+            StoredProcedureRequestContext? capturedContext = null;
+            CallToolResult result = await ExecuteCustomToolAsync(
+                dbParameters: dbParams,
+                userParameters: null,
+                captureContext: ctx => capturedContext = ctx);
+
+            AssertSuccess(result, "Should succeed for zero-param SP.");
+            Assert.IsNotNull(capturedContext);
+            Assert.AreEqual(0, capturedContext!.ResolvedParameters.Count);
+        }
+
+        #endregion
+
+        #region Execution Helpers
+
+        private const string TEST_ENTITY = "GetBook";
+        private const string SP_SOURCE_OBJECT = "get_book";
+
+        /// <summary>
+        /// Executes a DynamicCustomTool with mocked services.
+        /// </summary>
+        private static async Task<CallToolResult> ExecuteCustomToolAsync(
+            Dictionary<string, ParameterDefinition> dbParameters,
+            Dictionary<string, object>? userParameters,
+            Action<StoredProcedureRequestContext>? captureContext = null)
+        {
+            IServiceProvider sp = BuildExecutionServiceProvider(
+                dbParameters: dbParameters,
+                captureContext: captureContext);
+
+            Entity entity = CreateTestStoredProcedureEntity();
+            DynamicCustomTool tool = new(TEST_ENTITY, entity);
+
+            string argsJson = userParameters != null
+                ? JsonSerializer.Serialize(userParameters)
+                : "{}";
+            using JsonDocument arguments = JsonDocument.Parse(argsJson);
+
+            return await tool.ExecuteAsync(arguments, sp, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Builds a mocked service provider for DynamicCustomTool execution tests.
+        /// </summary>
+        private static IServiceProvider BuildExecutionServiceProvider(
+            Dictionary<string, ParameterDefinition> dbParameters,
+            Action<StoredProcedureRequestContext>? captureContext = null)
+        {
+            Entity entity = new(
+                Source: new(SP_SOURCE_OBJECT, EntitySourceType.StoredProcedure, Parameters: null, KeyFields: null),
+                GraphQL: new(TEST_ENTITY, TEST_ENTITY),
+                Rest: new(Enabled: true),
+                Fields: null,
+                Permissions: new[]
+                {
+                    new EntityPermission(
+                        Role: "anonymous",
+                        Actions: new[]
+                        {
+                            new EntityAction(Action: EntityActionOperation.Execute, Fields: null, Policy: null)
+                        })
+                },
+                Relationships: null,
+                Mappings: null,
+                Mcp: new EntityMcpOptions(customToolEnabled: true, dmlToolsEnabled: null));
+
+            Dictionary<string, Entity> entities = new() { [TEST_ENTITY] = entity };
+
+            RuntimeConfig config = new(
+                Schema: "test-schema",
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, ConnectionString: "", Options: null),
+                Runtime: new(
+                    Rest: new(),
+                    GraphQL: new(),
+                    Mcp: new(Enabled: true, Path: "/mcp", DmlTools: null),
+                    Host: new(Cors: null, Authentication: null, Mode: HostMode.Development)
+                ),
+                Entities: new(entities));
+
+            ServiceCollection services = new();
+
+            RuntimeConfigProvider configProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(config);
+            services.AddSingleton(configProvider);
+
+            // Mock authorization resolver
+            Mock<IAuthorizationResolver> mockAuthResolver = new();
+            mockAuthResolver.Setup(x => x.IsValidRoleContext(It.IsAny<HttpContext>())).Returns(true);
+            mockAuthResolver
+                .Setup(x => x.AreRoleAndOperationDefinedForEntity(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EntityActionOperation>()))
+                .Returns(true);
+            services.AddSingleton(mockAuthResolver.Object);
+
+            // Mock HttpContext
+            DefaultHttpContext httpContext = new();
+            httpContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER] = "anonymous";
+            IHttpContextAccessor httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+            services.AddSingleton(httpContextAccessor);
+
+            // Mock metadata provider with DatabaseStoredProcedure
+            DatabaseObject dbObject = new DatabaseStoredProcedure("dbo", SP_SOURCE_OBJECT)
+            {
+                SourceType = EntitySourceType.StoredProcedure,
+                StoredProcedureDefinition = new StoredProcedureDefinition
+                {
+                    Parameters = dbParameters
+                }
+            };
+
+            Mock<ISqlMetadataProvider> mockSqlMetadataProvider = new();
+            mockSqlMetadataProvider
+                .Setup(x => x.EntityToDatabaseObject)
+                .Returns(new Dictionary<string, DatabaseObject> { [TEST_ENTITY] = dbObject });
+            mockSqlMetadataProvider.Setup(x => x.GetDatabaseType()).Returns(DatabaseType.MSSQL);
+
+            Mock<IMetadataProviderFactory> mockMetadataProviderFactory = new();
+            mockMetadataProviderFactory
+                .Setup(x => x.GetMetadataProvider(It.IsAny<string>()))
+                .Returns(mockSqlMetadataProvider.Object);
+            services.AddSingleton(mockMetadataProviderFactory.Object);
+
+            // Mock query engine
+            Mock<IQueryEngine> mockQueryEngine = new();
+            mockQueryEngine
+                .Setup(x => x.ExecuteAsync(It.IsAny<StoredProcedureRequestContext>(), It.IsAny<string>()))
+                .Returns((StoredProcedureRequestContext ctx, string ds) =>
+                {
+                    captureContext?.Invoke(ctx);
+                    using JsonDocument doc = JsonDocument.Parse("[]");
+                    return Task.FromResult<IActionResult>(new OkObjectResult(doc.RootElement.Clone()));
+                });
+
+            Mock<IQueryEngineFactory> mockQueryEngineFactory = new();
+            mockQueryEngineFactory
+                .Setup(x => x.GetQueryEngine(It.IsAny<DatabaseType>()))
+                .Returns(mockQueryEngine.Object);
+            services.AddSingleton(mockQueryEngineFactory.Object);
+
+            services.AddLogging();
+
+            return services.BuildServiceProvider();
+        }
+
+        private static void AssertSuccess(CallToolResult result, string message)
+        {
+            Assert.IsTrue(result.IsError != true,
+                $"{message} Content: {GetFirstText(result)}");
+        }
+
+        private static string GetFirstText(CallToolResult result)
+        {
+            if (result.Content is null || result.Content.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return result.Content[0] is TextContentBlock textBlock
+                ? textBlock.Text ?? string.Empty
+                : string.Empty;
+        }
+
+        #endregion
 
         /// <summary>
         /// Helper method to create a test stored procedure entity.

--- a/src/Service.Tests/Mcp/DynamicCustomToolTests.cs
+++ b/src/Service.Tests/Mcp/DynamicCustomToolTests.cs
@@ -537,5 +537,271 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
                 Mcp: new EntityMcpOptions(customToolEnabled: true, dmlToolsEnabled: null)
             );
         }
+
+        #region Schema Alignment Tests (DB Metadata)
+
+        /// <summary>
+        /// After InitializeMetadata is called with valid DB metadata,
+        /// GetToolMetadata returns a schema with typed parameters from SP definition.
+        /// </summary>
+        [TestMethod]
+        public void GetToolMetadata_UsesDbMetadata_WhenInitialized()
+        {
+            // Arrange
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new() { SystemType = typeof(int) },
+                ["name"] = new() { SystemType = typeof(string) }
+            };
+
+            // Act
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert
+            Assert.AreEqual("integer", props.GetProperty("id").GetProperty("type").GetString());
+            Assert.AreEqual("string", props.GetProperty("name").GetProperty("type").GetString());
+        }
+
+        /// <summary>
+        /// When InitializeMetadata cannot resolve DB metadata, tool falls back to config schema.
+        /// </summary>
+        [TestMethod]
+        public void GetToolMetadata_FallsBackToConfig_WhenDbMetadataUnavailable()
+        {
+            // Arrange - use a service provider without metadata factory
+            ParameterMetadata[] parameters = new[]
+            {
+                new ParameterMetadata { Name = "userId", Description = "User ID" }
+            };
+            Entity entity = CreateTestStoredProcedureEntity(parameters: parameters);
+            DynamicCustomTool tool = new("GetUser", entity);
+
+            ServiceCollection services = new();
+            services.AddLogging();
+
+            // Act
+            tool.InitializeMetadata(services.BuildServiceProvider());
+            JsonElement props = ParseSchemaProperties(tool.GetToolMetadata());
+
+            // Assert - should use config-based permissive type array
+            Assert.AreEqual(JsonValueKind.Array, props.GetProperty("userId").GetProperty("type").ValueKind,
+                "Fallback schema should use multi-type array.");
+        }
+
+        /// <summary>
+        /// Without calling InitializeMetadata, tool uses config-based schema.
+        /// </summary>
+        [TestMethod]
+        public void GetToolMetadata_UsesConfigSchema_WhenNotInitialized()
+        {
+            // Arrange
+            ParameterMetadata[] parameters = new[]
+            {
+                new ParameterMetadata { Name = "bookId", Description = "Book identifier" }
+            };
+            Entity entity = CreateTestStoredProcedureEntity(parameters: parameters);
+            DynamicCustomTool tool = new("GetBook", entity);
+
+            // Act - no InitializeMetadata call
+            JsonElement props = ParseSchemaProperties(tool.GetToolMetadata());
+
+            // Assert
+            JsonElement param = props.GetProperty("bookId");
+            Assert.AreEqual(JsonValueKind.Array, param.GetProperty("type").ValueKind, "Config schema uses multi-type array.");
+            Assert.AreEqual("Book identifier", param.GetProperty("description").GetString());
+        }
+
+        /// <summary>
+        /// DB metadata parameters NOT in config are still discovered and included in schema.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_IncludesAllDbDiscoveredParams()
+        {
+            // Arrange - config has no parameters, but DB has them
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new() { SystemType = typeof(int) },
+                ["title"] = new() { SystemType = typeof(string) },
+                ["price"] = new() { SystemType = typeof(decimal) }
+            };
+
+            // Act
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert - all 3 DB-discovered params should appear
+            Assert.AreEqual(3, props.EnumerateObject().Count());
+            Assert.IsTrue(props.TryGetProperty("id", out _));
+            Assert.IsTrue(props.TryGetProperty("title", out _));
+            Assert.IsTrue(props.TryGetProperty("price", out _));
+        }
+
+        /// <summary>
+        /// Verifies type mapping for common .NET types to JSON Schema types.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(typeof(int), "integer")]
+        [DataRow(typeof(long), "integer")]
+        [DataRow(typeof(short), "integer")]
+        [DataRow(typeof(byte), "integer")]
+        [DataRow(typeof(float), "number")]
+        [DataRow(typeof(double), "number")]
+        [DataRow(typeof(decimal), "number")]
+        [DataRow(typeof(bool), "boolean")]
+        [DataRow(typeof(string), "string")]
+        [DataRow(typeof(Guid), "string")]
+        [DataRow(typeof(DateTime), "string")]
+        [DataRow(typeof(DateTimeOffset), "string")]
+        public void InitializeMetadata_MapsSystemTypesToJsonSchemaTypes(Type systemType, string expectedJsonType)
+        {
+            // Arrange & Act
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["param1"] = new() { SystemType = systemType }
+            };
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert
+            Assert.AreEqual(expectedJsonType, props.GetProperty("param1").GetProperty("type").GetString());
+        }
+
+        /// <summary>
+        /// When SystemType is null, schema uses a permissive multi-type array.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_UsesPermissiveType_WhenSystemTypeIsNull()
+        {
+            // Arrange & Act
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["unknown_param"] = new() { SystemType = null! }
+            };
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert
+            Assert.AreEqual(JsonValueKind.Array, props.GetProperty("unknown_param").GetProperty("type").ValueKind);
+        }
+
+        /// <summary>
+        /// When a parameter has HasConfigDefault=true, the description includes the default value.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_IncludesDefaultInDescription()
+        {
+            // Arrange & Act
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["tenant"] = new() { SystemType = typeof(string), HasConfigDefault = true, ConfigDefaultValue = "default_tenant" }
+            };
+            JsonElement props = InitializeAndGetSchemaProperties(dbParams);
+
+            // Assert
+            string desc = props.GetProperty("tenant").GetProperty("description").GetString()!;
+            StringAssert.Contains(desc, "default: default_tenant");
+        }
+
+        /// <summary>
+        /// Zero-parameter SP with DB metadata returns empty properties object.
+        /// </summary>
+        [TestMethod]
+        public void InitializeMetadata_ZeroParamSP_ReturnsEmptyProperties()
+        {
+            // Arrange & Act
+            JsonElement props = InitializeAndGetSchemaProperties(new Dictionary<string, ParameterDefinition>());
+
+            // Assert
+            Assert.AreEqual(0, props.EnumerateObject().Count());
+        }
+
+        /// <summary>
+        /// Helper: Creates a DynamicCustomTool, initializes it with mocked DB metadata, and returns
+        /// the "properties" element from the resulting input schema.
+        /// </summary>
+        private static JsonElement InitializeAndGetSchemaProperties(
+            Dictionary<string, ParameterDefinition> dbParameters,
+            string entityName = "TestSP")
+        {
+            Entity entity = CreateTestStoredProcedureEntity();
+            DynamicCustomTool tool = new(entityName, entity);
+            IServiceProvider sp = BuildServiceProviderForMetadata(entityName, dbParameters);
+
+            tool.InitializeMetadata(sp);
+            return ParseSchemaProperties(tool.GetToolMetadata());
+        }
+
+        /// <summary>
+        /// Helper: Parses the "properties" element from a tool's input schema.
+        /// </summary>
+        private static JsonElement ParseSchemaProperties(ModelContextProtocol.Protocol.Tool metadata)
+        {
+            return metadata.InputSchema.GetProperty("properties");
+        }
+
+        /// <summary>
+        /// Builds a service provider with mocked metadata infrastructure for schema tests.
+        /// </summary>
+        private static IServiceProvider BuildServiceProviderForMetadata(
+            string entityName,
+            Dictionary<string, ParameterDefinition> dbParameters)
+        {
+            Entity entity = new(
+                Source: new("test_procedure", EntitySourceType.StoredProcedure, Parameters: null, KeyFields: null),
+                GraphQL: new(entityName, entityName),
+                Rest: new(Enabled: true),
+                Fields: null,
+                Permissions: new[]
+                {
+                    new EntityPermission(
+                        Role: "anonymous",
+                        Actions: new[] { new EntityAction(Action: EntityActionOperation.Execute, Fields: null, Policy: null) })
+                },
+                Relationships: null,
+                Mappings: null,
+                Mcp: new EntityMcpOptions(customToolEnabled: true, dmlToolsEnabled: null));
+
+            Dictionary<string, Entity> entities = new() { [entityName] = entity };
+
+            RuntimeConfig config = new(
+                Schema: "test-schema",
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, ConnectionString: "", Options: null),
+                Runtime: new(
+                    Rest: new(),
+                    GraphQL: new(),
+                    Mcp: new(Enabled: true, Path: "/mcp", DmlTools: null),
+                    Host: new(Cors: null, Authentication: null, Mode: HostMode.Development)
+                ),
+                Entities: new(entities));
+
+            ServiceCollection services = new();
+
+            RuntimeConfigProvider configProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(config);
+            services.AddSingleton(configProvider);
+
+            // Mock metadata provider with DB object
+            DatabaseStoredProcedure dbObject = new("dbo", "test_procedure")
+            {
+                SourceType = EntitySourceType.StoredProcedure,
+                StoredProcedureDefinition = new StoredProcedureDefinition
+                {
+                    Parameters = dbParameters
+                }
+            };
+
+            Mock<ISqlMetadataProvider> mockSqlMetadataProvider = new();
+            mockSqlMetadataProvider
+                .Setup(x => x.EntityToDatabaseObject)
+                .Returns(new Dictionary<string, DatabaseObject> { [entityName] = dbObject });
+
+            Mock<IMetadataProviderFactory> mockMetadataProviderFactory = new();
+            mockMetadataProviderFactory
+                .Setup(x => x.GetMetadataProvider(It.IsAny<string>()))
+                .Returns(mockSqlMetadataProvider.Object);
+            services.AddSingleton(mockMetadataProviderFactory.Object);
+
+            services.AddLogging();
+
+            return services.BuildServiceProvider();
+        }
+
+        #endregion
     }
 }

--- a/src/Service.Tests/Mcp/ExecuteEntityToolMsSqlIntegrationTests.cs
+++ b/src/Service.Tests/Mcp/ExecuteEntityToolMsSqlIntegrationTests.cs
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Core.Resolvers;
+using Azure.DataApiBuilder.Core.Resolvers.Factories;
+using Azure.DataApiBuilder.Core.Services.Cache;
+using Azure.DataApiBuilder.Mcp.BuiltInTools;
+using Azure.DataApiBuilder.Service.Tests.SqlTests;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Protocol;
+using Moq;
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Azure.DataApiBuilder.Service.Tests.Mcp
+{
+    /// <summary>
+    /// Integration tests for ExecuteEntityTool's parameter validation and default application.
+    /// Verifies the end-to-end behavior after the fix:
+    /// - Parameters are validated against StoredProcedureDefinition.Parameters (DB metadata),
+    ///   not config-side parameters alone.
+    /// - Config defaults are applied from ParameterDefinition.HasConfigDefault/ConfigDefaultValue
+    ///   for any parameter the user did not supply.
+    ///
+    /// Scenarios (reuse SPs already defined in DatabaseSchema-MsSql.sql / dab-config.MsSql.json):
+    ///   - GetBook   -> SP get_book_by_id(@id int), no config params.
+    ///   - InsertBook -> SP insert_book(@title, @publisher_id), config defaults applied.
+    ///   - GetBooks  -> SP get_books, zero params.
+    /// </summary>
+    [TestClass, TestCategory(TestCategory.MSSQL)]
+    public class ExecuteEntityToolMsSqlIntegrationTests : SqlTestBase
+    {
+        [ClassInitialize]
+        public static async Task SetupAsync(TestContext context)
+        {
+            DatabaseEngine = TestCategory.MSSQL;
+            await InitializeTestFixture();
+        }
+
+        /// <summary>
+        /// Data-driven test validating successful SP execution across multiple parameter scenarios.
+        /// Each row exercises a distinct code path in ExecuteEntityTool:
+        /// - DB-discovered param with no config entry (validates the fix for param validation).
+        /// - Config defaults applied when user omits params.
+        /// - User-supplied params override config defaults.
+        /// - Zero-param SP succeeds with no parameters.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("GetBook", "{\"id\": 1}", DisplayName = "DB-discovered param accepted (no config entry)")]
+        [DataRow("InsertBook", null, DisplayName = "Config defaults applied when no params supplied")]
+        [DataRow("InsertBook", "{\"title\": \"Integration Test Book\", \"publisher_id\": 2345}", DisplayName = "User-supplied params override defaults")]
+        [DataRow("GetBooks", null, DisplayName = "Zero-param SP succeeds")]
+        public async Task ExecuteEntity_SuccessfulExecution(string entityName, string? parametersJson)
+        {
+            Dictionary<string, object>? parameters = parametersJson != null
+                ? JsonSerializer.Deserialize<Dictionary<string, object>>(parametersJson)
+                : null;
+
+            CallToolResult result = await ExecuteEntityAsync(entityName, parameters);
+
+            AssertSuccess(result,
+                $"execute_entity failed for entity '{entityName}' with params '{parametersJson}'.");
+
+            // Parse response and verify structure
+            string content = GetFirstTextContent(result);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(content), $"Expected non-empty result for entity '{entityName}'.");
+
+            using JsonDocument doc = JsonDocument.Parse(content);
+            JsonElement root = doc.RootElement;
+            Assert.AreEqual(entityName, root.GetProperty("entity").GetString());
+            Assert.AreEqual("Stored procedure executed successfully", root.GetProperty("message").GetString());
+        }
+
+        /// <summary>
+        /// Verify that GetBook with id=1 returns the actual book record from the database.
+        /// This ensures the parameter value is correctly passed to the stored procedure.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_GetBookById_ReturnsMatchingRecord()
+        {
+            Dictionary<string, object> parameters = new() { { "id", 1 } };
+            CallToolResult result = await ExecuteEntityAsync("GetBook", parameters);
+
+            AssertSuccess(result, "GetBook with id=1 should succeed.");
+
+            using JsonDocument doc = JsonDocument.Parse(GetFirstTextContent(result));
+            JsonElement root = doc.RootElement;
+
+            // Verify the value property contains the SP result with at least one record with id=1.
+            // SqlResponseHelpers.OkResponse wraps results in { value: [...] }, and
+            // BuildExecuteSuccessResponse serializes that as-is into the "value" field.
+            Assert.IsTrue(root.TryGetProperty("value", out JsonElement valueWrapper), "Response should contain 'value' property.");
+
+            // The value may be the wrapper object { "value": [...] } or directly an array.
+            JsonElement records = valueWrapper.ValueKind == JsonValueKind.Object
+                ? valueWrapper.GetProperty("value")
+                : valueWrapper;
+
+            Assert.AreEqual(JsonValueKind.Array, records.ValueKind);
+            Assert.IsTrue(records.GetArrayLength() > 0, "Expected at least one book record.");
+            Assert.AreEqual(1, records[0].GetProperty("id").GetInt32());
+        }
+
+        /// <summary>
+        /// Verify that InsertBook with no user params applies config defaults (title="randomX", publisher_id="1234").
+        /// The SP inserts using those defaults. We verify the tool reports success (the SP executed without error).
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_InsertBookWithDefaults_ExecutesSuccessfully()
+        {
+            CallToolResult result = await ExecuteEntityAsync("InsertBook", parameters: null);
+
+            AssertSuccess(result, "InsertBook with config defaults should succeed.");
+
+            using JsonDocument doc = JsonDocument.Parse(GetFirstTextContent(result));
+            JsonElement root = doc.RootElement;
+            Assert.AreEqual("InsertBook", root.GetProperty("entity").GetString());
+        }
+
+        /// <summary>
+        /// Reject a parameter name that does not exist in the DB metadata.
+        /// Validation against StoredProcedureDefinition.Parameters should catch this.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("GetBook", "nonexistent_param", "value", DisplayName = "Rejects unknown param on single-param SP")]
+        [DataRow("GetBooks", "bogus", "123", DisplayName = "Rejects any param on zero-param SP")]
+        public async Task ExecuteEntity_InvalidParamName_ReturnsError(string entityName, string paramName, string paramValue)
+        {
+            Dictionary<string, object> parameters = new() { { paramName, paramValue } };
+            CallToolResult result = await ExecuteEntityAsync(entityName, parameters);
+
+            Assert.IsTrue(result.IsError == true,
+                $"execute_entity should reject parameter '{paramName}' not in DB metadata for '{entityName}'.");
+            string content = GetFirstTextContent(result);
+            StringAssert.Contains(content, paramName);
+        }
+
+        private static async Task<CallToolResult> ExecuteEntityAsync(string entityName, Dictionary<string, object>? parameters)
+        {
+            IServiceProvider serviceProvider = BuildExecuteEntityServiceProvider();
+            ExecuteEntityTool tool = new();
+
+            var args = new Dictionary<string, object> { { "entity", entityName } };
+            if (parameters != null)
+            {
+                args["parameters"] = parameters;
+            }
+
+            string argsJson = JsonSerializer.Serialize(args);
+            using JsonDocument arguments = JsonDocument.Parse(argsJson);
+
+            return await tool.ExecuteAsync(arguments, serviceProvider, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Builds a service provider that wires ExecuteEntityTool to the shared fixture's
+        /// real ISqlMetadataProvider, real IQueryEngine (SqlQueryEngine), and real
+        /// authorization resolver, with a DefaultHttpContext carrying the anonymous role header.
+        /// Uses the RuntimeConfigProvider from the WebApplicationFactory so that the datasource
+        /// name matches what the real MsSqlQueryExecutor was initialized with.
+        /// </summary>
+        private static IServiceProvider BuildExecuteEntityServiceProvider()
+        {
+            ServiceCollection services = new();
+
+            // Use the RuntimeConfigProvider from the WebApplicationFactory — this is the same
+            // provider that initialized _queryExecutor, so its DefaultDataSourceName matches
+            // the key in _queryExecutor.ConnectionStringBuilders.
+            RuntimeConfigProvider configProvider = _application.Services.GetRequiredService<RuntimeConfigProvider>();
+            services.AddSingleton(configProvider);
+
+            // Real metadata-provider factory backed by the shared fixture's live provider.
+            services.AddSingleton(_metadataProviderFactory.Object);
+
+            // Real authorization resolver wired by SqlTestBase against the live config + provider.
+            services.AddSingleton(_authorizationResolver);
+
+            // Real HttpContext carrying the anonymous role header and a ClaimsPrincipal
+            // with the anonymous role claim so that AuthorizationResolver.IsValidRoleContext
+            // (which calls httpContext.User.IsInRole) returns true.
+            DefaultHttpContext httpContext = new();
+            httpContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER] = AuthorizationResolver.ROLE_ANONYMOUS;
+            ClaimsIdentity identity = new(
+                authenticationType: "TestAuth",
+                nameType: null,
+                roleType: AuthenticationOptions.ROLE_CLAIM_TYPE);
+            identity.AddClaim(new Claim(AuthenticationOptions.ROLE_CLAIM_TYPE, AuthorizationResolver.ROLE_ANONYMOUS));
+            httpContext.User = new ClaimsPrincipal(identity);
+            IHttpContextAccessor httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+            services.AddSingleton(httpContextAccessor);
+
+            // Build a real SqlQueryEngine using the shared fixtures.
+            Mock<IFusionCache> cache = new();
+            DabCacheService cacheService = new(cache.Object, logger: null, httpContextAccessor);
+
+            SqlQueryEngine queryEngine = new(
+                _queryManagerFactory.Object,
+                _metadataProviderFactory.Object,
+                httpContextAccessor,
+                _authorizationResolver,
+                _gqlFilterParser,
+                new Mock<ILogger<IQueryEngine>>().Object,
+                configProvider,
+                cacheService);
+
+            // Wrap in a mock IQueryEngineFactory that returns the real engine.
+            Mock<IQueryEngineFactory> queryEngineFactory = new();
+            queryEngineFactory
+                .Setup(f => f.GetQueryEngine(It.IsAny<DatabaseType>()))
+                .Returns(queryEngine);
+            services.AddSingleton(queryEngineFactory.Object);
+
+            services.AddLogging();
+
+            return services.BuildServiceProvider();
+        }
+
+        private static string GetFirstTextContent(CallToolResult result)
+        {
+            if (result.Content is null || result.Content.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return result.Content[0] is TextContentBlock textBlock
+                ? textBlock.Text ?? string.Empty
+                : string.Empty;
+        }
+
+        private static void AssertSuccess(CallToolResult result, string message)
+        {
+            Assert.IsTrue(result.IsError != true,
+                $"{message} Content: {GetFirstTextContent(result)}");
+        }
+    }
+}

--- a/src/Service.Tests/Mcp/ExecuteEntityToolTests.cs
+++ b/src/Service.Tests/Mcp/ExecuteEntityToolTests.cs
@@ -159,7 +159,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
 
             AssertSuccess(result, "Should succeed with config defaults.");
             Assert.IsNotNull(capturedContext, "Query engine should have been called.");
-            Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("title"));
+            Assert.IsTrue(capturedContext!.ResolvedParameters.ContainsKey("title"));
             Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("publisher_id"));
             Assert.AreEqual("defaultTitle", capturedContext.ResolvedParameters["title"]);
             Assert.AreEqual("999", capturedContext.ResolvedParameters["publisher_id"]);
@@ -186,7 +186,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
 
             AssertSuccess(result, "Should succeed with user-supplied params.");
             Assert.IsNotNull(capturedContext);
-            Assert.AreEqual("UserTitle", capturedContext.ResolvedParameters["title"]);
+            Assert.AreEqual("UserTitle", capturedContext!.ResolvedParameters["title"]);
             // publisher_id should get the config default since user didn't supply it
             Assert.AreEqual("999", capturedContext.ResolvedParameters["publisher_id"]);
         }
@@ -213,7 +213,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
 
             AssertSuccess(result, "Should succeed with partial params.");
             Assert.IsNotNull(capturedContext);
-            Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("id"));
+            Assert.IsTrue(capturedContext!.ResolvedParameters.ContainsKey("id"));
             Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("tenant"));
             Assert.AreEqual("default_tenant", capturedContext.ResolvedParameters["tenant"]);
         }
@@ -236,7 +236,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
 
             AssertSuccess(result, "Should succeed for zero-param SP.");
             Assert.IsNotNull(capturedContext);
-            Assert.AreEqual(0, capturedContext.ResolvedParameters.Count);
+            Assert.AreEqual(0, capturedContext!.ResolvedParameters.Count);
         }
 
         #endregion

--- a/src/Service.Tests/Mcp/ExecuteEntityToolTests.cs
+++ b/src/Service.Tests/Mcp/ExecuteEntityToolTests.cs
@@ -1,0 +1,449 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Auth;
+using Azure.DataApiBuilder.Config.DatabasePrimitives;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Core.Models;
+using Azure.DataApiBuilder.Core.Resolvers;
+using Azure.DataApiBuilder.Core.Resolvers.Factories;
+using Azure.DataApiBuilder.Core.Services;
+using Azure.DataApiBuilder.Core.Services.MetadataProviders;
+using Azure.DataApiBuilder.Mcp.BuiltInTools;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModelContextProtocol.Protocol;
+using Moq;
+
+namespace Azure.DataApiBuilder.Service.Tests.Mcp
+{
+    /// <summary>
+    /// Unit tests for ExecuteEntityTool parameter validation and default application.
+    /// Uses mocked metadata and query engine to isolate the tool's logic from real DB.
+    ///
+    /// Key behaviors tested:
+    /// - Parameters validated against StoredProcedureDefinition.Parameters (DB metadata).
+    /// - Config defaults (HasConfigDefault/ConfigDefaultValue) applied for missing params.
+    /// - Invalid parameter names rejected.
+    /// - Entity-level and runtime-level gating.
+    /// </summary>
+    [TestClass]
+    public class ExecuteEntityToolTests
+    {
+        private const string TEST_ENTITY = "GetBook";
+        private const string SP_SOURCE_OBJECT = "get_book";
+
+        #region Parameter Validation Tests
+
+        /// <summary>
+        /// A parameter that exists in DB metadata (StoredProcedureDefinition.Parameters)
+        /// is accepted even if it has no config-side entry.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_AcceptsDbDiscoveredParam_NotInConfig()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new()
+            };
+
+            CallToolResult result = await ExecuteWithMockedEngineAsync(
+                entityName: TEST_ENTITY,
+                dbParameters: dbParams,
+                userParameters: new() { { "id", 1 } });
+
+            AssertSuccess(result, "Should accept DB-discovered param 'id'.");
+        }
+
+        /// <summary>
+        /// A parameter name NOT in StoredProcedureDefinition.Parameters is rejected
+        /// with an InvalidArguments error.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("nonexistent", DisplayName = "Completely unknown param")]
+        [DataRow("ID", DisplayName = "Case-sensitive mismatch")]
+        public async Task ExecuteEntity_RejectsInvalidParamName(string invalidParamName)
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new()
+            };
+
+            CallToolResult result = await ExecuteWithMockedEngineAsync(
+                entityName: TEST_ENTITY,
+                dbParameters: dbParams,
+                userParameters: new() { { invalidParamName, "value" } });
+
+            Assert.IsTrue(result.IsError == true,
+                $"Should reject param '{invalidParamName}' not in DB metadata.");
+            string content = GetFirstText(result);
+            StringAssert.Contains(content, invalidParamName);
+            StringAssert.Contains(content, "InvalidArguments");
+        }
+
+        /// <summary>
+        /// Multiple parameters can be provided when all exist in DB metadata.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_AcceptsMultipleValidParams()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["title"] = new(),
+                ["publisher_id"] = new()
+            };
+
+            CallToolResult result = await ExecuteWithMockedEngineAsync(
+                entityName: TEST_ENTITY,
+                dbParameters: dbParams,
+                userParameters: new() { { "title", "Test" }, { "publisher_id", 123 } });
+
+            AssertSuccess(result, "Should accept all valid params.");
+        }
+
+        /// <summary>
+        /// If one param in a multi-param request is invalid, the entire request is rejected.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_RejectsRequest_WhenAnyParamInvalid()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new()
+            };
+
+            CallToolResult result = await ExecuteWithMockedEngineAsync(
+                entityName: TEST_ENTITY,
+                dbParameters: dbParams,
+                userParameters: new() { { "id", 1 }, { "bogus", "x" } });
+
+            Assert.IsTrue(result.IsError == true,
+                "Should reject request when any param is invalid.");
+            StringAssert.Contains(GetFirstText(result), "bogus");
+        }
+
+        #endregion
+
+        #region Default Application Tests
+
+        /// <summary>
+        /// Config defaults are applied for parameters the user did not supply.
+        /// Verifies that the context passed to the query engine includes the default values.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_AppliesConfigDefaults_ForMissingParams()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["title"] = new() { HasConfigDefault = true, ConfigDefaultValue = "defaultTitle" },
+                ["publisher_id"] = new() { HasConfigDefault = true, ConfigDefaultValue = "999" }
+            };
+
+            StoredProcedureRequestContext? capturedContext = null;
+            CallToolResult result = await ExecuteWithMockedEngineAsync(
+                entityName: TEST_ENTITY,
+                dbParameters: dbParams,
+                userParameters: null,
+                captureContext: ctx => capturedContext = ctx);
+
+            AssertSuccess(result, "Should succeed with config defaults.");
+            Assert.IsNotNull(capturedContext, "Query engine should have been called.");
+            Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("title"));
+            Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("publisher_id"));
+            Assert.AreEqual("defaultTitle", capturedContext.ResolvedParameters["title"]);
+            Assert.AreEqual("999", capturedContext.ResolvedParameters["publisher_id"]);
+        }
+
+        /// <summary>
+        /// User-supplied parameters override config defaults.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_UserParams_OverrideConfigDefaults()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["title"] = new() { HasConfigDefault = true, ConfigDefaultValue = "defaultTitle" },
+                ["publisher_id"] = new() { HasConfigDefault = true, ConfigDefaultValue = "999" }
+            };
+
+            StoredProcedureRequestContext? capturedContext = null;
+            CallToolResult result = await ExecuteWithMockedEngineAsync(
+                entityName: TEST_ENTITY,
+                dbParameters: dbParams,
+                userParameters: new() { { "title", "UserTitle" } },
+                captureContext: ctx => capturedContext = ctx);
+
+            AssertSuccess(result, "Should succeed with user-supplied params.");
+            Assert.IsNotNull(capturedContext);
+            Assert.AreEqual("UserTitle", capturedContext.ResolvedParameters["title"]);
+            // publisher_id should get the config default since user didn't supply it
+            Assert.AreEqual("999", capturedContext.ResolvedParameters["publisher_id"]);
+        }
+
+        /// <summary>
+        /// Parameters without config defaults are NOT injected into the request.
+        /// Only params with HasConfigDefault=true get applied.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_DoesNotInjectParams_WithoutConfigDefault()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new()
+            {
+                ["id"] = new(), // No config default
+                ["tenant"] = new() { HasConfigDefault = true, ConfigDefaultValue = "default_tenant" }
+            };
+
+            StoredProcedureRequestContext? capturedContext = null;
+            CallToolResult result = await ExecuteWithMockedEngineAsync(
+                entityName: TEST_ENTITY,
+                dbParameters: dbParams,
+                userParameters: new() { { "id", 42 } },
+                captureContext: ctx => capturedContext = ctx);
+
+            AssertSuccess(result, "Should succeed with partial params.");
+            Assert.IsNotNull(capturedContext);
+            Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("id"));
+            Assert.IsTrue(capturedContext.ResolvedParameters.ContainsKey("tenant"));
+            Assert.AreEqual("default_tenant", capturedContext.ResolvedParameters["tenant"]);
+        }
+
+        /// <summary>
+        /// Zero-parameter SP with no user params and no config defaults: no parameters
+        /// are passed to the query engine.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_ZeroParamSP_PassesEmptyParams()
+        {
+            Dictionary<string, ParameterDefinition> dbParams = new();
+
+            StoredProcedureRequestContext? capturedContext = null;
+            CallToolResult result = await ExecuteWithMockedEngineAsync(
+                entityName: TEST_ENTITY,
+                dbParameters: dbParams,
+                userParameters: null,
+                captureContext: ctx => capturedContext = ctx);
+
+            AssertSuccess(result, "Should succeed for zero-param SP.");
+            Assert.IsNotNull(capturedContext);
+            Assert.AreEqual(0, capturedContext.ResolvedParameters.Count);
+        }
+
+        #endregion
+
+        #region Gating Tests
+
+        /// <summary>
+        /// When the entity is not a stored procedure, ExecuteEntityTool returns InvalidEntity.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_RejectsNonStoredProcedureEntity()
+        {
+            IServiceProvider sp = BuildServiceProvider(
+                entityName: "Book",
+                sourceObject: "books",
+                sourceType: EntitySourceType.Table,
+                dbParameters: new());
+
+            ExecuteEntityTool tool = new();
+            using JsonDocument args = JsonDocument.Parse("{\"entity\": \"Book\"}");
+            CallToolResult result = await tool.ExecuteAsync(args, sp, CancellationToken.None);
+
+            Assert.IsTrue(result.IsError == true);
+            StringAssert.Contains(GetFirstText(result), "InvalidEntity");
+        }
+
+        /// <summary>
+        /// When the entity does not exist in config, returns EntityNotFound.
+        /// </summary>
+        [TestMethod]
+        public async Task ExecuteEntity_ReturnsError_WhenEntityNotFound()
+        {
+            IServiceProvider sp = BuildServiceProvider(
+                entityName: TEST_ENTITY,
+                sourceObject: SP_SOURCE_OBJECT,
+                sourceType: EntitySourceType.StoredProcedure,
+                dbParameters: new() { ["id"] = new() });
+
+            ExecuteEntityTool tool = new();
+            using JsonDocument args = JsonDocument.Parse("{\"entity\": \"NonExistent\"}");
+            CallToolResult result = await tool.ExecuteAsync(args, sp, CancellationToken.None);
+
+            Assert.IsTrue(result.IsError == true);
+            StringAssert.Contains(GetFirstText(result), "EntityNotFound");
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Runs ExecuteEntityTool with a mocked query engine that captures the
+        /// StoredProcedureRequestContext and returns an empty result.
+        /// </summary>
+        private static async Task<CallToolResult> ExecuteWithMockedEngineAsync(
+            string entityName,
+            Dictionary<string, ParameterDefinition> dbParameters,
+            Dictionary<string, object>? userParameters,
+            Action<StoredProcedureRequestContext>? captureContext = null)
+        {
+            IServiceProvider sp = BuildServiceProvider(
+                entityName: entityName,
+                sourceObject: SP_SOURCE_OBJECT,
+                sourceType: EntitySourceType.StoredProcedure,
+                dbParameters: dbParameters,
+                captureContext: captureContext);
+
+            ExecuteEntityTool tool = new();
+
+            var args = new Dictionary<string, object> { { "entity", entityName } };
+            if (userParameters != null)
+            {
+                args["parameters"] = userParameters;
+            }
+
+            string argsJson = JsonSerializer.Serialize(args);
+            using JsonDocument arguments = JsonDocument.Parse(argsJson);
+
+            return await tool.ExecuteAsync(arguments, sp, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Builds a fully mocked service provider for ExecuteEntityTool.
+        /// </summary>
+        private static IServiceProvider BuildServiceProvider(
+            string entityName,
+            string sourceObject,
+            EntitySourceType sourceType,
+            Dictionary<string, ParameterDefinition> dbParameters,
+            Action<StoredProcedureRequestContext>? captureContext = null)
+        {
+            Entity entity = new(
+                Source: new(sourceObject, sourceType, Parameters: null, KeyFields: null),
+                GraphQL: new(entityName, entityName),
+                Rest: new(Enabled: true),
+                Fields: null,
+                Permissions: new[]
+                {
+                    new EntityPermission(
+                        Role: "anonymous",
+                        Actions: new[]
+                        {
+                            new EntityAction(Action: EntityActionOperation.Execute, Fields: null, Policy: null)
+                        })
+                },
+                Relationships: null,
+                Mappings: null,
+                Mcp: null);
+
+            Dictionary<string, Entity> entities = new() { [entityName] = entity };
+
+            RuntimeConfig config = new(
+                Schema: "test-schema",
+                DataSource: new DataSource(DatabaseType: DatabaseType.MSSQL, ConnectionString: "", Options: null),
+                Runtime: new(
+                    Rest: new(),
+                    GraphQL: new(),
+                    Mcp: new(Enabled: true, Path: "/mcp", DmlTools: null),
+                    Host: new(Cors: null, Authentication: null, Mode: HostMode.Development)
+                ),
+                Entities: new(entities));
+
+            ServiceCollection services = new();
+
+            RuntimeConfigProvider configProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(config);
+            services.AddSingleton(configProvider);
+
+            // Mock authorization resolver
+            Mock<IAuthorizationResolver> mockAuthResolver = new();
+            mockAuthResolver.Setup(x => x.IsValidRoleContext(It.IsAny<HttpContext>())).Returns(true);
+            mockAuthResolver
+                .Setup(x => x.AreRoleAndOperationDefinedForEntity(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EntityActionOperation>()))
+                .Returns(true);
+            services.AddSingleton(mockAuthResolver.Object);
+
+            // Mock HttpContext with anonymous role header
+            DefaultHttpContext httpContext = new();
+            httpContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER] = "anonymous";
+            IHttpContextAccessor httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+            services.AddSingleton(httpContextAccessor);
+
+            // Mock metadata provider with DB object
+            DatabaseObject dbObject = sourceType == EntitySourceType.StoredProcedure
+                ? new DatabaseStoredProcedure("dbo", sourceObject)
+                {
+                    SourceType = EntitySourceType.StoredProcedure,
+                    StoredProcedureDefinition = new StoredProcedureDefinition
+                    {
+                        Parameters = dbParameters
+                    }
+                }
+                : new DatabaseTable("dbo", sourceObject) { SourceType = EntitySourceType.Table };
+
+            Mock<ISqlMetadataProvider> mockSqlMetadataProvider = new();
+            mockSqlMetadataProvider
+                .Setup(x => x.EntityToDatabaseObject)
+                .Returns(new Dictionary<string, DatabaseObject> { [entityName] = dbObject });
+            mockSqlMetadataProvider.Setup(x => x.GetDatabaseType()).Returns(DatabaseType.MSSQL);
+
+            Mock<IMetadataProviderFactory> mockMetadataProviderFactory = new();
+            mockMetadataProviderFactory
+                .Setup(x => x.GetMetadataProvider(It.IsAny<string>()))
+                .Returns(mockSqlMetadataProvider.Object);
+            services.AddSingleton(mockMetadataProviderFactory.Object);
+
+            // Mock query engine factory
+            Mock<IQueryEngine> mockQueryEngine = new();
+            mockQueryEngine
+                .Setup(x => x.ExecuteAsync(It.IsAny<StoredProcedureRequestContext>(), It.IsAny<string>()))
+                .Returns((StoredProcedureRequestContext ctx, string ds) =>
+                {
+                    captureContext?.Invoke(ctx);
+                    // Return empty JSON array result
+                    using JsonDocument doc = JsonDocument.Parse("[]");
+                    return Task.FromResult<IActionResult>(new OkObjectResult(doc.RootElement.Clone()));
+                });
+
+            Mock<IQueryEngineFactory> mockQueryEngineFactory = new();
+            mockQueryEngineFactory
+                .Setup(x => x.GetQueryEngine(It.IsAny<DatabaseType>()))
+                .Returns(mockQueryEngine.Object);
+            services.AddSingleton(mockQueryEngineFactory.Object);
+
+            services.AddLogging();
+
+            return services.BuildServiceProvider();
+        }
+
+        private static void AssertSuccess(CallToolResult result, string message)
+        {
+            Assert.IsTrue(result.IsError != true,
+                $"{message} Content: {GetFirstText(result)}");
+        }
+
+        private static string GetFirstText(CallToolResult result)
+        {
+            if (result.Content is null || result.Content.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            return result.Content[0] is TextContentBlock textBlock
+                ? textBlock.Text ?? string.Empty
+                : string.Empty;
+        }
+
+        #endregion
+    }
+}

--- a/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
+++ b/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
@@ -2842,7 +2842,11 @@
               }
             ]
           }
-        ]
+        ],
+        Mcp: {
+          CustomToolEnabled: true,
+          DmlToolEnabled: true
+        }
       }
     },
     {
@@ -2880,7 +2884,11 @@
               }
             ]
           }
-        ]
+        ],
+        Mcp: {
+          CustomToolEnabled: true,
+          DmlToolEnabled: true
+        }
       }
     },
     {
@@ -2918,7 +2926,11 @@
               }
             ]
           }
-        ]
+        ],
+        Mcp: {
+          CustomToolEnabled: true,
+          DmlToolEnabled: true
+        }
       }
     },
     {
@@ -2968,7 +2980,11 @@
               }
             ]
           }
-        ]
+        ],
+        Mcp: {
+          CustomToolEnabled: true,
+          DmlToolEnabled: true
+        }
       }
     },
     {
@@ -3006,7 +3022,11 @@
               }
             ]
           }
-        ]
+        ],
+        Mcp: {
+          CustomToolEnabled: true,
+          DmlToolEnabled: true
+        }
       }
     },
     {

--- a/src/Service.Tests/dab-config.MsSql.json
+++ b/src/Service.Tests/dab-config.MsSql.json
@@ -2890,7 +2890,10 @@
             }
           ]
         }
-      ]
+      ],
+      "mcp": {
+        "custom-tool": true
+      }
     },
     "GetBook": {
       "source": {
@@ -2928,7 +2931,10 @@
             }
           ]
         }
-      ]
+      ],
+      "mcp": {
+        "custom-tool": true
+      }
     },
     "GetPublisher": {
       "source": {
@@ -2966,7 +2972,10 @@
             }
           ]
         }
-      ]
+      ],
+      "mcp": {
+        "custom-tool": true
+      }
     },
     "InsertBook": {
       "source": {
@@ -3008,7 +3017,10 @@
             }
           ]
         }
-      ]
+      ],
+      "mcp": {
+        "custom-tool": true
+      }
     },
     "CountBooks": {
       "source": {
@@ -3046,7 +3058,10 @@
             }
           ]
         }
-      ]
+      ],
+      "mcp": {
+        "custom-tool": true
+      }
     },
     "DeleteLastInsertedBook": {
       "source": {

--- a/src/Service/Utilities/McpStdioHelper.cs
+++ b/src/Service/Utilities/McpStdioHelper.cs
@@ -83,10 +83,7 @@ namespace Azure.DataApiBuilder.Service.Utilities
             IEnumerable<Mcp.Model.IMcpTool> tools =
                 host.Services.GetServices<Mcp.Model.IMcpTool>();
 
-            foreach (Mcp.Model.IMcpTool tool in tools)
-            {
-                registry.RegisterTool(tool);
-            }
+            Mcp.Core.McpToolRegistry.InitializeAndRegisterTools(tools, registry, host.Services);
 
             IHostApplicationLifetime lifetime =
                 host.Services.GetRequiredService<IHostApplicationLifetime>();


### PR DESCRIPTION
Cherry-pick of commits from main to release/2.0:

- 5d6faf92 ExecuteEntityTool: DB metadata based parameter support (#3600)
- a085d86e DynamicCustomTool: DB metadata based parameter support (#3601)
- b84d8d6e DynamicCustomTool: Align tool input schema with DB metadata at runtime (#3619)