### PR TITLE
Mark required stored-procedure parameters as NON_NULL in GraphQL

### DIFF
--- a/src/Service.GraphQLBuilder/GraphQLStoredProcedureBuilder.cs
+++ b/src/Service.GraphQLBuilder/GraphQLStoredProcedureBuilder.cs
@@ -25,6 +25,12 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
         /// It uses the parameters to build the arguments and returns a list
         /// of the StoredProcedure GraphQL object.
         /// </summary>
+        /// <remarks>
+        /// Each input argument's GraphQL type is wrapped in <see cref="NonNullTypeNode"/> when the
+        /// parameter is required, so introspection (<c>String!</c> vs <c>String</c>) reflects whether
+        /// the caller must supply a value. A parameter is treated as required unless the runtime
+        /// config explicitly sets <c>required: false</c> for it.
+        /// </remarks>
         /// <param name="name">Name used for InputValueDefinition name.</param>
         /// <param name="entity">Entity's runtime config metadata.</param>
         /// <param name="dbObject">Stored procedure database schema metadata.</param>
@@ -55,16 +61,26 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
                     // Without database metadata, there is no way to know to cast 1 to a decimal versus an integer.
 
                     IValueNode? defaultValueNode = null;
-                    if (entity.Source.Parameters is not null)
-                    {
-                        ParameterMetadata? paramMetadata = entity.Source.Parameters
-                            .FirstOrDefault(p => p.Name == param);
+                    ParameterMetadata? paramMetadata = entity.Source.Parameters?
+                        .FirstOrDefault(p => p.Name == param);
 
-                        if (paramMetadata is not null && paramMetadata.Default is not null)
-                        {
-                            Tuple<string, IValueNode> defaultGraphQLValue = ConvertValueToGraphQLType(paramMetadata.Default.ToString()!, parameterDefinition: spdef.Parameters[param]);
-                            defaultValueNode = defaultGraphQLValue.Item2;
-                        }
+                    if (paramMetadata is not null && paramMetadata.Default is not null)
+                    {
+                        Tuple<string, IValueNode> defaultGraphQLValue = ConvertValueToGraphQLType(paramMetadata.Default.ToString()!, parameterDefinition: spdef.Parameters[param]);
+                        defaultValueNode = defaultGraphQLValue.Item2;
+                    }
+
+                    // Default to required so the schema doesn't silently mark a mandatory parameter as
+                    // optional. T-SQL nullability does not indicate whether a caller must supply a value,
+                    // so we only relax this when the config explicitly opts out.
+                    bool isRequired = paramMetadata?.Required ?? true;
+
+                    ITypeNode parameterTypeNode = new NamedTypeNode(
+                        SchemaConverter.GetGraphQLTypeFromSystemType(type: definition.SystemType));
+
+                    if (isRequired)
+                    {
+                        parameterTypeNode = new NonNullTypeNode((INullableTypeNode)parameterTypeNode);
                     }
 
                     inputValues.Add(
@@ -74,7 +90,7 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder
                             description: definition.Description != null
                                         ? new StringValueNode(definition.Description)
                                         : new StringValueNode($"parameters for {name.Value} stored-procedure"),
-                            type: new NamedTypeNode(SchemaConverter.GetGraphQLTypeFromSystemType(type: definition.SystemType)),
+                            type: parameterTypeNode,
                             defaultValue: defaultValueNode,
                             directives: new List<DirectiveNode>())
                         );

--- a/src/Service.Tests/GraphQLBuilder/Sql/StoredProcedureBuilderTests.cs
+++ b/src/Service.Tests/GraphQLBuilder/Sql/StoredProcedureBuilderTests.cs
@@ -249,5 +249,154 @@ namespace Azure.DataApiBuilder.Service.Tests.GraphQLBuilder.Sql
             string mismatchedTypeErrorMsg = $"Failure: Parameter '{parameterName}' is type '{actualGraphQLType}' but should be type '{expectedGraphQLType}'";
             Assert.AreEqual(expected: expectedGraphQLType, actual: actualGraphQLType, message: mismatchedTypeErrorMsg);
         }
+
+        /// <summary>
+        /// Validates that stored-procedure input arguments are emitted with the correct GraphQL
+        /// nullability based on the parameter's required flag:
+        /// <list type="bullet">
+        ///   <item><description>A parameter listed in config with <c>required: true</c> is wrapped in <see cref="NonNullTypeNode"/>.</description></item>
+        ///   <item><description>A parameter listed in config with <c>required: false</c> stays a nullable <see cref="NamedTypeNode"/>.</description></item>
+        ///   <item><description>A parameter discovered from database metadata but not declared in config defaults to required and is wrapped in <see cref="NonNullTypeNode"/>.</description></item>
+        /// </list>
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("requiredParam", true, false, true, DisplayName = "Config required=true -> NonNull")]
+        [DataRow("optionalParam", true, true, false, DisplayName = "Config required=false -> nullable")]
+        [DataRow("dbOnlyParam", false, false, true, DisplayName = "Param not in config -> defaults to NonNull (required)")]
+        public void StoredProcedure_RequiredFlag_ProducesNonNullType(
+            string parameterName,
+            bool listInConfig,
+            bool configRequiredFalse,
+            bool expectsNonNull)
+        {
+            DatabaseObject spDbObj = new DatabaseStoredProcedure(schemaName: "dbo", tableName: "spReqTest")
+            {
+                SourceType = EntitySourceType.StoredProcedure,
+                StoredProcedureDefinition = new()
+                {
+                    Parameters = new() { { parameterName, new() { SystemType = typeof(string) } } }
+                }
+            };
+            spDbObj.SourceDefinition.Columns.TryAdd("col1", new() { SystemType = typeof(string) });
+
+            List<ParameterMetadata> configParameters = new();
+            if (listInConfig)
+            {
+                configParameters.Add(new ParameterMetadata
+                {
+                    Name = parameterName,
+                    Required = !configRequiredFalse
+                });
+            }
+
+            FieldDefinitionNode field = BuildSchemaAndGetExecuteField(
+                spDbObj: spDbObj,
+                configParameters: configParameters,
+                graphQLTypeName: "SpReqTestType",
+                entityName: "SpReqTest");
+
+            InputValueDefinitionNode arg = field.Arguments.First(a => a.Name.Value == parameterName);
+
+            if (expectsNonNull)
+            {
+                Assert.IsInstanceOfType(arg.Type, typeof(NonNullTypeNode),
+                    $"Expected '{parameterName}' to be NonNullTypeNode but was '{arg.Type.GetType().Name}'.");
+            }
+            else
+            {
+                Assert.IsInstanceOfType(arg.Type, typeof(NamedTypeNode),
+                    $"Expected '{parameterName}' to be nullable NamedTypeNode but was '{arg.Type.GetType().Name}'.");
+            }
+
+            // Underlying named type should remain the same regardless of nullability wrapping.
+            Assert.AreEqual(STRING_TYPE, arg.Type.NamedType().Name.Value);
+        }
+
+        /// <summary>
+        /// Validates that a required parameter with a config-supplied default value still emits a
+        /// NON_NULL input argument and preserves the default value on the GraphQL schema.
+        /// </summary>
+        [TestMethod]
+        public void StoredProcedure_RequiredWithDefault_KeepsDefaultValue()
+        {
+            const string parameterName = "title";
+
+            DatabaseObject spDbObj = new DatabaseStoredProcedure(schemaName: "dbo", tableName: "spReqDefault")
+            {
+                SourceType = EntitySourceType.StoredProcedure,
+                StoredProcedureDefinition = new()
+                {
+                    Parameters = new() { { parameterName, new() { SystemType = typeof(string) } } }
+                }
+            };
+            spDbObj.SourceDefinition.Columns.TryAdd("col1", new() { SystemType = typeof(string) });
+
+            List<ParameterMetadata> configParameters = new()
+            {
+                new ParameterMetadata
+                {
+                    Name = parameterName,
+                    Required = true,
+                    Default = "Demo Title"
+                }
+            };
+
+            FieldDefinitionNode field = BuildSchemaAndGetExecuteField(
+                spDbObj: spDbObj,
+                configParameters: configParameters,
+                graphQLTypeName: "SpReqDefaultType",
+                entityName: "SpReqDefault");
+
+            InputValueDefinitionNode arg = field.Arguments.First(a => a.Name.Value == parameterName);
+
+            Assert.IsInstanceOfType(arg.Type, typeof(NonNullTypeNode), "Required parameter should be NonNullTypeNode.");
+            Assert.IsNotNull(arg.DefaultValue, "Default value should be preserved on NON_NULL input argument.");
+            Assert.IsInstanceOfType(arg.DefaultValue, typeof(StringValueNode));
+            Assert.AreEqual("Demo Title", ((StringValueNode)arg.DefaultValue!).Value);
+        }
+
+        /// <summary>
+        /// Helper that builds a query schema for a stored-procedure entity and returns
+        /// the generated execute* field so individual tests can assert on its argument
+        /// type nodes and default values.
+        /// </summary>
+        private static FieldDefinitionNode BuildSchemaAndGetExecuteField(
+            DatabaseObject spDbObj,
+            List<ParameterMetadata> configParameters,
+            string graphQLTypeName,
+            string entityName)
+        {
+            Entity spEntity = GraphQLTestHelpers.GenerateStoredProcedureEntity(
+                graphQLTypeName: graphQLTypeName,
+                graphQLOperation: GraphQLOperation.Query,
+                parameters: configParameters);
+
+            ObjectTypeDefinitionNode objectType = CreateGraphQLTypeForEntity(spEntity, entityName, spDbObj);
+
+            DocumentNode root = CreateGraphQLDocument(new Dictionary<string, ObjectTypeDefinitionNode>
+            {
+                { entityName, objectType }
+            });
+
+            Dictionary<string, EntityMetadata> permissions = GraphQLTestHelpers.CreateStubEntityPermissionsMap(
+                entityNames: new[] { entityName },
+                operations: new[] { EntityActionOperation.Execute },
+                roles: SchemaConverterTests.GetRolesAllowedForEntity());
+
+            Dictionary<string, Entity> entities = new() { { entityName, spEntity } };
+            Dictionary<string, DatabaseType> entityToDatabaseName = new() { { entityName, DatabaseType.MSSQL } };
+            Dictionary<string, DatabaseObject> dbObjects = new() { { entityName, spDbObj } };
+
+            DocumentNode queryRoot = QueryBuilder.Build(
+                root,
+                entityToDatabaseName,
+                entities: new(entities),
+                inputTypes: null,
+                entityPermissionsMap: permissions,
+                dbObjects: dbObjects);
+
+            ObjectTypeDefinitionNode queryNode = QueryBuilderTests.GetQueryNode(queryRoot);
+            return queryNode.Fields.First(f => f.Name.Value.StartsWith($"execute{graphQLTypeName}"));
+        }
     }
 }

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/DwSqlGraphQLQueryTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/DwSqlGraphQLQueryTests.cs
@@ -866,9 +866,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
         /// <summary>
         /// Checks failure on providing arguments with no default in runtimeconfig.
         /// In this test, there is no default value for the argument 'id' in runtimeconfig, nor is it specified in the query.
-        /// Stored procedure expects id argument to be provided.
-        /// This test validates the "Development Mode" error message which denotes the
-        /// specific missing parameter and stored procedure name.
+        /// GraphQL validation should reject the request because required argument 'id' is missing.
         /// </summary>
         [TestMethod]
         public async Task TestStoredProcedureQueryWithNoDefaultInConfig()
@@ -883,7 +881,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
             JsonElement result = await ExecuteGraphQLRequestAsync(graphQLQuery, graphQLQueryName, isAuthenticated: false);
             SqlTestHelper.TestForErrorInGraphQLResponse(
                 response: result.ToString(),
-                message: "Procedure or function 'get_publisher_by_id' expects parameter '@id', which was not supplied.");
+                message: "The argument `id` is required.");
         }
 
         /// <summary>

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
@@ -732,8 +732,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
         /// <summary>
         /// Checks failure on providing arguments with no default in runtimeconfig.
         /// In this test, there is no default value for the argument 'id' in runtimeconfig, nor is it specified in the query.
-        /// Stored procedure expects id argument to be provided.
-        /// The expected error message contents align with the expected "Development" mode response.
+        /// GraphQL validation should reject the request because required argument 'id' is missing.
         /// </summary>
         [TestMethod]
         public async Task TestStoredProcedureQueryWithNoDefaultInConfig()
@@ -746,7 +745,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
             }";
 
             JsonElement result = await ExecuteGraphQLRequestAsync(graphQLQuery, graphQLQueryName, isAuthenticated: false);
-            SqlTestHelper.TestForErrorInGraphQLResponse(result.ToString(), message: "Procedure or function 'get_publisher_by_id' expects parameter '@id', which was not supplied.");
+            SqlTestHelper.TestForErrorInGraphQLResponse(result.ToString(), message: "The argument `id` is required.");
         }
 
         /// <summary>


### PR DESCRIPTION
## Why make this change?

Closes #3501.

The GraphQL schema generated for stored-procedure entities emitted every input argument as nullable (`String`), so introspection couldn't distinguish required parameters from optional ones. Clients calling those mutations had no way to know which arguments were mandatory until SQL Server failed the call at execution time.

## What is this change?

In `GenerateStoredProcedureSchema`, each parameter's GraphQL type is now wrapped in `NonNullTypeNode` when the parameter is required, otherwise it stays a nullable `NamedTypeNode`. A parameter is treated as required unless the runtime config explicitly sets `required: false` for it. Names, value types, and the existing `defaultValue` handling are unchanged.

A required parameter with a config-supplied default still emits `NON_NULL` and keeps the default — that's valid GraphQL and matches client expectations.

The default-to-required behavior is intentional: T-SQL nullability (`is_nullable`) describes whether the parameter's type accepts NULL, not whether the caller must supply it. Defaulting to required produces a schema that's correct at execute time; users can opt out per-parameter via config when a procedure declares true defaults.

## How was this tested?

- [ ] Integration Tests
- [x] Unit Tests
- [x] Manual end-to-end test against a live SQL Server

### Unit tests

Added to `StoredProcedureBuilderTests`:

- `StoredProcedure_RequiredFlag_ProducesNonNullType` (3 data rows): `required: true` → `NonNullTypeNode`, `required: false` → nullable `NamedTypeNode`, parameter omitted from config → defaults to `NonNullTypeNode`.
- `StoredProcedure_RequiredWithDefault_KeepsDefaultValue`: required parameter with a config default emits `NonNullTypeNode` and preserves the default value.

### Manual end-to-end test

Three GraphQL mutations were configured against the existing `dbo.insert_book(@title varchar(max), @publisher_id int)` stored procedure. Each entity exercised a different config shape, and `__schema` introspection confirmed the input argument kinds:

| GraphQL field | Config shape | `title` | `publisher_id` |
| --- | --- | --- | --- |
| `executeInsertBookPartialConfig` | only `title` listed (`required: true`) | NON_NULL ✅ | NON_NULL ✅ (DB-only → defaults to required) |
| `executeInsertBookExplicitNotRequired` | `title` `required: false`, `publisher_id` `required: true` | nullable ✅ | NON_NULL ✅ |
| `executeInsertBookNoConfigParams` | no `parameters` block | NON_NULL ✅ | NON_NULL ✅ (silent → defaults to required) |

All scenarios produced the expected GraphQL types.

## Sample request

GraphQL introspection used to validate the schema:

```graphql
{
  __schema {
    mutationType {
      fields {
        name
        args {
          name
          type { kind name ofType { kind name } }
        }
      }
    }
  }
}
```
