### PR TITLE
fix: replace env defaults for stored procedures

### DIFF
--- a/src/Config/Converters/EntitySourceConverterFactory.cs
+++ b/src/Config/Converters/EntitySourceConverterFactory.cs
@@ -65,7 +65,7 @@ internal class EntitySourceConverterFactory : JsonConverterFactory
                 List<ParameterMetadata> paramList = [];
                 foreach (JsonProperty prop in parametersElement.EnumerateObject())
                 {
-                    string? defaultValue = GetClrValue(prop.Value)?.ToString();
+                    string? defaultValue = GetClrValue(prop.Value, _replacementSettings)?.ToString();
                     paramList.Add(new ParameterMetadata
                     {
                         Name = prop.Name,
@@ -112,16 +112,23 @@ internal class EntitySourceConverterFactory : JsonConverterFactory
             }
         }
 
-        private static object GetClrValue(JsonElement element)
+        private static object GetClrValue(JsonElement element, DeserializationVariableReplacementSettings? replacementSettings)
         {
             return element.ValueKind switch
             {
-                JsonValueKind.String => element.GetString() ?? string.Empty,
+                JsonValueKind.String => DeserializeStringValue(element, replacementSettings) ?? string.Empty,
                 JsonValueKind.Number => GetNumberValue(element),
                 JsonValueKind.True => true,
                 JsonValueKind.False => false,
                 _ => element.ToString()
             };
+        }
+
+        private static string? DeserializeStringValue(JsonElement element, DeserializationVariableReplacementSettings? replacementSettings)
+        {
+            Utf8JsonReader reader = new(JsonSerializer.SerializeToUtf8Bytes(element.GetString()));
+            reader.Read();
+            return reader.DeserializeString(replacementSettings);
         }
 
         /// <summary>

--- a/src/Service.Tests/UnitTests/RuntimeConfigLoaderJsonDeserializerTests.cs
+++ b/src/Service.Tests/UnitTests/RuntimeConfigLoaderJsonDeserializerTests.cs
@@ -165,6 +165,62 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             ClearEnvironmentVariablesFromDictionary(_environmentFileContentDict);
         }
 
+        [DataTestMethod]
+        [DataRow(false, "@env('year-end')", DisplayName = "Do not replace stored procedure parameter default environment variable.")]
+        [DataRow(true, "2024-06-30", DisplayName = "Replace stored procedure parameter default environment variable.")]
+        public void TestStoredProcedureParameterDefaultEnvVarReplacement(bool replaceEnvVar, string expectedDefaultValue)
+        {
+            const string envVarName = "year-end";
+            Environment.SetEnvironmentVariable(envVarName, "2024-06-30");
+
+            try
+            {
+                string configJson = @"
+                {
+                    ""data-source"": {
+                        ""database-type"": ""mssql"",
+                        ""connection-string"": ""Server=tcp:127.0.0.1,1433;Persist Security Info=False;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=False;Connection Timeout=5;""
+                    },
+                    ""entities"": {
+                        ""GetRecordsByDate"": {
+                            ""source"": {
+                                ""object"": ""get_records_by_date"",
+                                ""type"": ""stored-procedure"",
+                                ""parameters"": {
+                                    ""YearEndDate"": ""@env('year-end')""
+                                }
+                            },
+                            ""permissions"": [
+                                {
+                                    ""role"": ""anonymous"",
+                                    ""actions"": [
+                                        {
+                                            ""action"": ""execute""
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                }";
+
+                bool isParsingSuccessful = RuntimeConfigLoader.TryParseConfig(
+                    configJson,
+                    out RuntimeConfig runtimeConfig,
+                    replacementSettings: new DeserializationVariableReplacementSettings(
+                        azureKeyVaultOptions: null,
+                        doReplaceEnvVar: replaceEnvVar,
+                        doReplaceAkvVar: false));
+
+                Assert.IsTrue(isParsingSuccessful);
+                Assert.AreEqual(expectedDefaultValue, runtimeConfig.Entities["GetRecordsByDate"].Source.Parameters[0].Default);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVarName, null);
+            }
+        }
+
         /// <summary>
         /// Test the parsing of DataSource section in runtime config for cosmosdb_nosql
         /// where under cosmosDb options has database as null, container is not provided, and schema is an empty string.

--- a/src/Service.Tests/UnitTests/SqlExecuteStructureUnitTests.cs
+++ b/src/Service.Tests/UnitTests/SqlExecuteStructureUnitTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using Azure.DataApiBuilder.Auth;
+using Azure.DataApiBuilder.Config;
+using Azure.DataApiBuilder.Config.DatabasePrimitives;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Models;
+using Azure.DataApiBuilder.Core.Resolvers;
+using Azure.DataApiBuilder.Core.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Azure.DataApiBuilder.Service.Tests.UnitTests
+{
+    [TestClass]
+    public class SqlExecuteStructureUnitTests
+    {
+        [TestMethod]
+        public void ConfigDefaultDateTimeParameterIsResolvedAsDateTime()
+        {
+            const string entityName = "GetRecordsByDate";
+            const string parameterName = "YearEndDate";
+            const string envVarName = "year-end";
+            DateTime expectedDate = new(year: 2024, month: 6, day: 30, hour: 0, minute: 0, second: 0, kind: DateTimeKind.Utc);
+
+            Environment.SetEnvironmentVariable(envVarName, "2024-06-30");
+            try
+            {
+                Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(
+                    GetStoredProcedureConfigWithEnvDefault(),
+                    out RuntimeConfig runtimeConfig,
+                    replacementSettings: new DeserializationVariableReplacementSettings(
+                        azureKeyVaultOptions: null,
+                        doReplaceEnvVar: true,
+                        doReplaceAkvVar: false)));
+
+                StoredProcedureDefinition storedProcedureDefinition = new();
+                storedProcedureDefinition.Parameters.Add(
+                    parameterName,
+                    new ParameterDefinition
+                    {
+                        SystemType = typeof(DateTime),
+                        DbType = DbType.DateTime,
+                        HasConfigDefault = true,
+                        ConfigDefaultValue = runtimeConfig.Entities[entityName].Source.Parameters[0].Default
+                    });
+
+                DatabaseStoredProcedure storedProcedure = new(schemaName: "dbo", tableName: "get_records_by_date")
+                {
+                    SourceType = EntitySourceType.StoredProcedure,
+                    StoredProcedureDefinition = storedProcedureDefinition
+                };
+
+                Mock<ISqlMetadataProvider> metadataProvider = new();
+                metadataProvider.SetupGet(x => x.EntityToDatabaseObject).Returns(new Dictionary<string, DatabaseObject>
+                {
+                    { entityName, storedProcedure }
+                });
+                metadataProvider.Setup(x => x.GetStoredProcedureDefinition(entityName)).Returns(storedProcedureDefinition);
+                metadataProvider.Setup(x => x.GetSourceDefinition(entityName)).Returns(storedProcedureDefinition);
+
+                SqlExecuteStructure executeStructure = new(
+                    entityName,
+                    metadataProvider.Object,
+                    Mock.Of<IAuthorizationResolver>(),
+                    null,
+                    new Dictionary<string, object?>());
+
+                string dbConnectionParameterName = (string)executeStructure.ProcedureParameters[parameterName];
+                Assert.AreEqual(expectedDate, executeStructure.Parameters[dbConnectionParameterName].Value);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(envVarName, null);
+            }
+        }
+
+        private static string GetStoredProcedureConfigWithEnvDefault()
+        {
+            return @"
+            {
+                ""data-source"": {
+                    ""database-type"": ""mssql"",
+                    ""connection-string"": ""Server=tcp:127.0.0.1,1433;Persist Security Info=False;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=False;Connection Timeout=5;""
+                },
+                ""entities"": {
+                    ""GetRecordsByDate"": {
+                        ""source"": {
+                            ""object"": ""get_records_by_date"",
+                            ""type"": ""stored-procedure"",
+                            ""parameters"": {
+                                ""YearEndDate"": ""@env('year-end')""
+                            }
+                        },
+                        ""permissions"": [
+                            {
+                                ""role"": ""anonymous"",
+                                ""actions"": [
+                                    {
+                                        ""action"": ""execute""
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }";
+        }
+    }
+}


### PR DESCRIPTION
Closes #2067.

Old-format stored procedure `parameters` are normalized in `EntitySourceConverterFactory` before the normal entity source deserialization path. That path copied string defaults with `JsonElement.GetString()`, so a config default like `@env('year-end')` was stored literally even when environment-variable replacement was enabled. Later SQL execute type coercion tried to convert the literal placeholder to `DateTime` and failed.

This updates the old-format parameter reader to deserialize string defaults through the existing string converter with replacement settings, leaving number, boolean, and null handling unchanged. That gives stored procedure config defaults the same environment-variable replacement behavior as other string config fields before `SqlExecuteStructure` coerces the value to the database parameter type.

Tests cover replacement-enabled and replacement-disabled config parsing for `@env('year-end')`, plus a focused execute-structure regression that verifies the substituted default becomes a `DateTime` parameter value.

Verification:
- `git diff --check`
- `dotnet test src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj --no-restore --filter "FullyQualifiedName~RuntimeConfigLoaderJsonDeserializerTests|FullyQualifiedName~SqlExecuteStructureUnitTests"` could not run locally because `dotnet` is not installed in this container
- `dotnet build src/Config/Azure.DataApiBuilder.Config.csproj --no-restore` could not run locally for the same reason
