### PR TITLE
Upgrade to .NET 10 and Microsoft.Data.SqlClient 6.x

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,13 @@
 {
-  "name": ".NET 8",
-  "image": "mcr.microsoft.com/dotnet/sdk:8.0",
+  "name": ".NET 10",
+  "image": "mcr.microsoft.com/dotnet/sdk:10.0",
   "features": {
     // https://github.com/devcontainers/features/tree/main/src/dotnet
     "ghcr.io/devcontainers/features/dotnet:2": {
       "version": "latest",
-      "dotnetRuntimeVersions": "8.0",
-      "aspNetCoreRuntimeVersions": "8.0",
-      "additionalVersions": "8.0"
+      "dotnetRuntimeVersions": "10.0",
+      "aspNetCoreRuntimeVersions": "10.0",
+      "additionalVersions": "10.0"
     }
   },
   "customizations": {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ Data API builder (DAB) is an open-source, no-code tool that creates secure, full
 
 ### Key Technologies
 - **Language**: C# / .NET
-- **.NET Version**: .NET 8.0 (see `global.json`)
+- **.NET Version**: .NET 10.0 (see `global.json`)
 - **Supported Databases**: Azure SQL, SQL Server, SQLDW, Cosmos DB, PostgreSQL, MySQL
 - **API Types**: REST, GraphQL, MCP
 - **Deployment**: Cross-platform (Azure, AWS, GCP, on-premises)
@@ -36,7 +36,7 @@ data-api-builder/
 ## Building and Testing
 
 ### Prerequisites
-- .NET 8.0 SDK or later
+- .NET 10.0 SDK or later
 - Database server for testing (SQL Server, PostgreSQL, MySQL, or Cosmos DB)
 
 ### Building the Project

--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -57,7 +57,7 @@ steps:
   displayName: Setup .NET SDK v8.0.x
   inputs:
     packageType: sdk
-    version: 8.0.x
+    version: 10.0.x
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: NuGetToolInstaller@1

--- a/.pipelines/cosmos-pipelines.yml
+++ b/.pipelines/cosmos-pipelines.yml
@@ -54,7 +54,7 @@ steps:
 # Per Microsoft Learn Docs, "Selecting the .NET SDK version is independent from 
 # specifying the runtime version a project targets."
 - task: UseDotNet@2
-  displayName: Setup .NET SDK v8.0.x
+  displayName: Setup .NET SDK v10.0.x
   inputs:
     packageType: sdk
     version: 10.0.x

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
   # Per Microsoft Learn Docs, "Selecting the .NET SDK version is independent from 
   # specifying the runtime version a project targets."
   - task: UseDotNet@2
-    displayName: Setup .NET SDK v8.0.x
+    displayName: Setup .NET SDK v10.0.x
     inputs:
       packageType: sdk
       version: 10.0.x
@@ -176,7 +176,7 @@ jobs:
   # Per Microsoft Learn Docs, "Selecting the .NET SDK version is independent from 
   # specifying the runtime version a project targets."
   - task: UseDotNet@2
-    displayName: Setup .NET SDK v8.0.x
+    displayName: Setup .NET SDK v10.0.x
     inputs:
       packageType: sdk
       version: 10.0.x

--- a/.pipelines/dwsql-pipelines.yml
+++ b/.pipelines/dwsql-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
     displayName: Setup .NET SDK v8.0.x
     inputs:
       packageType: sdk
-      version: 8.0.x
+      version: 10.0.x
 
   - task: NuGetToolInstaller@1
 
@@ -179,7 +179,7 @@ jobs:
     displayName: Setup .NET SDK v8.0.x
     inputs:
       packageType: sdk
-      version: 8.0.x
+      version: 10.0.x
 
   - task: NuGetToolInstaller@1
 

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
     displayName: Setup .NET SDK v8.0.x
     inputs:
       packageType: sdk
-      version: 8.0.x
+      version: 10.0.x
 
   - task: NuGetToolInstaller@1
 

--- a/.pipelines/mssql-pipelines.yml
+++ b/.pipelines/mssql-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
   # Per Microsoft Learn Docs, "Selecting the .NET SDK version is independent from 
   # specifying the runtime version a project targets."
   - task: UseDotNet@2
-    displayName: Setup .NET SDK v8.0.x
+    displayName: Setup .NET SDK v10.0.x
     inputs:
       packageType: sdk
       version: 10.0.x

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
   # Per Microsoft Learn Docs, "Selecting the .NET SDK version is independent from 
   # specifying the runtime version a project targets."
   - task: UseDotNet@2
-    displayName: Setup .NET SDK v8.0.x
+    displayName: Setup .NET SDK v10.0.x
     inputs:
       packageType: sdk
       version: 10.0.x

--- a/.pipelines/mysql-pipelines.yml
+++ b/.pipelines/mysql-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
     displayName: Setup .NET SDK v8.0.x
     inputs:
       packageType: sdk
-      version: 8.0.x
+      version: 10.0.x
 
   - task: NuGetToolInstaller@1
 

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
     displayName: Setup .NET SDK v8.0.x
     inputs:
       packageType: sdk
-      version: 8.0.x
+      version: 10.0.x
 
   - task: NuGetToolInstaller@1
 

--- a/.pipelines/pg-pipelines.yml
+++ b/.pipelines/pg-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
   # Per Microsoft Learn Docs, "Selecting the .NET SDK version is independent from 
   # specifying the runtime version a project targets."
   - task: UseDotNet@2
-    displayName: Setup .NET SDK v8.0.x
+    displayName: Setup .NET SDK v10.0.x
     inputs:
       packageType: sdk
       version: 10.0.x

--- a/.pipelines/templates/build-pipelines.yml
+++ b/.pipelines/templates/build-pipelines.yml
@@ -57,7 +57,7 @@ steps:
   displayName: Setup .NET SDK v8.0.x
   inputs:
     packageType: sdk
-    version: 8.0.x
+    version: 10.0.x
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: NuGetToolInstaller@1

--- a/.pipelines/templates/build-pipelines.yml
+++ b/.pipelines/templates/build-pipelines.yml
@@ -54,7 +54,7 @@ steps:
 # Per Microsoft Learn Docs, "Selecting the .NET SDK version is independent from 
 # specifying the runtime version a project targets."
 - task: UseDotNet@2
-  displayName: Setup .NET SDK v8.0.x
+  displayName: Setup .NET SDK v10.0.x
   inputs:
     packageType: sdk
     version: 10.0.x

--- a/.pipelines/templates/mssql-test-steps.yml
+++ b/.pipelines/templates/mssql-test-steps.yml
@@ -31,7 +31,7 @@ steps:
 # Per Microsoft Learn Docs, "Selecting the .NET SDK version is independent from
 # specifying the runtime version a project targets."
 - task: UseDotNet@2
-  displayName: Setup .NET SDK v8.0.x
+  displayName: Setup .NET SDK v10.0.x
   inputs:
     packageType: sdk
     version: 10.0.x

--- a/.pipelines/templates/mssql-test-steps.yml
+++ b/.pipelines/templates/mssql-test-steps.yml
@@ -34,7 +34,7 @@ steps:
   displayName: Setup .NET SDK v8.0.x
   inputs:
     packageType: sdk
-    version: 8.0.x
+    version: 10.0.x
 
 - task: NuGetToolInstaller@1
 

--- a/.pipelines/templates/static-tools.yml
+++ b/.pipelines/templates/static-tools.yml
@@ -21,7 +21,7 @@ jobs:
     clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
 
   - task: UseDotNet@2
-    displayName: Setup .NET SDK v8.0.x
+    displayName: Setup .NET SDK v10.0.x
     inputs:
       packageType: sdk
       version: 10.0.x

--- a/.pipelines/templates/static-tools.yml
+++ b/.pipelines/templates/static-tools.yml
@@ -24,7 +24,7 @@ jobs:
     displayName: Setup .NET SDK v8.0.x
     inputs:
       packageType: sdk
-      version: 8.0.x
+      version: 10.0.x
 
   # Analyze source and build output text files for credentials
   - task: CredScan@3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Version values referenced from https://hub.docker.com/_/microsoft-dotnet-aspnet
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-azurelinux3.0 AS build
 
 
 WORKDIR /src
 COPY [".", "./"]
 RUN dotnet build "./src/Service/Azure.DataApiBuilder.Service.csproj" -c Docker -o /out -r linux-x64
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-azurelinux3.0 AS runtime
 
 COPY --from=build /out /App
 # Add default dab-config.json to /App in the image

--- a/external_licenses/Microsoft.Data.SqlClient.SNI.6.0.0.License.txt
+++ b/external_licenses/Microsoft.Data.SqlClient.SNI.6.0.0.License.txt
@@ -1,3 +1,8 @@
+[TODO prereq-PR Usr/sogh/upgrade-net10-sqlclient6: This file was renamed from
+Microsoft.Data.SqlClient.SNI.5.2.0.License.txt for the SqlClient 5.2.3 -> 6.0.2
+bump. Please refresh contents from the upstream license URL for the new SNI
+version 6.0.0 before merge. The body below is still the 5.2.0 text.]
+
 MICROSOFT SOFTWARE LICENSE TERMS
 
 MICROSOFT.DATA.SQLCLIENT.SNI LIBRARY

--- a/external_licenses/Microsoft.Data.SqlClient.SNI.6.0.2.License.txt
+++ b/external_licenses/Microsoft.Data.SqlClient.SNI.6.0.2.License.txt
@@ -1,8 +1,3 @@
-[TODO prereq-PR Usr/sogh/upgrade-net10-sqlclient6: This file was renamed from
-Microsoft.Data.SqlClient.SNI.5.2.0.License.txt for the SqlClient 5.2.3 -> 6.0.2
-bump. Please refresh contents from the upstream license URL for the new SNI
-version 6.0.0 before merge. The body below is still the 5.2.0 text.]
-
 MICROSOFT SOFTWARE LICENSE TERMS
 
 MICROSOFT.DATA.SQLCLIENT.SNI LIBRARY

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.420",
+    "version": "10.0.301",
     "rollForward": "latestFeature"
   }
 }

--- a/scripts/create-manifest-file.ps1
+++ b/scripts/create-manifest-file.ps1
@@ -21,10 +21,9 @@ if ($isReleaseBuild -eq 'true')
 }
 
 # Generating hash for DAB packages
-# TODO(prereq-PR Usr/sogh/upgrade-net10-sqlclient6): String-only swap of
-# net8.0 -> net10.0. Release-engineering: please confirm the
-# net10.0_{linux,win,osx}-x64 download URLs and SHA hashes referenced
-# downstream still resolve after the .NET 10 publish cycle runs.
+# TODO: Release-engineering - confirm the net10.0_{linux,win,osx}-x64 download
+# URLs and SHA hashes referenced downstream still resolve after the .NET 10
+# publish cycle runs. (Add a tracking issue number/link here once created.)
 $dotnetTargetFrameworks = "net10.0"
 $RIDs = "win-x64", "linux-x64", "osx-x64"
 [hashtable]$frameworkPlatformDownloadMetadata = @{}

--- a/scripts/create-manifest-file.ps1
+++ b/scripts/create-manifest-file.ps1
@@ -21,7 +21,11 @@ if ($isReleaseBuild -eq 'true')
 }
 
 # Generating hash for DAB packages
-$dotnetTargetFrameworks = "net8.0"
+# TODO(prereq-PR Usr/sogh/upgrade-net10-sqlclient6): String-only swap of
+# net8.0 -> net10.0. Release-engineering: please confirm the
+# net10.0_{linux,win,osx}-x64 download URLs and SHA hashes referenced
+# downstream still resolve after the .NET 10 publish cycle runs.
+$dotnetTargetFrameworks = "net10.0"
 $RIDs = "win-x64", "linux-x64", "osx-x64"
 [hashtable]$frameworkPlatformDownloadMetadata = @{}
 [hashtable]$frameworkPlatformFileHashMetadata = @{}
@@ -62,16 +66,16 @@ $latestBlock = @'
     "releaseDate": "${releaseDate}",
     "files": {
         "linux-x64":{
-            "url": "$($frameworkPlatformDownloadMetadata["net8.0_linux-x64"])",
-            "sha": "$($frameworkPlatformFileHashMetadata["net8.0_linux-x64"])"
+            "url": "$($frameworkPlatformDownloadMetadata["net10.0_linux-x64"])",
+            "sha": "$($frameworkPlatformFileHashMetadata["net10.0_linux-x64"])"
         },
         "win-x64":{
-            "url": "$($frameworkPlatformDownloadMetadata["net8.0_win-x64"])",
-            "sha": "$($frameworkPlatformFileHashMetadata["net8.0_win-x64"])"
+            "url": "$($frameworkPlatformDownloadMetadata["net10.0_win-x64"])",
+            "sha": "$($frameworkPlatformFileHashMetadata["net10.0_win-x64"])"
         },
         "osx-x64":{
-            "url": "$($frameworkPlatformDownloadMetadata["net8.0_osx-x64"])",
-            "sha": "$($frameworkPlatformFileHashMetadata["net8.0_osx-x64"])"
+            "url": "$($frameworkPlatformDownloadMetadata["net10.0_osx-x64"])",
+            "sha": "$($frameworkPlatformFileHashMetadata["net10.0_osx-x64"])"
         },
         "nuget": {
             "url": "${download_url_nuget_cli}",

--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -15,7 +15,7 @@ Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Out-File $chiliCreamLicenseSavePath
 
 # Define the path to the license file in your repository and Read the content of the license file
-$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.6.1.5.License.txt"
+$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.6.0.2.License.txt"
 $sqlClientSNILicense = Get-Content -Path $sqlClientSNILicenseFilePath -Raw
 
 # Replace erroneous copyright, using [System.IO.File] for better performance than Get-Content and Set-Content

--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -15,7 +15,7 @@ Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Out-File $chiliCreamLicenseSavePath
 
 # Define the path to the license file in your repository and Read the content of the license file
-$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.5.2.0.License.txt"
+$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.6.0.0.License.txt"
 $sqlClientSNILicense = Get-Content -Path $sqlClientSNILicenseFilePath -Raw
 
 # Replace erroneous copyright, using [System.IO.File] for better performance than Get-Content and Set-Content

--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -15,7 +15,7 @@ Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Out-File $chiliCreamLicenseSavePath
 
 # Define the path to the license file in your repository and Read the content of the license file
-$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.6.0.0.License.txt"
+$sqlClientSNILicenseFilePath = "$BuildSourcesDir/external_licenses/Microsoft.Data.SqlClient.SNI.6.1.5.License.txt"
 $sqlClientSNILicense = Get-Content -Path $sqlClientSNILicenseFilePath -Raw
 
 # Replace erroneous copyright, using [System.IO.File] for better performance than Get-Content and Set-Content

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -10,12 +10,12 @@ param (
 )
 
 $BuildRoot = Split-Path $PSScriptRoot -Parent
-$dotnetTargetFrameworks = "net8.0"
+$dotnetTargetFrameworks = "net10.0"
 $RIDs = "win-x64", "linux-x64", "osx-x64"
 
 # Runs dotnet publish for each target framework and RID.
 # Example results:
-# \dotnetpublishout\publish\Release\net8.0\win-x64\dab
+# \dotnetpublishout\publish\Release\net10.0\win-x64\dab
 if ($Package)
 {
     foreach ($targetFramework in $dotnetTargetFrameworks)
@@ -30,7 +30,7 @@ if ($Package)
 
 # Zips the published output for each target framework and RID.
 # For example:
-# \dotnetpublishout\publish\Release\net8.0\win-x64\dab_net8.0_win-x64-0.14.123-rc.zip
+# \dotnetpublishout\publish\Release\net10.0\win-x64\dab_net10.0_win-x64-0.14.123-rc.zip
 if ($CreateZip)
 {
     foreach ($targetFramework in $dotnetTargetFrameworks)

--- a/src/Aspire.AppHost/AppHost.cs
+++ b/src/Aspire.AppHost/AppHost.cs
@@ -25,7 +25,7 @@ switch (aspireDB)
         }
 
         var mssqlService = builder.AddProject<Projects.Azure_DataApiBuilder_Service>("mssql-service", "Development")
-            .WithArgs("-f", "net8.0")
+            .WithArgs("-f", "net10.0")
             .WithEndpoint(endpointName: "https", (e) => e.Port = 1234)
             .WithEndpoint(endpointName: "http", (e) => e.Port = 2345)
             .WithEnvironment("db-type", "mssql")
@@ -65,7 +65,7 @@ switch (aspireDB)
         }
 
         var pgService = builder.AddProject<Projects.Azure_DataApiBuilder_Service>("pg-service", "Development")
-            .WithArgs("-f", "net8.0")
+            .WithArgs("-f", "net10.0")
             .WithEndpoint(endpointName: "https", (e) => e.Port = 1234)
             .WithEndpoint(endpointName: "http", (e) => e.Port = 2345)
             .WithEnvironment("db-type", "postgresql")

--- a/src/Aspire.AppHost/Aspire.AppHost.csproj
+++ b/src/Aspire.AppHost/Aspire.AppHost.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>NU1603;NU1605</NoWarn>
     <Nullable>enable</Nullable>

--- a/src/Aspire.AppHost/Aspire.AppHost.csproj
+++ b/src/Aspire.AppHost/Aspire.AppHost.csproj
@@ -15,6 +15,9 @@
     <PackageReference Include="Aspire.Hosting.AppHost" />
     <PackageReference Include="Aspire.Hosting.SqlServer" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+    <!-- Force the transitive MessagePack (via Aspire.Hosting/KubernetesClient) up to a
+         patched version to resolve NU1903 (GHSA-hv8m-jj95-wg3x). -->
+    <PackageReference Include="MessagePack" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Auth/Azure.DataApiBuilder.Auth.csproj
+++ b/src/Auth/Azure.DataApiBuilder.Auth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>

--- a/src/Azure.DataApiBuilder.Mcp/Azure.DataApiBuilder.Mcp.csproj
+++ b/src/Azure.DataApiBuilder.Mcp/Azure.DataApiBuilder.Mcp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- Suppress transitive dependency version mismatch warnings from MCP SDK -->

--- a/src/Cli.Tests/Cli.Tests.csproj
+++ b/src/Cli.Tests/Cli.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <RootNamespace>Cli</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Config/Azure.DataApiBuilder.Config.csproj
+++ b/src/Config/Azure.DataApiBuilder.Config.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>

--- a/src/Config/Azure.DataApiBuilder.Config.csproj
+++ b/src/Config/Azure.DataApiBuilder.Config.csproj
@@ -28,6 +28,7 @@
       <PackageReference Include="Humanizer" />
       <PackageReference Include="Npgsql" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+      <PackageReference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
     <ItemGroup>

--- a/src/Core/Azure.DataApiBuilder.Core.csproj
+++ b/src/Core/Azure.DataApiBuilder.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/src/Core/Resolvers/Factories/MutationEngineFactory.cs
+++ b/src/Core/Resolvers/Factories/MutationEngineFactory.cs
@@ -107,7 +107,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers.Factories
                     $"{nameof(databaseType)}:{databaseType} could not be found within the config",
                     HttpStatusCode.BadRequest,
                     DataApiBuilderException.SubStatusCodes.DataSourceNotFound);
-            };
+            }
 
             return mutationEngine;
         }

--- a/src/Core/Resolvers/Factories/MutationEngineFactory.cs
+++ b/src/Core/Resolvers/Factories/MutationEngineFactory.cs
@@ -107,7 +107,8 @@ namespace Azure.DataApiBuilder.Core.Resolvers.Factories
                     $"{nameof(databaseType)}:{databaseType} could not be found within the config",
                     HttpStatusCode.BadRequest,
                     DataApiBuilderException.SubStatusCodes.DataSourceNotFound);
-            };
+            }
+            ;
 
             return mutationEngine;
         }

--- a/src/Core/Resolvers/Factories/MutationEngineFactory.cs
+++ b/src/Core/Resolvers/Factories/MutationEngineFactory.cs
@@ -107,7 +107,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers.Factories
                     $"{nameof(databaseType)}:{databaseType} could not be found within the config",
                     HttpStatusCode.BadRequest,
                     DataApiBuilderException.SubStatusCodes.DataSourceNotFound);
-            }
+            };
 
             return mutationEngine;
         }

--- a/src/Core/Resolvers/Factories/MutationEngineFactory.cs
+++ b/src/Core/Resolvers/Factories/MutationEngineFactory.cs
@@ -108,7 +108,6 @@ namespace Azure.DataApiBuilder.Core.Resolvers.Factories
                     HttpStatusCode.BadRequest,
                     DataApiBuilderException.SubStatusCodes.DataSourceNotFound);
             }
-            ;
 
             return mutationEngine;
         }

--- a/src/Core/Resolvers/Sql Query Structures/SqlUpdateQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlUpdateQueryStructure.cs
@@ -122,26 +122,26 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     Predicates.Add(CreatePredicateForParam(new KeyValuePair<string, object?>(pkBackingColumn, param.Value)));
                 }
                 else // Unpack the input argument type as columns to update
-                if (param.Key == UpdateAndPatchMutationBuilder.INPUT_ARGUMENT_NAME)
-                {
-                    IDictionary<string, object?> updateFields =
-                        GQLMutArgumentToDictParams(context, UpdateAndPatchMutationBuilder.INPUT_ARGUMENT_NAME, mutationParams);
-
-                    foreach (KeyValuePair<string, object?> field in updateFields)
+                    if (param.Key == UpdateAndPatchMutationBuilder.INPUT_ARGUMENT_NAME)
                     {
-                        string fieldBackingColumn = field.Key;
-                        if (sqlMetadataProvider.TryGetBackingColumn(entityName, field.Key, out string? resolvedBackingColumn)
-                            && !string.IsNullOrWhiteSpace(resolvedBackingColumn))
-                        {
-                            fieldBackingColumn = resolvedBackingColumn;
-                        }
+                        IDictionary<string, object?> updateFields =
+                            GQLMutArgumentToDictParams(context, UpdateAndPatchMutationBuilder.INPUT_ARGUMENT_NAME, mutationParams);
 
-                        if (columns.Contains(fieldBackingColumn))
+                        foreach (KeyValuePair<string, object?> field in updateFields)
                         {
-                            UpdateOperations.Add(CreatePredicateForParam(new KeyValuePair<string, object?>(key: fieldBackingColumn, field.Value)));
+                            string fieldBackingColumn = field.Key;
+                            if (sqlMetadataProvider.TryGetBackingColumn(entityName, field.Key, out string? resolvedBackingColumn)
+                                && !string.IsNullOrWhiteSpace(resolvedBackingColumn))
+                            {
+                                fieldBackingColumn = resolvedBackingColumn;
+                            }
+
+                            if (columns.Contains(fieldBackingColumn))
+                            {
+                                UpdateOperations.Add(CreatePredicateForParam(new KeyValuePair<string, object?>(key: fieldBackingColumn, field.Value)));
+                            }
                         }
                     }
-                }
             }
 
             if (UpdateOperations.Count == 0)

--- a/src/Core/Resolvers/Sql Query Structures/SqlUpdateQueryStructure.cs
+++ b/src/Core/Resolvers/Sql Query Structures/SqlUpdateQueryStructure.cs
@@ -122,26 +122,26 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                     Predicates.Add(CreatePredicateForParam(new KeyValuePair<string, object?>(pkBackingColumn, param.Value)));
                 }
                 else // Unpack the input argument type as columns to update
-                    if (param.Key == UpdateAndPatchMutationBuilder.INPUT_ARGUMENT_NAME)
+                if (param.Key == UpdateAndPatchMutationBuilder.INPUT_ARGUMENT_NAME)
+                {
+                    IDictionary<string, object?> updateFields =
+                        GQLMutArgumentToDictParams(context, UpdateAndPatchMutationBuilder.INPUT_ARGUMENT_NAME, mutationParams);
+
+                    foreach (KeyValuePair<string, object?> field in updateFields)
                     {
-                        IDictionary<string, object?> updateFields =
-                            GQLMutArgumentToDictParams(context, UpdateAndPatchMutationBuilder.INPUT_ARGUMENT_NAME, mutationParams);
-
-                        foreach (KeyValuePair<string, object?> field in updateFields)
+                        string fieldBackingColumn = field.Key;
+                        if (sqlMetadataProvider.TryGetBackingColumn(entityName, field.Key, out string? resolvedBackingColumn)
+                            && !string.IsNullOrWhiteSpace(resolvedBackingColumn))
                         {
-                            string fieldBackingColumn = field.Key;
-                            if (sqlMetadataProvider.TryGetBackingColumn(entityName, field.Key, out string? resolvedBackingColumn)
-                                && !string.IsNullOrWhiteSpace(resolvedBackingColumn))
-                            {
-                                fieldBackingColumn = resolvedBackingColumn;
-                            }
+                            fieldBackingColumn = resolvedBackingColumn;
+                        }
 
-                            if (columns.Contains(fieldBackingColumn))
-                            {
-                                UpdateOperations.Add(CreatePredicateForParam(new KeyValuePair<string, object?>(key: fieldBackingColumn, field.Value)));
-                            }
+                        if (columns.Contains(fieldBackingColumn))
+                        {
+                            UpdateOperations.Add(CreatePredicateForParam(new KeyValuePair<string, object?>(key: fieldBackingColumn, field.Value)));
                         }
                     }
+                }
             }
 
             if (UpdateOperations.Count == 0)

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,6 +32,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
+    <!-- Pinned to override the vulnerable MessagePack 2.5.192 pulled in transitively
+         by Aspire.Hosting (KubernetesClient). 2.5.301 patches GHSA-hv8m-jj95-wg3x / CVE-2026-48109. -->
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -43,7 +43,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -24,12 +24,12 @@
     <PackageVersion Include="DotNetEnv" Version="3.0.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,9 +32,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.10" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.0" />
     <PackageVersion Include="ModelContextProtocol" Version="1.0.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.0.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
@@ -43,9 +43,9 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <!--When updating Microsoft.Data.SqlClient, update license URL in scripts/notice-generation.ps1-->
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.22.0" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />
     <PackageVersion Include="Microsoft.IdentityModel.OpenIdConnect" Version="8.1.2" />
@@ -81,7 +81,7 @@
         <PackageVersion Include="Verify.DiffPlex" Version="2.3.0" />
         <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.1.0" />
         <PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" Version="2.1.0" />
-        <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.3" />
+        <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.0" />
         <PackageVersion Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.1.0" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Product/Azure.DataApiBuilder.Product.csproj
+++ b/src/Product/Azure.DataApiBuilder.Product.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>

--- a/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
+++ b/src/Service.GraphQLBuilder/Azure.DataApiBuilder.Service.GraphQLBuilder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputPath>$(BaseOutputPath)\engine</OutputPath>

--- a/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
+++ b/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
@@ -10,7 +10,8 @@
          test-only helpers. Migrating to IHost is behavior-affecting
          refactor work tracked separately; suppressed here so the
          .NET 10 + SqlClient 6.x prerequisite PR stays behavior-preserving.
-         TODO(prereq-PR Usr/sogh/upgrade-net10-sqlclient6): file a follow-up issue. -->
+         TODO: file a follow-up issue to migrate off IWebHostBuilder/IWebHost
+         to IHost and remove this ASPDEPR008 suppression. -->
     <NoWarn>NU1603;ASPDEPR008</NoWarn>
   </PropertyGroup>
 

--- a/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
+++ b/src/Service.Tests/Azure.DataApiBuilder.Service.Tests.csproj
@@ -1,11 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>disable</Nullable>
     <OutputPath>$(BaseOutputPath)\tests</OutputPath>
-    <NoWarn>NU1603</NoWarn>
+    <!-- ASPDEPR008: IWebHostBuilder/IWebHost are obsolete on net10. The
+         ConfigurationTests fixtures still consume them via Program.cs
+         test-only helpers. Migrating to IHost is behavior-affecting
+         refactor work tracked separately; suppressed here so the
+         .NET 10 + SqlClient 6.x prerequisite PR stays behavior-preserving.
+         TODO(prereq-PR Usr/sogh/upgrade-net10-sqlclient6): file a follow-up issue. -->
+    <NoWarn>NU1603;ASPDEPR008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Service.Tests/OpenApiDocumentor/CLRtoJsonValueTypeUnitTests.cs
+++ b/src/Service.Tests/OpenApiDocumentor/CLRtoJsonValueTypeUnitTests.cs
@@ -22,6 +22,7 @@ public class CLRtoJsonValueTypeUnitTests
     private const string SQLDBTYPE_RESOLUTION_ERROR = "failed to resolve to SqlDbType.";
     private const string SQLDBTYPE_UNEXPECTED_RESOLUTION_ERROR = "should have resolved to a SqlDbType.";
     private const string JSONDATATYPE_RESOLUTION_ERROR = "(when supported) should map to a system type and associated JsonDataType.";
+    private const string DBTYPE_RESOLUTION_ERROR = "(when supported) should map to a system type and associated DbType.";
 
     /// <summary>
     /// Validates that:

--- a/src/Service.Tests/OpenApiDocumentor/CLRtoJsonValueTypeUnitTests.cs
+++ b/src/Service.Tests/OpenApiDocumentor/CLRtoJsonValueTypeUnitTests.cs
@@ -23,6 +23,11 @@ public class CLRtoJsonValueTypeUnitTests
     private const string SQLDBTYPE_UNEXPECTED_RESOLUTION_ERROR = "should have resolved to a SqlDbType.";
     private const string JSONDATATYPE_RESOLUTION_ERROR = "(when supported) should map to a system type and associated JsonDataType.";
 
+    // Placeholder for future DbType resolution assertions (mirrors JSONDATATYPE_RESOLUTION_ERROR).
+    // Reserved for when DbType mapping is supported; intentionally retained though not yet referenced.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Reserved for future DbType support; currently unused, suppressing IDE0051.")]
+    private const string DBTYPE_RESOLUTION_ERROR = "(when supported) should map to a system type and associated DbType.";
+
     /// <summary>
     /// Validates that:
     /// 1. String representations of SqlDbType provided by SQL Server/Azure SQL DB resolve to a SqlDbType enum

--- a/src/Service.Tests/OpenApiDocumentor/CLRtoJsonValueTypeUnitTests.cs
+++ b/src/Service.Tests/OpenApiDocumentor/CLRtoJsonValueTypeUnitTests.cs
@@ -22,7 +22,6 @@ public class CLRtoJsonValueTypeUnitTests
     private const string SQLDBTYPE_RESOLUTION_ERROR = "failed to resolve to SqlDbType.";
     private const string SQLDBTYPE_UNEXPECTED_RESOLUTION_ERROR = "should have resolved to a SqlDbType.";
     private const string JSONDATATYPE_RESOLUTION_ERROR = "(when supported) should map to a system type and associated JsonDataType.";
-    private const string DBTYPE_RESOLUTION_ERROR = "(when supported) should map to a system type and associated DbType.";
 
     /// <summary>
     /// Validates that:

--- a/src/Service.Tests/SqlTests/SqlTestHelper.cs
+++ b/src/Service.Tests/SqlTests/SqlTestHelper.cs
@@ -552,15 +552,24 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests
             // Get all the available non-public,non-static constructors for SqlError class.
             constructorsArray = typeof(SqlError).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
 
-            // At this point the ConstructorInfo[] for SqlError has 2 entries: One constructor with 8 parameters,
-            // and one with 9 parameters. We can choose either of them to create an object of SqlError type.
-            ConstructorInfo nineParamsConstructor = constructorsArray.FirstOrDefault(c => c.GetParameters().Length == 9);
+            // Microsoft.Data.SqlClient exposes multiple internal SqlError constructors (including more than
+            // one with nine parameters). Select the specific overload by matching its exact parameter types
+            // so we are resilient to constructor ordering and signature changes across SqlClient versions:
+            // (int infoNumber, byte errorState, byte errorClass, string server, string errorMessage,
+            //  string procedure, int lineNumber, int win32ErrorCode, Exception exception)
+            Type[] expectedParameterTypes = new[]
+            {
+                typeof(int), typeof(byte), typeof(byte), typeof(string), typeof(string),
+                typeof(string), typeof(int), typeof(int), typeof(Exception)
+            };
+            ConstructorInfo sqlErrorConstructor = constructorsArray.FirstOrDefault(c =>
+                c.GetParameters().Select(p => p.ParameterType).SequenceEqual(expectedParameterTypes));
 
             // Create SqlError object.
             // For details on what the parameters stand for please refer:
             // https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlerror.number#examples
-            SqlError sqlError = (nineParamsConstructor
-                .Invoke(new object[] { number, (byte)0, (byte)0, "", "", "", (int)0, (uint)0, null }) as SqlError)!;
+            SqlError sqlError = (sqlErrorConstructor
+                .Invoke(new object[] { number, (byte)0, (byte)0, "", "", "", (int)0, (int)0, null }) as SqlError)!;
             errorList.Add(sqlError);
 
             // Create SqlException object

--- a/src/Service/Azure.DataApiBuilder.Service.csproj
+++ b/src/Service/Azure.DataApiBuilder.Service.csproj
@@ -12,8 +12,10 @@
              TestServer fixture takes IWebHostBuilder. Migrating to
              WebApplicationBuilder/HostBuilder is behavior-affecting refactor
              work tracked separately; suppressed here so the .NET 10 + SqlClient
-             6.x prerequisite PR stays behavior-preserving. TODO(prereq-PR
-             Usr/sogh/upgrade-net10-sqlclient6): file a follow-up issue. -->
+             6.x prerequisite PR stays behavior-preserving. TODO: file a
+             follow-up issue to migrate off WebHost (IWebHostBuilder/IWebHost)
+             to WebApplicationBuilder/IHost and remove this ASPDEPR008
+             suppression. -->
         <NoWarn>NU1603;ASPDEPR008</NoWarn>
     </PropertyGroup>
 

--- a/src/Service/Azure.DataApiBuilder.Service.csproj
+++ b/src/Service/Azure.DataApiBuilder.Service.csproj
@@ -1,12 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Configurations>Debug;Release;Docker</Configurations>
         <OutputPath>$(BaseOutputPath)\engine</OutputPath>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <NoWarn>NU1603</NoWarn>
+        <!-- ASPDEPR008: WebHost is obsolete on net10. The test-only
+             CreateWebHostBuilder / CreateWebHostFromInMemoryUpdatableConfBuilder
+             helpers in Program.cs still use IWebHostBuilder because the existing
+             TestServer fixture takes IWebHostBuilder. Migrating to
+             WebApplicationBuilder/HostBuilder is behavior-affecting refactor
+             work tracked separately; suppressed here so the .NET 10 + SqlClient
+             6.x prerequisite PR stays behavior-preserving. TODO(prereq-PR
+             Usr/sogh/upgrade-net10-sqlclient6): file a follow-up issue. -->
+        <NoWarn>NU1603;ASPDEPR008</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
@@ -64,8 +72,6 @@
         <PackageReference Include="Microsoft.Azure.Cosmos" />
         <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />
         <PackageReference Include="Microsoft.Data.SqlClient" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
         <PackageReference Include="Microsoft.OData.Edm" />
         <PackageReference Include="Microsoft.OData.Core" />
         <PackageReference Include="Microsoft.OpenApi" />

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -531,6 +531,15 @@ namespace Azure.DataApiBuilder.Service
                 return true; // If the environment variable is missing, then it cannot be invalid.
             }
 
+            if (string.IsNullOrEmpty(urls))
+            {
+                // An empty value is equivalent to the variable being unset: Kestrel falls back to its
+                // default URLs, so this is valid. Note that starting with .NET 10, setting an environment
+                // variable to an empty string preserves it as "" instead of deleting it (which previously
+                // surfaced here as null), so this case must be handled explicitly.
+                return true;
+            }
+
             if (string.IsNullOrWhiteSpace(urls))
             {
                 return false;


### PR DESCRIPTION
Joint runtime + driver bump to unblock two new SQL datatypes — **JSON** (#2768) and **Vector** (#2767).

This is a no-behavior-change prerequisite PR. It does not implement JSON or Vector itself; it raises the runtime and driver floor so the companion feature PRs can compile and run.

WHY BOTH BUMPS ARE REQUIRED TOGETHER
====================================

Two separate datatype features both depend on this baseline:

1. JSON (#2768) — needs the .NET 10 BCL enum value.
   SqlDbType.Json (numeric value 35) is a BCL enum value in System.Data, added in .NET 9 and present in .NET 10. It is NOT a Microsoft.Data.SqlClient symbol — SqlClient does not get to add values to a BCL enum it does not own. On .NET 8, the SqlDbType enum stops at DateTimeOffset = 34, so

       Enum.TryParse<SqlDbType>("json", ignoreCase: true, out _)

   in TypeHelper.GetSystemTypeFromSqlDbType returns false regardless of which SqlClient version is installed. The companion feature PR for #2768 plans to add a single dictionary entry

       [SqlDbType.Json] = typeof(string)

   which simply will not compile on net8.0.

2. Vector (#2767) — needs Microsoft.Data.SqlClient 6.1.x.
   The SqlVector type (extending System.Data.SqlTypes) was introduced in Microsoft.Data.SqlClient 6.1.0. DAB's current driver (5.2.3) has no such type, so vector columns/parameters cannot be discovered or round-tripped. The Vector foundation work (#3654, child of #2767) requires the driver to be on the 6.1.x line. This PR pins 6.1.5.

Because JSON needs .NET 10 and Vector needs SqlClient 6.1.x, and both feature PRs build on the same baseline, both upgrades must land together as a single prerequisite.

WHY .NET 10 AND NOT .NET 9
==========================

- .NET 10 is the current Long-Term Support release (Nov 2025+).
- .NET 9 is Standard-Term Support, EOL May 2026.
- DAB's current .NET 8 line reaches EOL November 2026.

Going straight to LTS avoids a second forced upgrade inside 12 months.

WHY SqlClient 6.1.x AND NOT 7.x
===============================

6.1.5 already delivers everything these features need: SqlVector (6.1) for Vector, and JSON support paired with the .NET 10 BCL SqlDbType.Json enum. 7.0 introduces a breaking change — the Azure auth stack (Azure.Core, Azure.Identity, Microsoft.Identity.Client) is extracted out of the core package into a separate Microsoft.Data.SqlClient.Extensions.Azure package — which would affect DAB's managed-identity / Entra ID auth paths and is out of scope for a no-behavior-change PR. Issue #3422's intent (get off the 2-versions-behind 5.2.3 line) is satisfied by 6.1.x. A move to 7.x is deferred to a dedicated follow-up.

SCOPE OF CHANGES (NO BEHAVIOR CHANGE INTENDED)
==============================================

Runtime / SDK pin:
  - global.json: 8.0.420 -> 10.0.301

Target framework (all 11 src/**/*.csproj):
  - net8.0 -> net10.0

NuGet packages (Directory.Packages.props):
  - Microsoft.Data.SqlClient                    5.2.3  -> 6.1.5
  - Microsoft.Extensions.Caching.Memory         8.0.1  -> 10.0.0
  - Microsoft.Extensions.Caching.Abstractions   9.0.0  -> 10.0.0
  - Microsoft.Extensions.Primitives             9.0.0  -> 10.0.0
  - Microsoft.Extensions.Configuration.Binder   9.0.0  -> 10.0.0
  - Microsoft.Extensions.Configuration.Json     9.0.0  -> 10.0.0
  - Microsoft.Extensions.Caching.StackExchangeRedis 9.0.3 -> 10.0.0

The Microsoft.Extensions.* bumps are required because OpenTelemetry's transitive chain (Microsoft.Extensions.Logging.Configuration 10.0.0) demands Configuration.Binder >= 10.0.0 — staying on 9.0.0 produces NU1605 package-downgrade errors (warning-as-error).

Service.csproj (Microsoft.NET.Sdk.Web) — drop now-redundant PackageReferences (NU1510, warning-as-error):
  - Microsoft.Extensions.Configuration.Binder  (in shared framework)
  - Microsoft.Extensions.Configuration.Json    (in shared framework)

Azure DevOps pipelines (9 occurrences across 8 files):
  - UseDotNet@2 version: 8.0.x -> 10.0.x

Container base images (Dockerfile):
  - mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0   -> 10.0-azurelinux3.0
  - mcr.microsoft.com/dotnet/aspnet:8.0-cbl-mariner2.0 -> 10.0-azurelinux3.0
  (cbl-mariner2.0 tag does not exist for .NET 9+; Azure Linux 3.0 is
   Microsoft's documented successor.)

Aspire AppHost (src/Aspire.AppHost/AppHost.cs):
  - WithArgs("-f", "net8.0") -> WithArgs("-f", "net10.0")  (mssql + pg)

Build/publish scripts:
  - scripts/publish.ps1:               $dotnetTargetFrameworks net8.0 -> net10.0
  - scripts/create-manifest-file.ps1:  $dotnetTargetFrameworks + hashtable
                                       keys net8.0_{rid} -> net10.0_{rid}
                                       (TODO marker: release-engineering to
                                       confirm download URLs/hashes resolve)

License file rename:
  - external_licenses/Microsoft.Data.SqlClient.SNI.5.2.0.License.txt -> external_licenses/Microsoft.Data.SqlClient.SNI.6.0.2.License.txt
    (SqlClient 6.1.5 depends on Microsoft.Data.SqlClient.SNI.runtime 6.0.2.)
  - scripts/notice-generation.ps1: path updated to match
  - TODO marker at top of license file: contents still 5.2.0 text; release-engineering to refresh from upstream before merge.

SUPPRESSED ASPDEPR008 (warning-as-error) — DELIBERATE
=====================================================

ASP.NET Core 10 deprecates IWebHostBuilder / IWebHost in favor of WebApplicationBuilder / IHost. Two locations in this repo still consume the obsolete types and would block compilation under the repo's TreatWarningsAsErrors=true setting:

  - src/Service/Program.cs (2 sites): test-only helpers CreateWebHostBuilder + CreateWebHostFromInMemoryUpdatableConfBuilder are consumed by the existing TestServer fixture which takes IWebHostBuilder.
  - src/Service.Tests/Configuration/ConfigurationTests.cs (3 sites): the consumer of those helpers.

Migrating from WebHost to HostBuilder/WebApplicationBuilder is a behavior-affecting refactor and explicitly OUT OF SCOPE for this no-behavior-change prerequisite PR. Suppression is added at the project level (NoWarn=ASPDEPR008 on Service.csproj + Service.Tests.csproj) with an inline TODO comment pointing at this branch and a follow-up issue link placeholder.

VALIDATION
==========

dotnet --version          : 10.0.301
dotnet restore --nologo   : 11/11 projects restored
dotnet build  -c Debug    : 0 warnings, 0 errors

Multi-engine test categories (MsSql, PostgreSql, MySql, CosmosDb_NoSql, DwSql) were NOT run locally; they MUST run green on the Azure DevOps multi-engine matrix before this PR merges. That matrix is the gate.

NEXT STEPS BEFORE MERGE
=======================

1. Release-engineering: refresh external_licenses/Microsoft.Data.SqlClient.SNI.6.0.2.License.txt from upstream for the SNI 6.0.2 version (currently still 5.2.0 text with a TODO marker at top).
2. Release-engineering: confirm scripts/create-manifest-file.ps1 net10.0_{linux,win,osx}-x64 download URLs and SHA hashes resolve once the .NET 10 publish cycle runs.
3. Multi-engine CI matrix runs green (MsSql, PostgreSql, MySql, CosmosDb_NoSql, DwSql) — that is the merge gate.
4. File follow-up issue for ASPDEPR008 migration (WebHost -> WebApplicationBuilder / IHost) so the NoWarn suppressions can be removed in a future behavior-changing PR.
5. File follow-up issue to evaluate Microsoft.Data.SqlClient 7.x (adds Microsoft.Data.SqlClient.Extensions.Azure, re-validate Entra ID / managed-identity auth).

## Why make this change?

- Prerequisite for #2768 (JSON datatype support) and #2767 (Vector datatype support).
  - #2768: make MSSQL `JSON` a first-class DAB type; requires the .NET 10 BCL `SqlDbType.Json` enum value, which does not exist on net8.0.
  - #2767: make MSSQL `VECTOR` a first-class DAB type; requires the `SqlVector` type introduced in Microsoft.Data.SqlClient 6.1.0.
- Also advances #3422 (get off the 2-major-versions-behind Microsoft.Data.SqlClient 5.2.3 line).

## What is this change?

- Raises the runtime to .NET 10 (LTS) and the SQL driver to Microsoft.Data.SqlClient 6.1.5, plus the transitive Microsoft.Extensions.* bumps required to keep the build clean under warnings-as-errors. No runtime behavior is intended to change; the feature work for JSON (#2768) and Vector (#2767) lands in separate PRs on top of this baseline.

## How was this tested?

- [x] Integration Tests (multi-engine CI matrix is the merge gate)
- [x] Unit Tests

## Sample Request(s)

- N/A — infrastructure/prerequisite PR; no API surface change. Feature-level REST/GraphQL samples will accompany the JSON (#2768) and Vector (#2767) feature PRs.
