### PR TITLE
Fix failure on REST requests with $filter and $orderby parameters

### DIFF
--- a/src/Core/Parsers/RequestParser.cs
+++ b/src/Core/Parsers/RequestParser.cs
@@ -322,8 +322,11 @@ namespace Azure.DataApiBuilder.Core.Parsers
                 return null;
             }
 
-            // Encode the parameterName to ensure it matches the encoding in the query string.
-            parameterName = HttpUtility.UrlEncode(parameterName);
+            // Encode the parameterName to ensure it matches the encoding in the query string if the $ sign is URL encoded.
+            if (!queryString.Contains(parameterName))
+            {
+                parameterName = HttpUtility.UrlEncode(parameterName);
+            }
 
             // Split on '&' which are parameter separators in properly URL-encoded query strings.
             // Any '&' characters within parameter values will be encoded as %26.

--- a/src/Core/Parsers/RequestParser.cs
+++ b/src/Core/Parsers/RequestParser.cs
@@ -323,7 +323,7 @@ namespace Azure.DataApiBuilder.Core.Parsers
             }
 
             // Encode the parameterName to ensure it matches the encoding in the query string if the $ sign is URL encoded.
-            if (!queryString.Contains(parameterName))
+            if (!queryString.Contains(parameterName, StringComparison.OrdinalIgnoreCase))
             {
                 parameterName = HttpUtility.UrlEncode(parameterName);
             }

--- a/src/Core/Parsers/RequestParser.cs
+++ b/src/Core/Parsers/RequestParser.cs
@@ -321,8 +321,6 @@ namespace Azure.DataApiBuilder.Core.Parsers
                 return null;
             }
 
-            parameterName = parameterName.Replace("$", "%24");
-
             // Split on '&' which are parameter separators in properly URL-encoded query strings.
             // Any '&' characters within parameter values will be encoded as %26.
             foreach (string param in queryString.TrimStart('?').Split('&'))

--- a/src/Core/Parsers/RequestParser.cs
+++ b/src/Core/Parsers/RequestParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using System.Web;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Services;
 using Azure.DataApiBuilder.Service.Exceptions;
@@ -320,6 +321,9 @@ namespace Azure.DataApiBuilder.Core.Parsers
             {
                 return null;
             }
+
+            // Encode the parameterName to ensure it matches the encoding in the query string.
+            parameterName = HttpUtility.UrlEncode(parameterName);
 
             // Split on '&' which are parameter separators in properly URL-encoded query strings.
             // Any '&' characters within parameter values will be encoded as %26.

--- a/src/Core/Parsers/RequestParser.cs
+++ b/src/Core/Parsers/RequestParser.cs
@@ -321,6 +321,8 @@ namespace Azure.DataApiBuilder.Core.Parsers
                 return null;
             }
 
+            parameterName = parameterName.Replace("$", "%24");
+
             // Split on '&' which are parameter separators in properly URL-encoded query strings.
             // Any '&' characters within parameter values will be encoded as %26.
             foreach (string param in queryString.TrimStart('?').Split('&'))

--- a/src/Core/Services/RestService.cs
+++ b/src/Core/Services/RestService.cs
@@ -71,7 +71,8 @@ namespace Azure.DataApiBuilder.Core.Services
             DatabaseObject dbObject = sqlMetadataProvider.EntityToDatabaseObject[entityName];
 
             QueryString? query = GetHttpContext().Request.QueryString;
-            string queryString = query is null ? string.Empty : GetHttpContext().Request.QueryString.ToString().Replace("%24", "$");    //Add replacement in order to ensure '$' sign is present as expected
+            string queryString = query is null ? string.Empty : GetHttpContext().Request.QueryString.ToString()
+                .Replace("?%24", "?$").Replace("&%24", "&$");   //Add replacement in order to ensure '$' sign is present as expected only for the case where it is after a '?' or '&' signs.
 
             // Read the request body early so it can be used for downstream processing.
             string requestBody = string.Empty;

--- a/src/Core/Services/RestService.cs
+++ b/src/Core/Services/RestService.cs
@@ -71,8 +71,7 @@ namespace Azure.DataApiBuilder.Core.Services
             DatabaseObject dbObject = sqlMetadataProvider.EntityToDatabaseObject[entityName];
 
             QueryString? query = GetHttpContext().Request.QueryString;
-            string queryString = query is null ? string.Empty : GetHttpContext().Request.QueryString.ToString()
-                .Replace("?%24", "?$").Replace("&%24", "&$");   //Add replacement in order to ensure '$' sign is present as expected only for the case where it is after a '?' or '&' signs.
+            string queryString = query is null ? string.Empty : GetHttpContext().Request.QueryString.ToString();
 
             // Read the request body early so it can be used for downstream processing.
             string requestBody = string.Empty;

--- a/src/Core/Services/RestService.cs
+++ b/src/Core/Services/RestService.cs
@@ -71,7 +71,7 @@ namespace Azure.DataApiBuilder.Core.Services
             DatabaseObject dbObject = sqlMetadataProvider.EntityToDatabaseObject[entityName];
 
             QueryString? query = GetHttpContext().Request.QueryString;
-            string queryString = query is null ? string.Empty : GetHttpContext().Request.QueryString.ToString();
+            string queryString = query is null ? string.Empty : GetHttpContext().Request.QueryString.ToString().Replace("%24", "$");    //Add replacement in order to ensure '$' sign is present as expected
 
             // Read the request body early so it can be used for downstream processing.
             string requestBody = string.Empty;

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -4228,9 +4228,11 @@ type Planet @model(name:""PlanetAlias"") {
         /// End to end test that validates that REST requests with OData query
         /// options $filter and $orderby succeed to ensure no regression can occur.
         /// </summary>
-        [TestMethod]
+        [DataTestMethod]
+        [DataRow("/api/Book?$orderby=id desc&$filter=publisher_id eq 1234", DisplayName = "Regular REST uri")]
+        [DataRow("/api/Book?%24orderby=id%20desc&%24filter=publisher_id%20eq%201234", DisplayName = "Regular REST uri")]
         [TestCategory(TestCategory.MSSQL)]
-        public async Task TestForRestRequestsWithFilterAndOrderbyParameters()
+        public async Task TestForRestRequestsWithFilterAndOrderbyParameters(string restUri)
         {
             // The configuration file is constructed by merging hard-coded JSON strings to simulate the scenario where users manually edit the
             // configuration file (instead of using CLI).

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -4229,8 +4229,8 @@ type Planet @model(name:""PlanetAlias"") {
         /// options $filter and $orderby succeed to ensure no regression can occur.
         /// </summary>
         [DataTestMethod]
-        [DataRow("/api/Book?$orderby=id desc&$filter=publisher_id eq 1234", DisplayName = "Regular REST uri")]
-        [DataRow("/api/Book?%24orderby=id%20desc&%24filter=publisher_id%20eq%201234", DisplayName = "Regular REST uri")]
+        [DataRow("/api/Book?$orderby=id desc&$filter=publisher_id eq 1234", DisplayName = "REST URL without encoded characters")]
+        [DataRow("/api/Book?%24orderby=id%20desc&%24filter=publisher_id%20eq%201234", DisplayName = "REST URL with encoded characters")]
         [TestCategory(TestCategory.MSSQL)]
         public async Task TestForRestRequestsWithFilterAndOrderbyParameters(string restUri)
         {
@@ -4261,7 +4261,7 @@ type Planet @model(name:""PlanetAlias"") {
 
                 string restResponseBody = await restResponse.Content.ReadAsStringAsync();
                 Assert.IsTrue(!string.IsNullOrEmpty(restResponseBody), "REST response should contain data");
-                Assert.IsTrue(restResponseBody.Contains("\"publisher_id\": 1234"));
+                Assert.IsTrue(restResponseBody.Contains("\"publisher_id\":1234"));
             }
         }
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -4253,7 +4253,7 @@ type Planet @model(name:""PlanetAlias"") {
             using (HttpClient client = server.CreateClient())
             {
                 // Act
-                using HttpRequestMessage restRequest = new(HttpMethod.Get, "/api/Book?$orderby=id desc&$filter=publisher_id eq 1234");
+                using HttpRequestMessage restRequest = new(HttpMethod.Get, restUri);
                 using HttpResponseMessage restResponse = await client.SendAsync(restRequest);
 
                 // Assert - Verify REST response

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -4261,7 +4261,7 @@ type Planet @model(name:""PlanetAlias"") {
 
                 string restResponseBody = await restResponse.Content.ReadAsStringAsync();
                 Assert.IsTrue(!string.IsNullOrEmpty(restResponseBody), "REST response should contain data");
-                Assert.IsTrue(restResponseBody.Contains("1234"));
+                Assert.IsTrue(restResponseBody.Contains("\"publisher_id\": 1234"));
             }
         }
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -4251,7 +4251,6 @@ type Planet @model(name:""PlanetAlias"") {
             using (HttpClient client = server.CreateClient())
             {
                 // Act
-                RuntimeConfigProvider configProvider = server.Services.GetService<RuntimeConfigProvider>();
                 using HttpRequestMessage restRequest = new(HttpMethod.Get, "/api/Book?$orderby=id desc&$filter=publisher_id eq 1234");
                 using HttpResponseMessage restResponse = await client.SendAsync(restRequest);
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -4258,6 +4258,10 @@ type Planet @model(name:""PlanetAlias"") {
 
                 // Assert - Verify REST response
                 Assert.AreEqual(HttpStatusCode.OK, restResponse.StatusCode, "REST request to auto-generated entity should succeed");
+
+                string restResponseBody = await restResponse.Content.ReadAsStringAsync();
+                Assert.IsTrue(!string.IsNullOrEmpty(restResponseBody), "REST response should contain data");
+                Assert.IsTrue(restResponseBody.Contains("1234"));
             }
         }
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -4225,6 +4225,42 @@ type Planet @model(name:""PlanetAlias"") {
         }
 
         /// <summary>
+        /// End to end test that validates that REST requests with OData query
+        /// options $filter and $orderby succeed to ensure no regression can occur.
+        /// </summary>
+        [TestMethod]
+        [TestCategory(TestCategory.MSSQL)]
+        public async Task TestForRestRequestsWithFilterAndOrderbyParameters()
+        {
+            // The configuration file is constructed by merging hard-coded JSON strings to simulate the scenario where users manually edit the
+            // configuration file (instead of using CLI).
+            string configJson = TestHelper.AddPropertiesToJson(TestHelper.BASE_CONFIG, BOOK_ENTITY_JSON);
+            Assert.IsTrue(RuntimeConfigLoader.TryParseConfig(
+                configJson,
+                out RuntimeConfig deserializedConfig,
+                replacementSettings: new(),
+                connectionString: GetConnectionStringFromEnvironmentConfig(environment: TestCategory.MSSQL)));
+            string configFileName = "custom-config.json";
+            File.WriteAllText(configFileName, deserializedConfig.ToJson());
+            string[] args = new[]
+            {
+                    $"--ConfigFileName={configFileName}"
+            };
+
+            using (TestServer server = new(Program.CreateWebHostBuilder(args)))
+            using (HttpClient client = server.CreateClient())
+            {
+                // Act
+                RuntimeConfigProvider configProvider = server.Services.GetService<RuntimeConfigProvider>();
+                using HttpRequestMessage restRequest = new(HttpMethod.Get, "/api/Book?$orderby=id desc&$filter=publisher_id eq 1234");
+                using HttpResponseMessage restResponse = await client.SendAsync(restRequest);
+
+                // Assert - Verify REST response
+                Assert.AreEqual(HttpStatusCode.OK, restResponse.StatusCode, "REST request to auto-generated entity should succeed");
+            }
+        }
+
+        /// <summary>
         /// Test different loglevel values that are avaliable by deserializing RuntimeConfig with specified LogLevel
         /// and checks if value exists properly inside the deserialized RuntimeConfig.
         /// </summary>


### PR DESCRIPTION
## Why make this change?

- Fix issue #3662

This issue is caused by a regression in PR https://github.com/Azure/data-api-builder/pull/3080
The regression is that we start using the raw encoded URL and we assume that the `$` character is not encoded when using the `ExtractRawQueryParameter` function, this is half true, since depending on where the URL comes from it will encode it or it will treat it as a special character and leave it as it is.
This means the function looks for the `$filter` or `$orderby` when the URL has the possibility to change them to `%24filter` or `%24orderby` which causes the failure.

## What is this change?

This change fixes a bug that caused using `$filter` or `$orderby` in REST. This is done by encoding the `parameterName` so that it has the same format as the raw URL, it will only change it if it is unable to find the original `$` character in the raw query.

## How was this tested?

- [ ] Integration Tests
- [x] Unit Tests
Added end to end test to ensure that REST requests that use `$filter` and `$orderby` succeed for both cases where a user uses the special character `$` or its URL encoded format `%24`.

## Sample Request(s)
http://localhost:5000/api/Book?$orderby=id desc
http://localhost:5000/api/Book?$filter=publisher_id 1234
