### PR TITLE
Restrict POST /configuration endpoint to loopback

### DIFF
--- a/src/Service.Tests/Configuration/ConfigurationEndpointAuthorizationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationEndpointAuthorizationTests.cs
@@ -104,25 +104,43 @@ public class ConfigurationEndpointAuthorizationTests
         HttpStatusCode expectedStatus)
     {
         // Arrange
+        // Other tests in the assembly (e.g. TestLoadingLocalCosmosSettings) set
+        // ASPNETCORE_ENVIRONMENT / DAB_ENVIRONMENT without cleanup. Those env vars cause
+        // FileSystemRuntimeConfigLoader to find an environment-specific dab-config.*.json on
+        // disk and auto-initialize the runtime, which makes POST /configuration return
+        // 409 Conflict before our security middleware can be exercised. Snapshot and clear
+        // them so each test starts from an uninitialized runtime.
+        string originalAspNetEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        string originalDabEnv = Environment.GetEnvironmentVariable("DAB_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+        Environment.SetEnvironmentVariable("DAB_ENVIRONMENT", null);
         Environment.SetEnvironmentVariable(Startup.CONFIG_AUTH_TOKEN_ENV_VAR, configuredToken);
 
-        using TestServer server = new(Program.CreateWebHostFromInMemoryUpdatableConfBuilder(Array.Empty<string>()));
-        using HttpClient httpClient = server.CreateClient();
+        try
+        {
+            using TestServer server = new(Program.CreateWebHostFromInMemoryUpdatableConfBuilder(Array.Empty<string>()));
+            using HttpClient httpClient = server.CreateClient();
 
-        HttpRequestMessage request = new(HttpMethod.Post, configurationEndpoint)
-        {
-            Content = BuildPostContent(configurationEndpoint),
-        };
-        if (providedHeader is not null)
-        {
-            request.Headers.Add(Startup.CONFIG_AUTH_HEADER, providedHeader);
+            HttpRequestMessage request = new(HttpMethod.Post, configurationEndpoint)
+            {
+                Content = BuildPostContent(configurationEndpoint),
+            };
+            if (providedHeader is not null)
+            {
+                request.Headers.Add(Startup.CONFIG_AUTH_HEADER, providedHeader);
+            }
+
+            // Act
+            HttpResponseMessage postResult = await httpClient.SendAsync(request);
+
+            // Assert
+            Assert.AreEqual(expectedStatus, postResult.StatusCode);
         }
-
-        // Act
-        HttpResponseMessage postResult = await httpClient.SendAsync(request);
-
-        // Assert
-        Assert.AreEqual(expectedStatus, postResult.StatusCode);
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", originalAspNetEnv);
+            Environment.SetEnvironmentVariable("DAB_ENVIRONMENT", originalDabEnv);
+        }
     }
 
     [TestCleanup]

--- a/src/Service.Tests/Configuration/ConfigurationEndpointAuthorizationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationEndpointAuthorizationTests.cs
@@ -39,6 +39,7 @@ public class ConfigurationEndpointAuthorizationTests
     // --- No bootstrap token configured ---
     [DataRow("127.0.0.1", null, null, true, DisplayName = "Loopback IPv4, no token => allow")]
     [DataRow("::1", null, null, true, DisplayName = "Loopback IPv6, no token => allow")]
+    [DataRow("::ffff:127.0.0.1", null, null, true, DisplayName = "IPv4-mapped IPv6 loopback (dual-stack Kestrel), no token => allow")]
     [DataRow(null, null, null, true, DisplayName = "In-process (null IP), no token => allow")]
     [DataRow("192.168.1.100", null, null, false, DisplayName = "Private IPv4, no token => deny")]
     [DataRow("10.0.0.1", null, null, false, DisplayName = "Private IPv4 (10/8), no token => deny")]

--- a/src/Service.Tests/Configuration/ConfigurationEndpointAuthorizationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationEndpointAuthorizationTests.cs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Service.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Azure.DataApiBuilder.Service.Tests.Configuration.ConfigurationEndpoints;
+using static Azure.DataApiBuilder.Service.Tests.Configuration.TestConfigFileReader;
+
+namespace Azure.DataApiBuilder.Service.Tests.Configuration;
+
+/// <summary>
+/// Tests for the security mitigation on the POST /configuration endpoint (CWE-306).
+/// Verifies that the endpoint is restricted to loopback addresses and optionally
+/// gated behind a bootstrap token (DAB_CONFIG_AUTH_TOKEN / X-DAB-CONFIG-AUTH header).
+/// </summary>
+[TestClass]
+public class ConfigurationEndpointAuthorizationTests
+{
+    /// <summary>
+    /// Validates IsConfigurationRequestAuthorized across the full matrix of inputs:
+    /// remote IP (loopback v4/v6, private/public, null/in-process), configured bootstrap
+    /// token, and provided X-DAB-CONFIG-AUTH header value.
+    /// </summary>
+    /// <param name="remoteIp">
+    /// Source IP for the simulated request. Use null to model an in-process call
+    /// (e.g. TestServer) where there is no underlying TCP connection.
+    /// </param>
+    /// <param name="configuredToken">Value to set DAB_CONFIG_AUTH_TOKEN to, or null to leave unset.</param>
+    /// <param name="providedHeader">Value of the X-DAB-CONFIG-AUTH header, or null to omit.</param>
+    /// <param name="expected">Expected authorization result.</param>
+    [DataTestMethod]
+    // --- No bootstrap token configured ---
+    [DataRow("127.0.0.1", null, null, true, DisplayName = "Loopback IPv4, no token => allow")]
+    [DataRow("::1", null, null, true, DisplayName = "Loopback IPv6, no token => allow")]
+    [DataRow(null, null, null, true, DisplayName = "In-process (null IP), no token => allow")]
+    [DataRow("192.168.1.100", null, null, false, DisplayName = "Private IPv4, no token => deny")]
+    [DataRow("10.0.0.1", null, null, false, DisplayName = "Private IPv4 (10/8), no token => deny")]
+    [DataRow("172.17.0.1", null, null, false, DisplayName = "Docker bridge IP, no token => deny")]
+    [DataRow("203.0.113.50", null, null, false, DisplayName = "Public IPv4, no token => deny")]
+    // --- Bootstrap token configured ---
+    [DataRow("127.0.0.1", "secret", "secret", true, DisplayName = "Loopback + correct token => allow")]
+    [DataRow("127.0.0.1", "secret", "wrong", false, DisplayName = "Loopback + wrong token => deny")]
+    [DataRow("127.0.0.1", "secret", null, false, DisplayName = "Loopback + missing header => deny")]
+    [DataRow("192.168.1.50", "secret", "secret", false, DisplayName = "Non-loopback + correct token => still deny")]
+    [DataRow(null, "secret", null, false, DisplayName = "In-process + missing header => deny")]
+    [DataRow(null, "secret", "secret", true, DisplayName = "In-process + correct token => allow")]
+    public void IsConfigurationRequestAuthorized_Matrix(
+        string remoteIp,
+        string configuredToken,
+        string providedHeader,
+        bool expected)
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable(Startup.CONFIG_AUTH_TOKEN_ENV_VAR, configuredToken);
+
+        DefaultHttpContext httpContext = new();
+        httpContext.Connection.RemoteIpAddress = remoteIp is null ? null : IPAddress.Parse(remoteIp);
+        if (providedHeader is not null)
+        {
+            httpContext.Request.Headers[Startup.CONFIG_AUTH_HEADER] = providedHeader;
+        }
+
+        // Act
+        bool result = Startup.IsConfigurationRequestAuthorized(httpContext);
+
+        // Assert
+        Assert.AreEqual(expected, result);
+    }
+
+    /// <summary>
+    /// End-to-end test against the full middleware pipeline via TestServer. Drives both
+    /// /configuration (v1) and /configuration/v2 with every token combination and verifies
+    /// the HTTP status code returned by the security middleware.
+    /// </summary>
+    /// <param name="configurationEndpoint">The endpoint being tested.</param>
+    /// <param name="configuredToken">Value to set DAB_CONFIG_AUTH_TOKEN to, or null to leave unset.</param>
+    /// <param name="providedHeader">Value of the X-DAB-CONFIG-AUTH header, or null to omit.</param>
+    /// <param name="expectedStatus">Expected HTTP status code from the POST.</param>
+    [DataTestMethod, TestCategory(TestCategory.COSMOSDBNOSQL)]
+    // No token configured -- backward-compatible loopback success
+    [DataRow(CONFIGURATION_ENDPOINT, null, null, HttpStatusCode.OK)]
+    [DataRow(CONFIGURATION_ENDPOINT_V2, null, null, HttpStatusCode.OK)]
+    // Token configured and correct -- allowed
+    [DataRow(CONFIGURATION_ENDPOINT, "integration-token", "integration-token", HttpStatusCode.OK)]
+    [DataRow(CONFIGURATION_ENDPOINT_V2, "integration-token", "integration-token", HttpStatusCode.OK)]
+    // Token configured but wrong -- forbidden
+    [DataRow(CONFIGURATION_ENDPOINT, "correct-token", "wrong-token", HttpStatusCode.Forbidden)]
+    [DataRow(CONFIGURATION_ENDPOINT_V2, "correct-token", "wrong-token", HttpStatusCode.Forbidden)]
+    // Token configured but header missing -- forbidden
+    [DataRow(CONFIGURATION_ENDPOINT, "required-token", null, HttpStatusCode.Forbidden)]
+    [DataRow(CONFIGURATION_ENDPOINT_V2, "required-token", null, HttpStatusCode.Forbidden)]
+    public async Task EndToEnd_PostConfiguration_StatusCodeMatrix(
+        string configurationEndpoint,
+        string configuredToken,
+        string providedHeader,
+        HttpStatusCode expectedStatus)
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable(Startup.CONFIG_AUTH_TOKEN_ENV_VAR, configuredToken);
+
+        using TestServer server = new(Program.CreateWebHostFromInMemoryUpdatableConfBuilder(Array.Empty<string>()));
+        using HttpClient httpClient = server.CreateClient();
+
+        HttpRequestMessage request = new(HttpMethod.Post, configurationEndpoint)
+        {
+            Content = BuildPostContent(configurationEndpoint),
+        };
+        if (providedHeader is not null)
+        {
+            request.Headers.Add(Startup.CONFIG_AUTH_HEADER, providedHeader);
+        }
+
+        // Act
+        HttpResponseMessage postResult = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.AreEqual(expectedStatus, postResult.StatusCode);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        Environment.SetEnvironmentVariable(Startup.CONFIG_AUTH_TOKEN_ENV_VAR, null);
+    }
+
+    /// <summary>
+    /// Builds the JSON post body appropriate for the given configuration endpoint version.
+    /// </summary>
+    private static JsonContent BuildPostContent(string endpoint)
+    {
+        Config.ObjectModel.RuntimeConfig config = ReadCosmosConfigurationFromFile() with { Schema = "@env('schema')" };
+        const string graphqlSchema = @"
+                type Entity {
+                    id: ID!
+                    name: String!
+                }
+                ";
+
+        if (endpoint == CONFIGURATION_ENDPOINT)
+        {
+            return JsonContent.Create(new ConfigurationPostParameters(
+                Configuration: config.ToJson(),
+                Schema: graphqlSchema,
+                ConnectionString: "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+                AccessToken: null));
+        }
+
+        if (endpoint == CONFIGURATION_ENDPOINT_V2)
+        {
+            return JsonContent.Create(new ConfigurationPostParametersV2(
+                Configuration: config.ToJson(),
+                ConfigurationOverrides: "{}",
+                Schema: graphqlSchema,
+                AccessToken: null));
+        }
+
+        throw new ArgumentException($"Unknown endpoint: {endpoint}", nameof(endpoint));
+    }
+}

--- a/src/Service.Tests/Configuration/ConfigurationEndpointAuthorizationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationEndpointAuthorizationTests.cs
@@ -23,6 +23,42 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration;
 [TestClass]
 public class ConfigurationEndpointAuthorizationTests
 {
+    // Names of environment variables this test class manipulates. Snapshotted in
+    // TestInitialize and restored in TestCleanup so each test starts and ends from
+    // the same global state regardless of what other tests in the assembly do.
+    private const string ASPNETCORE_ENVIRONMENT_VAR = "ASPNETCORE_ENVIRONMENT";
+    private const string DAB_ENVIRONMENT_VAR = "DAB_ENVIRONMENT";
+
+    private string _originalAuthToken;
+    private string _originalAspNetEnvironment;
+    private string _originalDabEnvironment;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        // Snapshot the originals so they can be restored verbatim in TestCleanup.
+        _originalAuthToken = Environment.GetEnvironmentVariable(Startup.CONFIG_AUTH_TOKEN_ENV_VAR);
+        _originalAspNetEnvironment = Environment.GetEnvironmentVariable(ASPNETCORE_ENVIRONMENT_VAR);
+        _originalDabEnvironment = Environment.GetEnvironmentVariable(DAB_ENVIRONMENT_VAR);
+
+        // Other tests in the assembly (e.g. TestLoadingLocalCosmosSettings) set
+        // ASPNETCORE_ENVIRONMENT / DAB_ENVIRONMENT without cleanup. Those env vars cause
+        // FileSystemRuntimeConfigLoader to find an environment-specific dab-config.*.json on
+        // disk and auto-initialize the runtime, which makes POST /configuration return
+        // 409 Conflict before our security middleware can be exercised. Clear them so each
+        // test starts from an uninitialized runtime; the originals are restored in cleanup.
+        Environment.SetEnvironmentVariable(ASPNETCORE_ENVIRONMENT_VAR, null);
+        Environment.SetEnvironmentVariable(DAB_ENVIRONMENT_VAR, null);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        Environment.SetEnvironmentVariable(Startup.CONFIG_AUTH_TOKEN_ENV_VAR, _originalAuthToken);
+        Environment.SetEnvironmentVariable(ASPNETCORE_ENVIRONMENT_VAR, _originalAspNetEnvironment);
+        Environment.SetEnvironmentVariable(DAB_ENVIRONMENT_VAR, _originalDabEnvironment);
+    }
+
     /// <summary>
     /// Validates IsConfigurationRequestAuthorized across the full matrix of inputs:
     /// remote IP (loopback v4/v6, private/public, null/in-process), configured bootstrap
@@ -49,7 +85,11 @@ public class ConfigurationEndpointAuthorizationTests
     [DataRow("127.0.0.1", "secret", "secret", true, DisplayName = "Loopback + correct token => allow")]
     [DataRow("127.0.0.1", "secret", "wrong", false, DisplayName = "Loopback + wrong token => deny")]
     [DataRow("127.0.0.1", "secret", null, false, DisplayName = "Loopback + missing header => deny")]
-    [DataRow("192.168.1.50", "secret", "secret", false, DisplayName = "Non-loopback + correct token => still deny")]
+    [DataRow("192.168.1.50", "secret", "secret", false, DisplayName = "Private IPv4 + correct token => still deny (non-loopback)")]
+    [DataRow("192.168.1.50", "secret", "wrong", false, DisplayName = "Private IPv4 + wrong token => deny")]
+    [DataRow("203.0.113.50", "secret", "secret", false, DisplayName = "Public IPv4 + correct token => still deny (non-loopback)")]
+    [DataRow("203.0.113.50", "secret", "wrong", false, DisplayName = "Public IPv4 + wrong token => deny")]
+    [DataRow("203.0.113.50", "secret", null, false, DisplayName = "Public IPv4 + missing header => deny")]
     [DataRow(null, "secret", null, false, DisplayName = "In-process + missing header => deny")]
     [DataRow(null, "secret", "secret", true, DisplayName = "In-process + correct token => allow")]
     public void IsConfigurationRequestAuthorized_Matrix(
@@ -103,50 +143,29 @@ public class ConfigurationEndpointAuthorizationTests
         string providedHeader,
         HttpStatusCode expectedStatus)
     {
-        // Arrange
-        // Other tests in the assembly (e.g. TestLoadingLocalCosmosSettings) set
-        // ASPNETCORE_ENVIRONMENT / DAB_ENVIRONMENT without cleanup. Those env vars cause
-        // FileSystemRuntimeConfigLoader to find an environment-specific dab-config.*.json on
-        // disk and auto-initialize the runtime, which makes POST /configuration return
-        // 409 Conflict before our security middleware can be exercised. Snapshot and clear
-        // them so each test starts from an uninitialized runtime.
-        string originalAspNetEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-        string originalDabEnv = Environment.GetEnvironmentVariable("DAB_ENVIRONMENT");
-        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
-        Environment.SetEnvironmentVariable("DAB_ENVIRONMENT", null);
+        // Arrange -- ASPNETCORE_ENVIRONMENT / DAB_ENVIRONMENT are already cleared by
+        // TestInitialize so the runtime starts uninitialized and our middleware is
+        // exercised. Only the per-row auth token still needs to be set here; TestCleanup
+        // restores the original value.
         Environment.SetEnvironmentVariable(Startup.CONFIG_AUTH_TOKEN_ENV_VAR, configuredToken);
 
-        try
+        using TestServer server = new(Program.CreateWebHostFromInMemoryUpdatableConfBuilder(Array.Empty<string>()));
+        using HttpClient httpClient = server.CreateClient();
+
+        HttpRequestMessage request = new(HttpMethod.Post, configurationEndpoint)
         {
-            using TestServer server = new(Program.CreateWebHostFromInMemoryUpdatableConfBuilder(Array.Empty<string>()));
-            using HttpClient httpClient = server.CreateClient();
-
-            HttpRequestMessage request = new(HttpMethod.Post, configurationEndpoint)
-            {
-                Content = BuildPostContent(configurationEndpoint),
-            };
-            if (providedHeader is not null)
-            {
-                request.Headers.Add(Startup.CONFIG_AUTH_HEADER, providedHeader);
-            }
-
-            // Act
-            HttpResponseMessage postResult = await httpClient.SendAsync(request);
-
-            // Assert
-            Assert.AreEqual(expectedStatus, postResult.StatusCode);
-        }
-        finally
+            Content = BuildPostContent(configurationEndpoint),
+        };
+        if (providedHeader is not null)
         {
-            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", originalAspNetEnv);
-            Environment.SetEnvironmentVariable("DAB_ENVIRONMENT", originalDabEnv);
+            request.Headers.Add(Startup.CONFIG_AUTH_HEADER, providedHeader);
         }
-    }
 
-    [TestCleanup]
-    public void Cleanup()
-    {
-        Environment.SetEnvironmentVariable(Startup.CONFIG_AUTH_TOKEN_ENV_VAR, null);
+        // Act
+        HttpResponseMessage postResult = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.AreEqual(expectedStatus, postResult.StatusCode);
     }
 
     /// <summary>

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Auth;
 using Azure.DataApiBuilder.Config;
@@ -89,6 +91,19 @@ namespace Azure.DataApiBuilder.Service
         public static AzureLogAnalyticsOptions AzureLogAnalyticsOptions = new();
         public static FileSinkOptions FileSinkOptions = new();
         public const string NO_HTTPS_REDIRECT_FLAG = "--no-https-redirect";
+
+        /// <summary>
+        /// Environment variable name for the optional bootstrap token that gates access to the
+        /// POST /configuration endpoint in late-configured (hosted) mode. When set, the request
+        /// must include an X-DAB-CONFIG-AUTH header whose value matches this token.
+        /// </summary>
+        internal const string CONFIG_AUTH_TOKEN_ENV_VAR = "DAB_CONFIG_AUTH_TOKEN";
+
+        /// <summary>
+        /// Header name used to supply the configuration bootstrap token.
+        /// </summary>
+        internal const string CONFIG_AUTH_HEADER = "X-DAB-CONFIG-AUTH";
+
         private readonly HotReloadEventHandler<HotReloadEventArgs> _hotReloadEventHandler = new();
         private RuntimeConfigProvider? _configProvider;
         private ILogger<Startup> _logger = logger;
@@ -949,6 +964,10 @@ namespace Azure.DataApiBuilder.Service
                     {
                         context.Response.StatusCode = StatusCodes.Status409Conflict;
                     }
+                    else if (!IsConfigurationRequestAuthorized(context))
+                    {
+                        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    }
                     else
                     {
                         await next.Invoke();
@@ -1477,6 +1496,49 @@ namespace Azure.DataApiBuilder.Service
         private static bool IsUIEnabled(RuntimeConfig? runtimeConfig, IWebHostEnvironment env)
         {
             return (runtimeConfig is not null && runtimeConfig.IsDevelopmentMode()) || env.IsDevelopment();
+        }
+
+        /// <summary>
+        /// Determines whether a POST /configuration request is authorized by enforcing:
+        /// 1. The request must originate from a loopback address (localhost / 127.0.0.1 / ::1).
+        /// 2. If the DAB_CONFIG_AUTH_TOKEN environment variable is set, the request must include
+        ///    an X-DAB-CONFIG-AUTH header whose value matches the token (constant-time comparison).
+        /// This mitigates Missing Authentication for Critical Function" by preventing
+        /// unauthenticated network-remote callers from hijacking the runtime configuration.
+        /// </summary>
+        internal static bool IsConfigurationRequestAuthorized(HttpContext context)
+        {
+            // Defense 1: Restrict to loopback addresses only.
+            // A null RemoteIpAddress indicates an in-process call (e.g. TestServer)
+            // where there is no underlying TCP connection — by definition this cannot
+            // be a remote attacker, so we treat it as loopback-equivalent. A real
+            // network-borne request always carries a TCP source IP.
+            IPAddress? remoteIp = context.Connection.RemoteIpAddress;
+            if (remoteIp is not null && !IPAddress.IsLoopback(remoteIp))
+            {
+                return false;
+            }
+
+            // Defense 2: If a bootstrap token is configured, require it in the request header.
+            string? expectedToken = Environment.GetEnvironmentVariable(CONFIG_AUTH_TOKEN_ENV_VAR);
+            if (!string.IsNullOrEmpty(expectedToken))
+            {
+                string? providedToken = context.Request.Headers[CONFIG_AUTH_HEADER].FirstOrDefault();
+                if (string.IsNullOrEmpty(providedToken))
+                {
+                    return false;
+                }
+
+                // Use fixed-time comparison to prevent timing attacks.
+                if (!CryptographicOperations.FixedTimeEquals(
+                    Encoding.UTF8.GetBytes(expectedToken),
+                    Encoding.UTF8.GetBytes(providedToken)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -1500,11 +1500,12 @@ namespace Azure.DataApiBuilder.Service
 
         /// <summary>
         /// Determines whether a POST /configuration request is authorized by enforcing:
-        /// 1. The request must originate from a loopback address (localhost / 127.0.0.1 / ::1).
+        /// 1. The request must originate from a loopback address (localhost / 127.0.0.1 / ::1
+        ///    or its IPv4-mapped IPv6 form such as ::ffff:127.0.0.1).
         /// 2. If the DAB_CONFIG_AUTH_TOKEN environment variable is set, the request must include
         ///    an X-DAB-CONFIG-AUTH header whose value matches the token (constant-time comparison).
-        /// This mitigates Missing Authentication for Critical Function" by preventing
-        /// unauthenticated network-remote callers from hijacking the runtime configuration.
+        /// This prevents unauthenticated network-remote callers from supplying the runtime
+        /// configuration during the late-configured bootstrap window.
         /// </summary>
         internal static bool IsConfigurationRequestAuthorized(HttpContext context)
         {
@@ -1514,9 +1515,16 @@ namespace Azure.DataApiBuilder.Service
             // be a remote attacker, so we treat it as loopback-equivalent. A real
             // network-borne request always carries a TCP source IP.
             IPAddress? remoteIp = context.Connection.RemoteIpAddress;
-            if (remoteIp is not null && !IPAddress.IsLoopback(remoteIp))
+            if (remoteIp is not null)
             {
-                return false;
+                // Kestrel often listens on dual-stack IPv6, so an IPv4 loopback caller can
+                // arrive as the IPv4-mapped IPv6 form (e.g. ::ffff:127.0.0.1). IPAddress.IsLoopback
+                // does not treat those as loopback, so normalize to IPv4 first.
+                IPAddress effectiveIp = remoteIp.IsIPv4MappedToIPv6 ? remoteIp.MapToIPv4() : remoteIp;
+                if (!IPAddress.IsLoopback(effectiveIp))
+                {
+                    return false;
+                }
             }
 
             // Defense 2: If a bootstrap token is configured, require it in the request header.


### PR DESCRIPTION
## Summary

Restrict the late-configured `POST /configuration` endpoint so it is only callable from the loopback interface, with an optional bootstrap-token check on top.

## Why

`POST /configuration` is used in hosted mode (e.g. Azure Static Web Apps) to deliver the runtime config — including the database connection string — to an uninitialized DAB instance. It currently runs before the authentication middleware and has no other access control, which is more permissive than required for what is effectively a host-to-runtime bootstrap channel.

## Change

In `src/Service/Startup.cs`, the existing middleware that gates `POST /configuration` now also checks `IsConfigurationRequestAuthorized(HttpContext)` and returns `403 Forbidden` if it fails. The check enforces:

1. The request must originate from a loopback address. Null `RemoteIpAddress` (in-process callers such as `TestServer`) is treated as loopback.
2. If the `DAB_CONFIG_AUTH_TOKEN` environment variable is set, the request must include a matching `X-DAB-CONFIG-AUTH` header (fixed-time comparison).

The rest of the middleware ordering is unchanged.

## Backward compatibility

- Azure Static Web Apps platform config injector (posts over loopback inside the container) keeps working unchanged.
- Existing in-process `TestServer` tests keep working unchanged.
- The bootstrap token is opt-in — when the env var is unset, behavior on loopback matches today's behavior.

## Tests

- [x] Unit Tests
