### PR TITLE
[Phase 2] Enable MSSQL JSON data type - type mapping & error codes (engine)

### DIFF
--- a/src/Core/Models/SqlTypeConstants.cs
+++ b/src/Core/Models/SqlTypeConstants.cs
@@ -47,6 +47,7 @@ public static class SqlTypeConstants
         { "time", true },                 // SqlDbType.Time
         { "datetime2", true },            // SqlDbType.DateTime2
         { "datetimeoffset", true },       // SqlDbType.DateTimeOffset
+        { "json", true },                 // SqlDbType.Json (SQL Server 2025+) treated as string
         { "", false },                    // SqlDbType.Udt and SqlDbType.Structured provided by SQL as empty strings (unsupported)
         { "numeric", true}                // Not present in SqlDbType, however can be returned by sql functions like LAG and should map to decimal.
     };

--- a/src/Core/Resolvers/MsSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MsSqlDbExceptionParser.cs
@@ -30,7 +30,10 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 "4435", "4436", "4437", "4438", "4439", "4440", "4441",
                 "4442", "4443", "4444", "4445", "4446", "4447", "4448",
                 "4450", "4451", "4452", "4453", "4454", "4455", "4456",
-                "4457", "4933", "4934", "4936", "4988", "8102"
+                "4457", "4933", "4934", "4936", "4988", "8102",
+                // JSON data type validation errors (SQL Server 2025+). Invalid JSON
+                // supplied for a json column is a client error, mapped to HTTP 400.
+                "13608", "13609", "13610", "13611", "13612", "13613", "13614"
             });
 
             TransientExceptionCodes.UnionWith(new List<string>

--- a/src/Core/Resolvers/MsSqlDbExceptionParser.cs
+++ b/src/Core/Resolvers/MsSqlDbExceptionParser.cs
@@ -95,8 +95,9 @@ namespace Azure.DataApiBuilder.Core.Resolvers
         {
             int errorCode = ((SqlException)e).Number;
             // MSSQL 201 - Procedure or function '%.*ls' expects parameter '%.*ls', which was not supplied.
+            // SQL Server 2025+ JSON validation errors are also client input errors.
             // Pending revisions of error code classifications, this is a temporary fix to determine substatus code.
-            if (errorCode == 201)
+            if (errorCode is 201 or 13608 or 13609 or 13610 or 13611 or 13612 or 13613 or 13614)
             {
                 return DataApiBuilderException.SubStatusCodes.DatabaseInputError;
             }

--- a/src/Core/Services/TypeHelper.cs
+++ b/src/Core/Services/TypeHelper.cs
@@ -97,6 +97,7 @@ namespace Azure.DataApiBuilder.Core.Services
             [SqlDbType.Float] = typeof(double),
             [SqlDbType.Image] = typeof(byte[]),
             [SqlDbType.Int] = typeof(int),
+            [SqlDbType.Json] = typeof(string),
             [SqlDbType.Money] = typeof(decimal),
             [SqlDbType.NChar] = typeof(char),
             [SqlDbType.NText] = typeof(string),

--- a/src/Service.Tests/OpenApiDocumentor/CLRtoJsonValueTypeUnitTests.cs
+++ b/src/Service.Tests/OpenApiDocumentor/CLRtoJsonValueTypeUnitTests.cs
@@ -111,4 +111,17 @@ public class CLRtoJsonValueTypeUnitTests
         Assert.AreNotEqual(notExpected: JsonDataType.Undefined, actual: TypeHelper.GetJsonDataTypeFromSystemType(nullableType));
         Assert.IsNotNull(TypeHelper.GetDbTypeFromSystemType(nullableType));
     }
+
+    /// <summary>
+    /// Validates that the SQL Server 2025+ 'json' data type literal resolves to the
+    /// CLR string type and maps to JsonDataType.String, i.e. DAB treats a JSON column
+    /// just like a string column.
+    /// </summary>
+    [TestMethod]
+    public void JsonSqlDbTypeResolvesToString()
+    {
+        Type resolvedType = TypeHelper.GetSystemTypeFromSqlDbType("json");
+        Assert.AreEqual(typeof(string), resolvedType);
+        Assert.AreEqual(JsonDataType.String, TypeHelper.GetJsonDataTypeFromSystemType(resolvedType));
+    }
 }

--- a/src/Service.Tests/UnitTests/DbExceptionParserUnitTests.cs
+++ b/src/Service.Tests/UnitTests/DbExceptionParserUnitTests.cs
@@ -9,6 +9,7 @@ using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Resolvers;
+using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -97,7 +98,8 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
         /// <summary>
         /// Validates that JSON data type validation error codes raised by SQL Server 2025+
-        /// when invalid JSON is supplied for a json column are mapped to HTTP 400 Bad Request.
+        /// when invalid JSON is supplied for a json column are mapped to HTTP 400 Bad Request
+        /// and are classified as client input errors.
         /// </summary>
         /// <param name="number">SQL error code populated in SqlException.Number.</param>
         [DataTestMethod]
@@ -127,9 +129,14 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             RuntimeConfigProvider provider = new(loader);
             DbExceptionParser dbExceptionParser = new MsSqlDbExceptionParser(provider);
 
+            DbException sqlException = SqlTestHelper.CreateSqlException(number);
+
             Assert.AreEqual(
                 System.Net.HttpStatusCode.BadRequest,
-                dbExceptionParser.GetHttpStatusCodeForException(SqlTestHelper.CreateSqlException(number)));
+                dbExceptionParser.GetHttpStatusCodeForException(sqlException));
+            Assert.AreEqual(
+                DataApiBuilderException.SubStatusCodes.DatabaseInputError,
+                dbExceptionParser.GetResultSubStatusCodeForException(sqlException));
         }
     }
 }

--- a/src/Service.Tests/UnitTests/DbExceptionParserUnitTests.cs
+++ b/src/Service.Tests/UnitTests/DbExceptionParserUnitTests.cs
@@ -94,5 +94,42 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
 
             Assert.AreEqual(expected, dbExceptionParser.IsTransientException(SqlTestHelper.CreateSqlException(number)));
         }
+
+        /// <summary>
+        /// Validates that JSON data type validation error codes raised by SQL Server 2025+
+        /// when invalid JSON is supplied for a json column are mapped to HTTP 400 Bad Request.
+        /// </summary>
+        /// <param name="number">SQL error code populated in SqlException.Number.</param>
+        [DataTestMethod]
+        [DataRow(13608, DisplayName = "JSON validation error code 13608 maps to 400")]
+        [DataRow(13609, DisplayName = "JSON validation error code 13609 maps to 400")]
+        [DataRow(13610, DisplayName = "JSON validation error code 13610 maps to 400")]
+        [DataRow(13611, DisplayName = "JSON validation error code 13611 maps to 400")]
+        [DataRow(13612, DisplayName = "JSON validation error code 13612 maps to 400")]
+        [DataRow(13613, DisplayName = "JSON validation error code 13613 maps to 400")]
+        [DataRow(13614, DisplayName = "JSON validation error code 13614 maps to 400")]
+        public void TestJsonValidationErrorsMapToBadRequest(int number)
+        {
+            RuntimeConfig mockConfig = new(
+                Schema: "",
+                DataSource: new(DatabaseType.MSSQL, "", new()),
+                Runtime: new(
+                    Rest: new(),
+                    GraphQL: new(),
+                    Mcp: new(),
+                    Host: new(null, null, HostMode.Development)
+                ),
+                Entities: new(new Dictionary<string, Entity>())
+            );
+            MockFileSystem fileSystem = new();
+            fileSystem.AddFile(FileSystemRuntimeConfigLoader.DEFAULT_CONFIG_FILE_NAME, new MockFileData(mockConfig.ToJson()));
+            FileSystemRuntimeConfigLoader loader = new(fileSystem);
+            RuntimeConfigProvider provider = new(loader);
+            DbExceptionParser dbExceptionParser = new MsSqlDbExceptionParser(provider);
+
+            Assert.AreEqual(
+                System.Net.HttpStatusCode.BadRequest,
+                dbExceptionParser.GetHttpStatusCodeForException(SqlTestHelper.CreateSqlException(number)));
+        }
     }
 }


### PR DESCRIPTION
## What this PR does

Adds support for the SQL Server 2025 `JSON` column type by treating it exactly like a normal text (`string`) column. Reading, writing, filtering, and sorting all reuse the paths DAB already has for strings — no new type, no special handling.

## The change

Two small edits to the engine:

1. **Map the type** — tell DAB that a `JSON` column is a `string`.
2. **Map the errors** — when SQL Server rejects invalid JSON, return **HTTP 400 (Bad Request)** instead of a generic 500.

Both are covered by new unit tests.

This PR is intentionally scoped to just the engine change. The database test table and end-to-end (REST/GraphQL) tests are **not** included here because they need a real SQL Server 2025 database — and our CI currently runs on LocalDB, which doesn't understand the `JSON` type yet. Those tests come in the next phase.

## Delivery plan

| Phase | What | Status |
|------|------|--------|
| 1 | Upgrade to .NET 10 + SqlClient 6.x (prerequisite) | ✅ Merged (#3656) |
| 2 | JSON type + error mapping | This PR |
| 3 | Test table + full REST/GraphQL/MCP tests | Next |
| 4 | Error/filter edge cases + regression | After |

## Notes
- No changes to PostgreSQL, MySQL, DwSql, or CosmosDB.
- Related issue: #2768.
