### PR TITLE
Fix missing WHERE clause in DWSql upsert UPDATE branch

### DIFF
--- a/src/Core/Resolvers/DWSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/DWSqlQueryBuilder.cs
@@ -452,12 +452,17 @@ namespace Azure.DataApiBuilder.Core.Resolvers
             // Final query to be executed for the given PUT/PATCH operation.
             StringBuilder upsertQuery = new(prefixQuery);
 
+            // Predicates to scope the UPDATE to the record(s) identified by the PK
+            // combined with any database policy defined for the update operation.
+            string updatePredicates = JoinPredicateStrings(pkPredicates, structure.GetDbPolicyForOperation(EntityActionOperation.Update));
+
             // Query to update record (if there exists one for given PK).
             StringBuilder updateQuery = new(
                 $"IF @ROWS_TO_UPDATE = 1 " +
                 $"BEGIN " +
                 $"UPDATE {tableName} " +
-                $"SET {updateOperations} ");
+                $"SET {updateOperations} " +
+                $"WHERE {updatePredicates} ");
 
             // End the IF block.
             updateQuery.Append("END ");

--- a/src/Service.Tests/UnitTests/DwSqlQueryBuilderUpsertTests.cs
+++ b/src/Service.Tests/UnitTests/DwSqlQueryBuilderUpsertTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using Azure.DataApiBuilder.Auth;
+using Azure.DataApiBuilder.Config.DatabasePrimitives;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Core.Models;
+using Azure.DataApiBuilder.Core.Resolvers;
+using Azure.DataApiBuilder.Core.Services;
+using Azure.DataApiBuilder.Core.Services.MetadataProviders;
+using Microsoft.AspNetCore.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Azure.DataApiBuilder.Service.Tests.UnitTests
+{
+    /// <summary>
+    /// Regression tests for the Azure Synapse Analytics (dwsql) upsert query builder.
+    /// These validate that the generated UPDATE branch of an upsert is always scoped by a
+    /// WHERE clause targeting the primary key (and any configured update database policy).
+    /// A missing WHERE clause would cause a single PUT upsert to overwrite every row in the
+    /// target table (CWE-862).
+    /// </summary>
+    [TestClass]
+    public class DwSqlQueryBuilderUpsertTests
+    {
+        private const string ENTITY_NAME = "Book";
+        private const string SCHEMA_NAME = "dbo";
+        private const string TABLE_NAME = "books";
+
+        private delegate void TryGetColumnCallback(string entity, string field, out string? column);
+
+        /// <summary>
+        /// Maps exposed field names to backing column names (identity mapping for the test entity).
+        /// </summary>
+        private static readonly Dictionary<string, string> _columnMapping = new()
+        {
+            { "id", "id" },
+            { "title", "title" },
+            { "publisher_id", "publisher_id" }
+        };
+
+        /// <summary>
+        /// Verifies that the dwsql upsert builder scopes the UPDATE branch with a WHERE clause
+        /// containing the primary key predicate and the configured update database policy.
+        /// </summary>
+        [TestMethod]
+        [TestCategory(TestCategory.DWSQL)]
+        public void DwSqlUpsertUpdateBranchContainsWhereClauseScopedByPrimaryKeyAndPolicy()
+        {
+            // Arrange
+            const string updateDbPolicy = "([publisher_id] != 0)";
+
+            SqlUpsertQueryStructure structure = CreateUpsertStructure();
+
+            // Simulate an update database policy being defined for the operation.
+            structure.DbPolicyPredicatesForOperations[EntityActionOperation.Update] = updateDbPolicy;
+
+            DwSqlQueryBuilder builder = new();
+
+            // Act
+            string query = builder.Build(structure);
+
+            // Assert
+            Assert.IsTrue(query.Contains("UPDATE", StringComparison.Ordinal), $"Expected an UPDATE statement. Query: {query}");
+
+            // Isolate the UPDATE (IF @ROWS_TO_UPDATE = 1) branch so the assertion targets the UPDATE, not the INSERT.
+            int updateIndex = query.IndexOf("UPDATE", StringComparison.Ordinal);
+            int endIndex = query.IndexOf("END", updateIndex, StringComparison.Ordinal);
+            Assert.IsTrue(endIndex > updateIndex, $"Expected the UPDATE branch to be closed by END. Query: {query}");
+            string updateBranch = query.Substring(updateIndex, endIndex - updateIndex);
+
+            Assert.IsTrue(
+                updateBranch.Contains("WHERE", StringComparison.Ordinal),
+                $"The dwsql upsert UPDATE branch MUST include a WHERE clause to scope the update. Query: {query}");
+
+            Assert.IsTrue(
+                updateBranch.Contains("[id]", StringComparison.Ordinal),
+                $"The dwsql upsert UPDATE WHERE clause MUST scope by the primary key column. Query: {query}");
+
+            Assert.IsTrue(
+                updateBranch.Contains(updateDbPolicy, StringComparison.Ordinal),
+                $"The dwsql upsert UPDATE WHERE clause MUST include the update database policy. Query: {query}");
+        }
+
+        /// <summary>
+        /// Builds a minimal <see cref="SqlUpsertQueryStructure"/> for the test entity using a mocked
+        /// metadata provider so no live database is required.
+        /// </summary>
+        private static SqlUpsertQueryStructure CreateUpsertStructure()
+        {
+            SourceDefinition sourceDefinition = new()
+            {
+                PrimaryKey = new() { "id" }
+            };
+            sourceDefinition.Columns.Add("id", new ColumnDefinition
+            {
+                SystemType = typeof(int),
+                DbType = DbType.Int32
+            });
+            sourceDefinition.Columns.Add("title", new ColumnDefinition
+            {
+                SystemType = typeof(string),
+                DbType = DbType.String,
+                IsNullable = true
+            });
+            sourceDefinition.Columns.Add("publisher_id", new ColumnDefinition
+            {
+                SystemType = typeof(int),
+                DbType = DbType.Int32
+            });
+
+            DatabaseTable dbTable = new(SCHEMA_NAME, TABLE_NAME)
+            {
+                TableDefinition = sourceDefinition,
+                SourceType = EntitySourceType.Table
+            };
+
+            Mock<ISqlMetadataProvider> metadataProvider = new();
+            metadataProvider.Setup(x => x.EntityToDatabaseObject)
+                .Returns(new Dictionary<string, DatabaseObject> { { ENTITY_NAME, dbTable } });
+            metadataProvider.Setup(x => x.GetSourceDefinition(ENTITY_NAME)).Returns(sourceDefinition);
+            metadataProvider.Setup(x => x.GetDatabaseType()).Returns(DatabaseType.DWSQL);
+
+            string outColumn;
+            metadataProvider.Setup(x => x.TryGetBackingColumn(It.IsAny<string>(), It.IsAny<string>(), out outColumn))
+                .Callback(new TryGetColumnCallback((string entity, string field, out string? column)
+                    => _columnMapping.TryGetValue(field, out column)))
+                .Returns((string entity, string field, string column) => _columnMapping.ContainsKey(field));
+
+            string outExposed;
+            metadataProvider.Setup(x => x.TryGetExposedColumnName(It.IsAny<string>(), It.IsAny<string>(), out outExposed))
+                .Callback(new TryGetColumnCallback((string entity, string field, out string? column)
+                    => _columnMapping.TryGetValue(field, out column)))
+                .Returns((string entity, string field, string column) => _columnMapping.ContainsKey(field));
+
+            // The update policy is injected directly onto the structure, so the resolver only needs
+            // to return an empty policy (no throw) during construction.
+            Mock<IAuthorizationResolver> authorizationResolver = new();
+            authorizationResolver
+                .Setup(x => x.ProcessDBPolicy(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EntityActionOperation>(), It.IsAny<HttpContext>()))
+                .Returns(string.Empty);
+
+            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
+            Mock<IMetadataProviderFactory> metadataProviderFactory = new();
+            GQLFilterParser gQLFilterParser = new(runtimeConfigProvider, metadataProviderFactory.Object);
+
+            DefaultHttpContext httpContext = new();
+            httpContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER] = "authenticated";
+
+            Dictionary<string, object?> mutationParams = new()
+            {
+                { "id", 1 },
+                { "title", "The Hobbit Returns to The Shire" },
+                { "publisher_id", 1234 }
+            };
+
+            return new SqlUpsertQueryStructure(
+                entityName: ENTITY_NAME,
+                sqlMetadataProvider: metadataProvider.Object,
+                authorizationResolver: authorizationResolver.Object,
+                gQLFilterParser: gQLFilterParser,
+                mutationParams: mutationParams,
+                incrementalUpdate: false,
+                httpContext: httpContext);
+        }
+    }
+}

--- a/src/Service.Tests/UnitTests/DwSqlQueryBuilderUpsertTests.cs
+++ b/src/Service.Tests/UnitTests/DwSqlQueryBuilderUpsertTests.cs
@@ -127,17 +127,17 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             metadataProvider.Setup(x => x.GetSourceDefinition(ENTITY_NAME)).Returns(sourceDefinition);
             metadataProvider.Setup(x => x.GetDatabaseType()).Returns(DatabaseType.DWSQL);
 
-            string outColumn;
+            string? outColumn;
             metadataProvider.Setup(x => x.TryGetBackingColumn(It.IsAny<string>(), It.IsAny<string>(), out outColumn))
                 .Callback(new TryGetColumnCallback((string entity, string field, out string? column)
                     => _columnMapping.TryGetValue(field, out column)))
-                .Returns((string entity, string field, string column) => _columnMapping.ContainsKey(field));
+                .Returns((string entity, string field, string? column) => _columnMapping.ContainsKey(field));
 
-            string outExposed;
+            string? outExposed;
             metadataProvider.Setup(x => x.TryGetExposedColumnName(It.IsAny<string>(), It.IsAny<string>(), out outExposed))
                 .Callback(new TryGetColumnCallback((string entity, string field, out string? column)
                     => _columnMapping.TryGetValue(field, out column)))
-                .Returns((string entity, string field, string column) => _columnMapping.ContainsKey(field));
+                .Returns((string entity, string field, string? column) => _columnMapping.ContainsKey(field));
 
             // The update policy is injected directly onto the structure, so the resolver only needs
             // to return an empty policy (no throw) during construction.


### PR DESCRIPTION
The dwsql (Azure Synapse) upsert builder emitted an UPDATE with no WHERE clause, so a single PUT upsert hitting the existing-row UPDATE branch overwrote every row in the target table and dropped the update DB policy (CWE-862).

Append WHERE {pkPredicates AND update DB policy} to the UPDATE branch, mirroring MsSqlQueryBuilder.Build(SqlUpsertQueryStructure) and the DWSql PATCH path. Add a regression test asserting the generated dwsql upsert UPDATE branch is scoped by the PK and the update database policy.

## Why make this change?

Fixes a security defect (CWE-862, missing row scoping / authorization) in the Azure Synapse Analytics (dwsql / Dedicated SQL Pool) upsert query builder.
The dwsql upsert builder computed pkPredicates but never appended a WHERE clause to the generated UPDATE. As a result, any authenticated user with entity-level update permission could issue a single [PUT /api/<entity>/<pk>] that hit the existing-row UPDATE branch and overwrite every row in the target table, while also silently discarding the row-level update database policy. The API still returns a normal single-record 200, so the mass overwrite is indistinguishable from a legitimate single-row update in application logs.
Not affected: the MSSQL/PostgreSQL/MySQL upsert builders and DAB's own DWSql PATCH path ([Build(SqlUpdateStructure)]), which all correctly scope the UPDATE with WHERE.

## What is this change?

- Summary of how your changes work to give reviewers context of your intent.
Append WHERE {pkPredicates AND update DB policy} to the UPDATE branch, mirroring MsSqlQueryBuilder.Build(SqlUpsertQueryStructure) and the DWSql PATCH path. Add a regression test asserting the generated dwsql upsert UPDATE branch is scoped by the PK and the update database policy.

## How was this tested?

- [ ] Integration Tests
- [X] Unit Tests
- [X] Manual tests
I have verified manually against a live Fabric Warehouse/dwsql instance. Ran a PUT upsert through DAB REST e2e and confirmed via direct SQL that only the targeted row changed and the change persisted. I also removed the fix/WHERE clause and confirmed a single PUT then overwrote all rows in the table, reproducing CWE-862, which the fix prevents.

## Sample Request(s)

Given a dwsql entity Book (PK id) with update permission granted, the following existing-row upsert previously overwrote all rows:
PUT /api/Book/id/7
Content-Type: application/json

{
  "title": "The Hobbit Returns to The Shire",
  "publisher_id": 1234
}

Generated UPDATE branch before the fix (overwrites every row):
IF @ROWS_TO_UPDATE = 1 BEGIN UPDATE [dbo].[books] SET [title] = @param1, [publisher_id] = @param2 END

Generated UPDATE branch after the fix (scoped to the target row and update policy):
IF @ROWS_TO_UPDATE = 1 BEGIN UPDATE [dbo].[books] SET [title] = @param1, [publisher_id] = @param2 WHERE [dbo].[books].[id] = @param0 END
