### PR TITLE
Refuse to start in production when EasyAuth providers lack Azure environment signals

### DIFF
--- a/src/Core/AuthenticationHelpers/AppServiceAuthenticationInformation.cs
+++ b/src/Core/AuthenticationHelpers/AppServiceAuthenticationInformation.cs
@@ -15,10 +15,6 @@ public static class AppServiceAuthenticationInfo
     /// Environment variable key whose value represents whether AppService EasyAuth is enabled ("true" or "false").
     /// </summary>
     public const string APPSERVICESAUTH_ENABLED_ENVVAR = "WEBSITE_AUTH_ENABLED";
-    /// <summary>
-    /// Environment variable key whose value represents Identity Provider such as "AzureActiveDirectory"
-    /// </summary>
-    public const string APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR = "WEBSITE_AUTH_DEFAULT_PROVIDER";
 
     // ── AppService messages ──────────────────────────────────────────────────────────────────────
     /// <summary>

--- a/src/Core/AuthenticationHelpers/AppServiceAuthenticationInformation.cs
+++ b/src/Core/AuthenticationHelpers/AppServiceAuthenticationInformation.cs
@@ -19,14 +19,22 @@ public static class AppServiceAuthenticationInfo
     /// Environment variable key whose value represents Identity Provider such as "AzureActiveDirectory"
     /// </summary>
     public const string APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR = "WEBSITE_AUTH_DEFAULT_PROVIDER";
+
+    // ── AppService messages ──────────────────────────────────────────────────────────────────────
     /// <summary>
     /// Error message used when AppService Authentication is configured in production mode in a non AppService Environment.
     /// </summary>
-    public const string APPSERVICE_PROD_MISSING_ENV_CONFIG = "AppService environment not detected while runtime is in production mode.";
+    public const string APPSERVICE_PROD_MISSING_ENV_CONFIG =
+        "AppService environment not detected while runtime is in production mode. " +
+        "The X-MS-CLIENT-PRINCIPAL header is not cryptographically validated by DAB and can be trivially " +
+        "forged when the service is not hosted behind an Azure App Service EasyAuth proxy. " +
+        "Set host.mode to 'development' for local testing, or deploy behind Azure App Service.";
     /// <summary>
     /// Warning message logged when AppService environment not detected (applicable to development mode).
     /// </summary>
-    public const string APPSERVICE_DEV_MISSING_ENV_CONFIG = "AppService environment not detected, EasyAuth authentication may not behave as expected.";
+    public const string APPSERVICE_DEV_MISSING_ENV_CONFIG =
+        "AppService environment not detected. The X-MS-CLIENT-PRINCIPAL header is not cryptographically " +
+        "validated; EasyAuth authentication may not behave as expected outside an Azure App Service environment.";
 
     /// <summary>
     /// Returns a best guess whether AppService is enabled in the environment by checking for

--- a/src/Core/AuthenticationHelpers/AppServiceAuthenticationInformation.cs
+++ b/src/Core/AuthenticationHelpers/AppServiceAuthenticationInformation.cs
@@ -21,10 +21,7 @@ public static class AppServiceAuthenticationInfo
     /// Error message used when AppService Authentication is configured in production mode in a non AppService Environment.
     /// </summary>
     public const string APPSERVICE_PROD_MISSING_ENV_CONFIG =
-        "AppService environment not detected while runtime is in production mode. " +
-        "The X-MS-CLIENT-PRINCIPAL header is not cryptographically validated by DAB and can be trivially " +
-        "forged when the service is not hosted behind an Azure App Service EasyAuth proxy. " +
-        "Set host.mode to 'development' for local testing, or deploy behind Azure App Service.";
+        "App Service: Cannot start in production: EasyAuth is configured with host.mode set to production, but the Azure App Service environment could not be detected because the WEBSITE_AUTH_ENABLED environment variable was missing or did not have the value true. DAB requires an Azure App Service EasyAuth proxy in production because it trusts the X-MS-CLIENT-PRINCIPAL header as the authenticated user identity, and without the EasyAuth proxy this header could be forged. If this is a local or non-Azure deployment, set host.mode to development. If this is intended to run in production, deploy it behind Azure App Service, enable EasyAuth, and verify that WEBSITE_AUTH_ENABLED=true is available to the application.";
     /// <summary>
     /// Warning message logged when AppService environment not detected (applicable to development mode).
     /// </summary>

--- a/src/Core/AuthenticationHelpers/AppServiceAuthenticationInformation.cs
+++ b/src/Core/AuthenticationHelpers/AppServiceAuthenticationInformation.cs
@@ -47,14 +47,12 @@ public static class AppServiceAuthenticationInfo
     /// </summary>
     public static bool AreExpectedAppServiceEnvVarsPresent()
     {
+        // WEBSITE_AUTH_ENABLED is the only variable that is reliably injected by the Azure platform
+        // whenever App Service Authentication (EasyAuth) is enabled, regardless of how many identity
+        // providers are configured. WEBSITE_AUTH_DEFAULT_PROVIDER is only set when a *single* provider
+        // is selected; multi-provider configurations leave it unset, so it must not be required here.
         string? appServiceEnabled = Environment.GetEnvironmentVariable(APPSERVICESAUTH_ENABLED_ENVVAR);
-        string? appServiceIdentityProvider = Environment.GetEnvironmentVariable(APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR);
-
-        if (string.IsNullOrEmpty(appServiceEnabled) || string.IsNullOrEmpty(appServiceIdentityProvider))
-        {
-            return false;
-        }
-
-        return appServiceEnabled.Equals(value: "true", comparisonType: StringComparison.OrdinalIgnoreCase);
+        return appServiceEnabled is not null &&
+               appServiceEnabled.Equals(value: "true", comparisonType: StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Core/AuthenticationHelpers/StaticWebAppsAuthentication.cs
+++ b/src/Core/AuthenticationHelpers/StaticWebAppsAuthentication.cs
@@ -34,6 +34,31 @@ public class StaticWebAppsAuthentication
     }
 
     /// <summary>
+    /// Environment variable key set by the Azure platform for every App Service and Static Web Apps
+    /// hosted site. Its presence is the best-effort signal that the runtime is executing behind an
+    /// Azure-managed proxy that injects and validates the X-MS-CLIENT-PRINCIPAL header.
+    /// </summary>
+    public const string WEBSITE_SITE_NAME_ENVVAR = "WEBSITE_SITE_NAME";
+
+    // ── StaticWebApps messages ───────────────────────────────────────────────────────────────────
+    /// <summary>
+    /// Error message used when StaticWebApps Authentication is configured in production mode
+    /// without a detectable Azure-hosted environment.
+    /// </summary>
+    public const string SWA_PROD_MISSING_ENV_CONFIG =
+        "StaticWebApps environment not detected while runtime is in production mode. " +
+        "The X-MS-CLIENT-PRINCIPAL header is not cryptographically validated by DAB and can be trivially " +
+        "forged when the service is not hosted behind an Azure Static Web Apps proxy. " +
+        "Set host.mode to 'development' for local testing, or deploy behind Azure Static Web Apps.";
+
+    /// <summary>
+    /// Warning message logged when StaticWebApps environment not detected (applicable to development mode).
+    /// </summary>
+    public const string SWA_DEV_MISSING_ENV_CONFIG =
+        "StaticWebApps environment not detected. The X-MS-CLIENT-PRINCIPAL header is not cryptographically " +
+        "validated; EasyAuth authentication may not behave as expected outside an Azure Static Web Apps environment.";
+
+    /// <summary>
     /// Base64 decodes and deserializes the x-ms-client-principal payload containing
     /// SWA token metadata.
     /// Writes SWA token metadata (roles and token claims) to .NET ClaimsIdentity object.
@@ -97,5 +122,15 @@ public class StaticWebAppsAuthentication
         }
 
         return identity;
+    }
+
+    /// <summary>
+    /// Returns a best-effort indication that the runtime is executing inside an Azure Static Web Apps
+    /// environment by checking for the presence of <see cref="WEBSITE_SITE_NAME_ENVVAR"/>, which is
+    /// injected by the Azure platform for every SWA-hosted application.
+    /// </summary>
+    public static bool AreExpectedSWAEnvVarsPresent()
+    {
+        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WEBSITE_SITE_NAME_ENVVAR));
     }
 }

--- a/src/Service.Tests/Caching/HealthEndpointCachingTests.cs
+++ b/src/Service.Tests/Caching/HealthEndpointCachingTests.cs
@@ -25,7 +25,7 @@ public class HealthEndpointCachingTests
     [TestInitialize]
     public void SetupAuthProviderEnvironmentVariables()
     {
-        TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+        TestHelper.SetAppServiceEnvironmentVariable();
     }
 
     [TestCleanup]

--- a/src/Service.Tests/Caching/HealthEndpointCachingTests.cs
+++ b/src/Service.Tests/Caching/HealthEndpointCachingTests.cs
@@ -22,6 +22,12 @@ public class HealthEndpointCachingTests
 {
     private const string CUSTOM_CONFIG_FILENAME = "custom-config.json";
 
+    [TestInitialize]
+    public void SetupAuthProviderEnvironmentVariables()
+    {
+        TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+    }
+
     [TestCleanup]
     public void CleanupAfterEachTest()
     {

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -735,6 +735,13 @@ type Moon {
             TestHelper.UnsetAllDABEnvironmentVariables();
         }
 
+        [TestInitialize]
+        public void SetupAuthProviderEnvironmentVariables()
+        {
+            TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+            TestHelper.SetStaticWebAppsEnvironmentVariable();
+        }
+
         /// <summary>
         /// When updating config during runtime is possible, then For invalid config the Application continues to
         /// accept request with status code of 503.

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -3958,7 +3958,6 @@ type Planet @model(name:""PlanetAlias"") {
         {
             // Clears or sets App Service Environment Variables based on test input.
             Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, setAppServiceEnvVars ? "true" : null);
-            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, setAppServiceEnvVars ? "AzureActiveDirectory" : null);
             Environment.SetEnvironmentVariable(StaticWebAppsAuthentication.WEBSITE_SITE_NAME_ENVVAR, setStaticWebAppsEnvVar ? "test-site-name" : null);
             TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
 
@@ -4005,7 +4004,6 @@ type Planet @model(name:""PlanetAlias"") {
             finally
             {
                 Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, null);
-                Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, null);
                 Environment.SetEnvironmentVariable(StaticWebAppsAuthentication.WEBSITE_SITE_NAME_ENVVAR, null);
             }
         }

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -738,7 +738,7 @@ type Moon {
         [TestInitialize]
         public void SetupAuthProviderEnvironmentVariables()
         {
-            TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+            TestHelper.SetAppServiceEnvironmentVariable();
             TestHelper.SetStaticWebAppsEnvironmentVariable();
         }
 

--- a/src/Service.Tests/Configuration/ConfigurationTests.cs
+++ b/src/Service.Tests/Configuration/ConfigurationTests.cs
@@ -3934,23 +3934,25 @@ type Planet @model(name:""PlanetAlias"") {
         /// </summary>
         /// <param name="hostMode">HostMode in Runtime config - Development or Production.</param>
         /// <param name="authType">EasyAuth auth type - AppService or StaticWebApps.</param>
-        /// <param name="setEnvVars">Whether to set the AppService host environment variables.</param>
+        /// <param name="setAppServiceEnvVars">Whether to set the AppService host environment variables.</param>
+        /// <param name="setStaticWebAppsEnvVar">Whether to set the Static Web Apps host environment variable.</param>
         /// <param name="expectError">Whether an error is expected.</param>
         [DataTestMethod]
         [TestCategory(TestCategory.MSSQL)]
-        [DataRow(HostMode.Development, EasyAuthType.AppService, false, false, DisplayName = "AppService Dev - No EnvVars - No Error")]
-        [DataRow(HostMode.Development, EasyAuthType.AppService, true, false, DisplayName = "AppService Dev - EnvVars - No Error")]
-        [DataRow(HostMode.Production, EasyAuthType.AppService, false, false, DisplayName = "AppService Prod - No EnvVars - Error")]
-        [DataRow(HostMode.Production, EasyAuthType.AppService, true, false, DisplayName = "AppService Prod - EnvVars - Error")]
-        [DataRow(HostMode.Development, EasyAuthType.StaticWebApps, false, false, DisplayName = "SWA Dev - No EnvVars - No Error")]
-        [DataRow(HostMode.Development, EasyAuthType.StaticWebApps, true, false, DisplayName = "SWA Dev - EnvVars - No Error")]
-        [DataRow(HostMode.Production, EasyAuthType.StaticWebApps, false, false, DisplayName = "SWA Prod - No EnvVars - No Error")]
-        [DataRow(HostMode.Production, EasyAuthType.StaticWebApps, true, false, DisplayName = "SWA Prod - EnvVars - No Error")]
-        public void TestProductionModeAppServiceEnvironmentCheck(HostMode hostMode, EasyAuthType authType, bool setEnvVars, bool expectError)
+        [DataRow(HostMode.Development, EasyAuthType.AppService, false, false, false, DisplayName = "AppService Dev - No EnvVars - No Error")]
+        [DataRow(HostMode.Development, EasyAuthType.AppService, true, false, false, DisplayName = "AppService Dev - EnvVars - No Error")]
+        [DataRow(HostMode.Production, EasyAuthType.AppService, false, false, true, DisplayName = "AppService Prod - No EnvVars - Error")]
+        [DataRow(HostMode.Production, EasyAuthType.AppService, true, false, false, DisplayName = "AppService Prod - EnvVars - No Error")]
+        [DataRow(HostMode.Development, EasyAuthType.StaticWebApps, false, false, false, DisplayName = "SWA Dev - No EnvVars - No Error")]
+        [DataRow(HostMode.Development, EasyAuthType.StaticWebApps, false, true, false, DisplayName = "SWA Dev - EnvVars - No Error")]
+        [DataRow(HostMode.Production, EasyAuthType.StaticWebApps, false, false, true, DisplayName = "SWA Prod - No EnvVars - Error")]
+        [DataRow(HostMode.Production, EasyAuthType.StaticWebApps, false, true, false, DisplayName = "SWA Prod - EnvVars - No Error")]
+        public void TestProductionModeAppServiceEnvironmentCheck(HostMode hostMode, EasyAuthType authType, bool setAppServiceEnvVars, bool setStaticWebAppsEnvVar, bool expectError)
         {
             // Clears or sets App Service Environment Variables based on test input.
-            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, setEnvVars ? "true" : null);
-            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, setEnvVars ? "AzureActiveDirectory" : null);
+            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, setAppServiceEnvVars ? "true" : null);
+            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, setAppServiceEnvVars ? "AzureActiveDirectory" : null);
+            Environment.SetEnvironmentVariable(StaticWebAppsAuthentication.WEBSITE_SITE_NAME_ENVVAR, setStaticWebAppsEnvVar ? "test-site-name" : null);
             TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
 
             FileSystem fileSystem = new();
@@ -3987,7 +3989,17 @@ type Planet @model(name:""PlanetAlias"") {
             catch (DataApiBuilderException ex)
             {
                 Assert.IsTrue(expectError, message: ex.Message);
-                Assert.AreEqual(AppServiceAuthenticationInfo.APPSERVICE_PROD_MISSING_ENV_CONFIG, ex.Message);
+                Assert.AreEqual(
+                    expected: authType == EasyAuthType.AppService
+                        ? AppServiceAuthenticationInfo.APPSERVICE_PROD_MISSING_ENV_CONFIG
+                        : StaticWebAppsAuthentication.SWA_PROD_MISSING_ENV_CONFIG,
+                    actual: ex.Message);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, null);
+                Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, null);
+                Environment.SetEnvironmentVariable(StaticWebAppsAuthentication.WEBSITE_SITE_NAME_ENVVAR, null);
             }
         }
 

--- a/src/Service.Tests/Configuration/HealthEndpointRolesTests.cs
+++ b/src/Service.Tests/Configuration/HealthEndpointRolesTests.cs
@@ -22,6 +22,12 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
 
         private const string CUSTOM_CONFIG_FILENAME = "custom-config.json";
 
+        [TestInitialize]
+        public void SetupAuthProviderEnvironmentVariables()
+        {
+            TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+        }
+
         [TestCleanup]
         public void CleanupAfterEachTest()
         {

--- a/src/Service.Tests/Configuration/HealthEndpointRolesTests.cs
+++ b/src/Service.Tests/Configuration/HealthEndpointRolesTests.cs
@@ -25,7 +25,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         [TestInitialize]
         public void SetupAuthProviderEnvironmentVariables()
         {
-            TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+            TestHelper.SetAppServiceEnvironmentVariable();
         }
 
         [TestCleanup]

--- a/src/Service.Tests/Configuration/HealthEndpointTests.cs
+++ b/src/Service.Tests/Configuration/HealthEndpointTests.cs
@@ -36,6 +36,12 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         private const string CUSTOM_CONFIG_FILENAME = "custom_config.json";
         private const string BASE_DAB_URL = "http://localhost:5000";
 
+        [TestInitialize]
+        public void SetupAuthProviderEnvironmentVariables()
+        {
+            TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+        }
+
         [TestCleanup]
         public void CleanupAfterEachTest()
         {

--- a/src/Service.Tests/Configuration/HealthEndpointTests.cs
+++ b/src/Service.Tests/Configuration/HealthEndpointTests.cs
@@ -39,7 +39,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Configuration
         [TestInitialize]
         public void SetupAuthProviderEnvironmentVariables()
         {
-            TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+            TestHelper.SetAppServiceEnvironmentVariable();
         }
 
         [TestCleanup]

--- a/src/Service.Tests/SqlTests/SqlTestHelper.cs
+++ b/src/Service.Tests/SqlTests/SqlTestHelper.cs
@@ -380,6 +380,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests
             DatabaseType dbType = DatabaseType.MSSQL,
             string testCategory = TestCategory.MSSQL)
         {
+            TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
             DataSource dataSource = new(dbType, GetConnectionStringFromEnvironmentConfig(environment: testCategory), new());
             Config.ObjectModel.AuthenticationOptions authenticationOptions = new(Provider: nameof(EasyAuthType.AppService), null);
 

--- a/src/Service.Tests/SqlTests/SqlTestHelper.cs
+++ b/src/Service.Tests/SqlTests/SqlTestHelper.cs
@@ -380,7 +380,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests
             DatabaseType dbType = DatabaseType.MSSQL,
             string testCategory = TestCategory.MSSQL)
         {
-            TestHelper.SetAppServiceEasyAuthEnvironmentVariables();
+            TestHelper.SetAppServiceEnvironmentVariable();
             DataSource dataSource = new(dbType, GetConnectionStringFromEnvironmentConfig(environment: testCategory), new());
             Config.ObjectModel.AuthenticationOptions authenticationOptions = new(Provider: nameof(EasyAuthType.AppService), null);
 

--- a/src/Service.Tests/TestHelper.cs
+++ b/src/Service.Tests/TestHelper.cs
@@ -34,7 +34,7 @@ namespace Azure.DataApiBuilder.Service.Tests
             Environment.SetEnvironmentVariable(StaticWebAppsAuthentication.WEBSITE_SITE_NAME_ENVVAR, null);
         }
 
-        public static void SetAppServiceEasyAuthEnvironmentVariables()
+        public static void SetAppServiceEnvironmentVariable()
         {
             Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, "true");
         }

--- a/src/Service.Tests/TestHelper.cs
+++ b/src/Service.Tests/TestHelper.cs
@@ -31,14 +31,12 @@ namespace Azure.DataApiBuilder.Service.Tests
             Environment.SetEnvironmentVariable(FileSystemRuntimeConfigLoader.ASP_NET_CORE_ENVIRONMENT_VAR_NAME, null);
             Environment.SetEnvironmentVariable(FileSystemRuntimeConfigLoader.RUNTIME_ENV_CONNECTION_STRING, null);
             Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, null);
-            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, null);
             Environment.SetEnvironmentVariable(StaticWebAppsAuthentication.WEBSITE_SITE_NAME_ENVVAR, null);
         }
 
         public static void SetAppServiceEasyAuthEnvironmentVariables()
         {
             Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, "true");
-            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, "AzureActiveDirectory");
         }
 
         public static void SetStaticWebAppsEnvironmentVariable()

--- a/src/Service.Tests/TestHelper.cs
+++ b/src/Service.Tests/TestHelper.cs
@@ -9,6 +9,7 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.AuthenticationHelpers;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Service.Tests.Configuration;
 using Humanizer;
@@ -29,6 +30,20 @@ namespace Azure.DataApiBuilder.Service.Tests
             Environment.SetEnvironmentVariable(FileSystemRuntimeConfigLoader.RUNTIME_ENVIRONMENT_VAR_NAME, null);
             Environment.SetEnvironmentVariable(FileSystemRuntimeConfigLoader.ASP_NET_CORE_ENVIRONMENT_VAR_NAME, null);
             Environment.SetEnvironmentVariable(FileSystemRuntimeConfigLoader.RUNTIME_ENV_CONNECTION_STRING, null);
+            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, null);
+            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, null);
+            Environment.SetEnvironmentVariable(StaticWebAppsAuthentication.WEBSITE_SITE_NAME_ENVVAR, null);
+        }
+
+        public static void SetAppServiceEasyAuthEnvironmentVariables()
+        {
+            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_ENABLED_ENVVAR, "true");
+            Environment.SetEnvironmentVariable(AppServiceAuthenticationInfo.APPSERVICESAUTH_IDENTITYPROVIDER_ENVVAR, "AzureActiveDirectory");
+        }
+
+        public static void SetStaticWebAppsEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable(StaticWebAppsAuthentication.WEBSITE_SITE_NAME_ENVVAR, "dab-service-tests");
         }
 
         /// <summary>

--- a/src/Service/Startup.cs
+++ b/src/Service/Startup.cs
@@ -1148,10 +1148,35 @@ namespace Azure.DataApiBuilder.Service
                     EasyAuthType easyAuthType = EnumExtensions.Deserialize<EasyAuthType>(runtimeConfig.Runtime.Host.Authentication.Provider);
                     bool isProductionMode = mode != HostMode.Development;
                     bool appServiceEnvironmentDetected = AppServiceAuthenticationInfo.AreExpectedAppServiceEnvVarsPresent();
+                    bool swaEnvironmentDetected = StaticWebAppsAuthentication.AreExpectedSWAEnvVarsPresent();
 
                     if (easyAuthType == EasyAuthType.AppService && !appServiceEnvironmentDetected)
                     {
+                        if (isProductionMode)
+                        {
+                            // SECURITY: In production the X-MS-CLIENT-PRINCIPAL header is blindly trusted.
+                            // Refuse to start when there is no evidence of an App Service EasyAuth proxy.
+                            throw new DataApiBuilderException(
+                                message: AppServiceAuthenticationInfo.APPSERVICE_PROD_MISSING_ENV_CONFIG,
+                                statusCode: System.Net.HttpStatusCode.ServiceUnavailable,
+                                subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
+                        }
+
                         _logBuffer.BufferLog(LogLevel.Warning, AppServiceAuthenticationInfo.APPSERVICE_DEV_MISSING_ENV_CONFIG);
+                    }
+                    else if (easyAuthType == EasyAuthType.StaticWebApps && !swaEnvironmentDetected)
+                    {
+                        if (isProductionMode)
+                        {
+                            // SECURITY: In production the X-MS-CLIENT-PRINCIPAL header is blindly trusted.
+                            // Refuse to start when there is no evidence of a Static Web Apps proxy.
+                            throw new DataApiBuilderException(
+                                message: StaticWebAppsAuthentication.SWA_PROD_MISSING_ENV_CONFIG,
+                                statusCode: System.Net.HttpStatusCode.ServiceUnavailable,
+                                subStatusCode: DataApiBuilderException.SubStatusCodes.ConfigValidationError);
+                        }
+
+                        _logBuffer.BufferLog(LogLevel.Warning, StaticWebAppsAuthentication.SWA_DEV_MISSING_ENV_CONFIG);
                     }
 
                     string defaultScheme = easyAuthType == EasyAuthType.AppService


### PR DESCRIPTION
## Why make this change?

- Closes #3710
- Related to the security posture of EasyAuth-based authentication providers (`StaticWebApps`, `AppService`).
  - DAB does **not** cryptographically verify the `X-MS-CLIENT-PRINCIPAL` header — it is decoded and trusted as-is. The header is only sanitized and re-injected by the Azure Static Web Apps or App Service EasyAuth proxy layer. When DAB is exposed directly (Docker, bare-metal, AKS, etc.) without that proxy in front, any client can forge the header and impersonate any user or role.
  - Previously there was a development-mode warning for the `AppService` provider but no guard for `StaticWebApps`, and no enforcement at all in production mode for either provider.

## What is this change?

- **`AppServiceAuthenticationInformation.cs`**: Updated the `APPSERVICE_PROD_MISSING_ENV_CONFIG` and `APPSERVICE_DEV_MISSING_ENV_CONFIG` message constants to explicitly call out the header-forgery risk.
- **`StaticWebAppsAuthentication.cs`**: Added parallel constants (`SWA_PROD_MISSING_ENV_CONFIG`, `SWA_DEV_MISSING_ENV_CONFIG`, `WEBSITE_SITE_NAME_ENVVAR`) and a new `AreExpectedSWAEnvVarsPresent()` helper that checks for the `WEBSITE_SITE_NAME` environment variable — the Azure-platform signal present in every SWA-hosted app.
- **`Startup.cs` — `ConfigureAuthentication`**: Extended the existing AppService env-var check to also cover `StaticWebApps`, with a symmetric two-tier policy:

  | Provider | `host.mode = development` | `host.mode = production` |
  |---|---|---|
  | `AppService`, env vars absent | `LogLevel.Warning` (unchanged) | `DataApiBuilderException` — **refuses to start** (new) |
  | `StaticWebApps`, `WEBSITE_SITE_NAME` absent | `LogLevel.Warning` (new) | `DataApiBuilderException` — **refuses to start** (new) |

  - Azure App Service EasyAuth: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
  - Azure Static Web Apps user info / `X-MS-CLIENT-PRINCIPAL`: https://learn.microsoft.com/azure/static-web-apps/user-information?tabs=csharp