### PR TITLE
Session Context Bug fix

### DIFF
--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -530,9 +530,11 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 foreach ((string claimType, string claimValue) in sessionParams)
                 {
                     string keyName = $"{SESSION_KEY_NAME}{counter.Current()}";
-                    string paramName = $"{SESSION_PARAM_NAME}{counter.Next()}";
                     parameters.Add(keyName, new(claimType));
+
+                    string paramName = $"{SESSION_PARAM_NAME}{counter.Next()}";
                     parameters.Add(paramName, new(claimValue));
+
                     // Append statement to set read only param value - can be set only once for a connection.
                     string statementToSetReadOnlyParam = "EXEC sp_set_session_context " + keyName + ", " + paramName + ", @read_only = 0;";
                     sessionMapQuery = sessionMapQuery.Append(statementToSetReadOnlyParam);

--- a/src/Core/Resolvers/MsSqlQueryExecutor.cs
+++ b/src/Core/Resolvers/MsSqlQueryExecutor.cs
@@ -516,6 +516,7 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
             // Counter to generate different param name for each of the sessionParam.
             IncrementingInteger counter = new();
+            const string SESSION_KEY_NAME = $"{BaseQueryStructure.PARAM_NAME_PREFIX}session_key";
             const string SESSION_PARAM_NAME = $"{BaseQueryStructure.PARAM_NAME_PREFIX}session_param";
             StringBuilder sessionMapQuery = new();
 
@@ -528,10 +529,12 @@ namespace Azure.DataApiBuilder.Core.Resolvers
 
                 foreach ((string claimType, string claimValue) in sessionParams)
                 {
+                    string keyName = $"{SESSION_KEY_NAME}{counter.Current()}";
                     string paramName = $"{SESSION_PARAM_NAME}{counter.Next()}";
+                    parameters.Add(keyName, new(claimType));
                     parameters.Add(paramName, new(claimValue));
                     // Append statement to set read only param value - can be set only once for a connection.
-                    string statementToSetReadOnlyParam = "EXEC sp_set_session_context " + $"'{claimType}', " + paramName + ", @read_only = 0;";
+                    string statementToSetReadOnlyParam = "EXEC sp_set_session_context " + keyName + ", " + paramName + ", @read_only = 0;";
                     sessionMapQuery = sessionMapQuery.Append(statementToSetReadOnlyParam);
                 }
             }

--- a/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
+++ b/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
@@ -327,7 +327,6 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
             DisplayName = "Anonymous role - X-MS-API-ROLE is not honored")]
         [DataRow(true, "author",
             DisplayName = "Authenticated role - existing X-MS-API-ROLE is honored")]
-        [TestMethod]
         public async Task TestClientRoleHeaderPresence(bool addAuthenticated, string clientRoleHeader)
         {
             string generatedToken = AuthTestHelper.CreateStaticWebAppsEasyAuthToken(addAuthenticated);
@@ -357,15 +356,11 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
                 ""auth_typ"":""aad"",
                 ""claims"":[
                   {
-                    ""typ"":""x', N'v';
-                        SET IDENTITY_INSERT authors ON;
-                        INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');
-                        SET IDENTITY_INSERT authors OFF;
-                        SELECT 1 AS inserted FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
-                        --"",
+                    ""typ"":""x', N'v';SET IDENTITY_INSERT authors ON;INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');SET IDENTITY_INSERT authors OFF;SELECT 1 AS inserted FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;--"",
                     ""val"":""x""
                   }
-                ]
+                ],
+                ""UserRoles"":[""anonymous""]
             }";
 
             string generatedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(header));
@@ -373,7 +368,7 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
                 await SendRequestAndGetHttpContextState(
                     generatedToken,
                     EasyAuthType.StaticWebApps,
-                    clientRoleHeader: "authenticated");
+                    clientRoleHeader: "anonymous");
             Assert.AreEqual(expected: (int)HttpStatusCode.OK, actual: postMiddlewareContext.Response.StatusCode);
 
             using IHost host = await WebHostBuilderHelper.CreateWebHost(EasyAuthType.StaticWebApps.ToString(), false);

--- a/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
+++ b/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
@@ -2,18 +2,14 @@
 // Licensed under the MIT License.
 
 #nullable enable
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.AuthenticationHelpers;
 using Azure.DataApiBuilder.Core.Authorization;
-using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Service.Tests.Authentication.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
@@ -348,49 +344,6 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
         }
 
         /// <summary>
-        /// Tests we ensure that an invalid query in the EasyAuth header does not result in a successful request.
-        /// </summary>
-        [TestMethod]
-        public async Task TestInvalidQueryInHeader()
-        {
-            string header = @"
-            {
-                ""auth_typ"":""aad"",
-                ""claims"":[
-                  {
-                    ""typ"":""x', N'v';INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');--"",
-                    ""val"":""x""
-                  }
-                ],
-                ""UserRoles"":[""authenticated""]
-            }";
-
-            string generatedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(header));
-
-            const string SESSION_CONFIG = $"session-context-config.{TestCategory.MSSQL}.json";
-            SetupSessionContextConfig(SESSION_CONFIG);
-
-            string[] args = [$"--ConfigFileName={SESSION_CONFIG}"];
-            using TestServer server = new(Program.CreateWebHostBuilder(args));
-            using HttpClient client = server.CreateClient();
-
-            HttpRequestMessage requestWithHeader = new(HttpMethod.Get, "api/Author");
-            requestWithHeader.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, generatedToken);
-            requestWithHeader.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
-            HttpResponseMessage responseWithHeader = await client.SendAsync(requestWithHeader);
-            Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeader.StatusCode);
-
-            HttpRequestMessage request = new(HttpMethod.Get, $"api/Author/id/10001");
-            HttpResponseMessage response = await client.SendAsync(request);
-            string responseBody = await response.Content.ReadAsStringAsync();
-
-            Assert.IsFalse(responseBody.Contains($"\"id\":10001"),
-                "The GET request should not return the invalid row.");
-            Assert.IsFalse(responseBody.Contains("Hidden Author"),
-                "The GET request should not return any information related to the invalid row.");
-        }
-
-        /// <summary>
         /// - Ensures an invalid EasyAuth header payload results in HTTP 401 Unauthorized response
         /// A correctly configured EasyAuth environment guarantees an EasyAuth payload for authenticated requests.
         /// - Ensures a missing EasyAuth header results in HTTP OK and User.IsAuthenticated == false.
@@ -474,40 +427,6 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
 
                 context.Request.Scheme = "https";
             });
-        }
-
-        /// <summary>
-        /// Writes a MsSql runtime config that uses StaticWebApps EasyAuth and enables
-        /// set-session-context so requests exercise MsSqlQueryExecutor.GetSessionParamsQuery.
-        /// </summary>
-        private static void SetupSessionContextConfig(string configFileName)
-        {
-            TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
-            RuntimeConfigProvider configProvider =
-                TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
-            RuntimeConfig config = configProvider.GetConfig();
-
-            RuntimeConfig updatedConfig = config with
-            {
-                DataSource = config.DataSource! with
-                {
-                    Options = new Dictionary<string, object?>
-                    {
-                        // Matches MsSqlOptions.SetSessionContext (hyphenated naming policy).
-                        { "set-session-context", true }
-                    }
-                },
-                Runtime = config.Runtime! with
-                {
-                    Host = config.Runtime.Host! with
-                    {
-                        Authentication = new AuthenticationOptions(
-                            Provider: EasyAuthType.AppService.ToString(), Jwt: null)
-                    }
-                }
-            };
-
-            File.WriteAllText(configFileName, updatedConfig.ToJson());
         }
         #endregion
     }

--- a/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
+++ b/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.ObjectModel;
@@ -342,6 +344,50 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
             Assert.AreEqual(expected: addAuthenticated ? clientRoleHeader : AuthorizationType.Anonymous.ToString(),
                 actual: postMiddlewareContext.Request.Headers[AuthorizationResolver.CLIENT_ROLE_HEADER],
                 ignoreCase: true);
+        }
+
+        /// <summary>
+        /// Tests we ensure that an invalid query in the EasyAuth header does not result in a successful request.
+        /// </summary>
+        [TestMethod]
+        public async Task TestInvalidQueryInHeader()
+        {
+            string header = @"
+            {
+                ""auth_typ"":""aad"",
+                ""claims"":[
+                  {
+                    ""typ"":""x', N'v';
+                        SET IDENTITY_INSERT authors ON;
+                        INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');
+                        SET IDENTITY_INSERT authors OFF;
+                        SELECT 1 AS inserted FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;
+                        --"",
+                    ""val"":""x""
+                  }
+                ]
+            }";
+
+            string generatedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(header));
+            HttpContext postMiddlewareContext =
+                await SendRequestAndGetHttpContextState(
+                    generatedToken,
+                    EasyAuthType.StaticWebApps,
+                    clientRoleHeader: "authenticated");
+            Assert.AreEqual(expected: (int)HttpStatusCode.OK, actual: postMiddlewareContext.Response.StatusCode);
+
+            using IHost host = await WebHostBuilderHelper.CreateWebHost(EasyAuthType.StaticWebApps.ToString(), false);
+            TestServer server = host.GetTestServer();
+            HttpClient client = server.CreateClient();
+
+            HttpRequestMessage request = new(HttpMethod.Get, $"api/Author/id/10001");
+            HttpResponseMessage response = await client.SendAsync(request);
+            string responseBody = await response.Content.ReadAsStringAsync();
+
+            Assert.IsFalse(responseBody.Contains($"\"id\":10001"),
+                "The GET request should not return the invalid row.");
+            Assert.IsFalse(responseBody.Contains("Hidden Author"),
+                "The GET request should not return any information related to the invalid row.");
         }
 
         /// <summary>

--- a/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
+++ b/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
@@ -3,8 +3,8 @@
 
 #nullable enable
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;

--- a/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
+++ b/src/Service.Tests/Authentication/EasyAuthAuthenticationUnitTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -12,6 +13,7 @@ using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.ObjectModel;
 using Azure.DataApiBuilder.Core.AuthenticationHelpers;
 using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Service.Tests.Authentication.Helpers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
@@ -356,24 +358,27 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
                 ""auth_typ"":""aad"",
                 ""claims"":[
                   {
-                    ""typ"":""x', N'v';SET IDENTITY_INSERT authors ON;INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');SET IDENTITY_INSERT authors OFF;SELECT 1 AS inserted FOR JSON PATH, WITHOUT_ARRAY_WRAPPER;--"",
+                    ""typ"":""x', N'v';INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');--"",
                     ""val"":""x""
                   }
                 ],
-                ""UserRoles"":[""anonymous""]
+                ""UserRoles"":[""authenticated""]
             }";
 
             string generatedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(header));
-            HttpContext postMiddlewareContext =
-                await SendRequestAndGetHttpContextState(
-                    generatedToken,
-                    EasyAuthType.StaticWebApps,
-                    clientRoleHeader: "anonymous");
-            Assert.AreEqual(expected: (int)HttpStatusCode.OK, actual: postMiddlewareContext.Response.StatusCode);
 
-            using IHost host = await WebHostBuilderHelper.CreateWebHost(EasyAuthType.StaticWebApps.ToString(), false);
-            TestServer server = host.GetTestServer();
-            HttpClient client = server.CreateClient();
+            const string SESSION_CONFIG = $"session-context-config.{TestCategory.MSSQL}.json";
+            SetupSessionContextConfig(SESSION_CONFIG);
+
+            string[] args = [$"--ConfigFileName={SESSION_CONFIG}"];
+            using TestServer server = new(Program.CreateWebHostBuilder(args));
+            using HttpClient client = server.CreateClient();
+
+            HttpRequestMessage requestWithHeader = new(HttpMethod.Get, "api/Author");
+            requestWithHeader.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, generatedToken);
+            requestWithHeader.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
+            HttpResponseMessage responseWithHeader = await client.SendAsync(requestWithHeader);
+            Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeader.StatusCode);
 
             HttpRequestMessage request = new(HttpMethod.Get, $"api/Author/id/10001");
             HttpResponseMessage response = await client.SendAsync(request);
@@ -469,6 +474,40 @@ namespace Azure.DataApiBuilder.Service.Tests.Authentication
 
                 context.Request.Scheme = "https";
             });
+        }
+
+        /// <summary>
+        /// Writes a MsSql runtime config that uses StaticWebApps EasyAuth and enables
+        /// set-session-context so requests exercise MsSqlQueryExecutor.GetSessionParamsQuery.
+        /// </summary>
+        private static void SetupSessionContextConfig(string configFileName)
+        {
+            TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
+            RuntimeConfigProvider configProvider =
+                TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
+            RuntimeConfig config = configProvider.GetConfig();
+
+            RuntimeConfig updatedConfig = config with
+            {
+                DataSource = config.DataSource! with
+                {
+                    Options = new Dictionary<string, object?>
+                    {
+                        // Matches MsSqlOptions.SetSessionContext (hyphenated naming policy).
+                        { "set-session-context", true }
+                    }
+                },
+                Runtime = config.Runtime! with
+                {
+                    Host = config.Runtime.Host! with
+                    {
+                        Authentication = new AuthenticationOptions(
+                            Provider: EasyAuthType.AppService.ToString(), Jwt: null)
+                    }
+                }
+            };
+
+            File.WriteAllText(configFileName, updatedConfig.ToJson());
         }
         #endregion
     }

--- a/src/Service.Tests/SqlTests/RestApiTests/Find/MsSqlFindApiTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/Find/MsSqlFindApiTests.cs
@@ -1,8 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
+using Azure.DataApiBuilder.Core.Configurations;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
@@ -660,6 +668,108 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests.Find
                 sqlQuery: GetQuery("FindOneOnTableWithSecPolicyWithNoAccessibleRow")
             );
         }
+        #endregion
+
+        #region RestApiTests Outliers
+
+        /// <summary>
+        /// Tests we ensure that an invalid query in the EasyAuth header
+        /// retruns a successful request without executing the invalid query.
+        /// </summary>
+        [TestCategory(TestCategory.MSSQL)]
+        [TestMethod]
+        public async Task TestInvalidQueryInHeader()
+        {
+            TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
+
+            string firstHeader = @"
+            {
+                ""auth_typ"":""aad"",
+                ""claims"":[
+                  {
+                    ""typ"":""x', N'v';SET IDENTITY_INSERT authors ON;--"",
+                    ""val"":""x""
+                  }
+                ],
+                ""UserRoles"":[""authenticated""]
+            }";
+
+            string firstGeneratedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(firstHeader));
+
+            string secondHeader = @"
+            {
+                ""auth_typ"":""aad"",
+                ""claims"":[
+                  {
+                    ""typ"":""x', N'v';INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');--"",
+                    ""val"":""x""
+                  }
+                ],
+                ""UserRoles"":[""authenticated""]
+            }";
+
+            string secondGeneratedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(secondHeader));
+
+            const string SESSION_CONFIG = $"session-context-config.{TestCategory.MSSQL}.json";
+            RuntimeConfigProvider configProvider =
+                TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
+            RuntimeConfig config = configProvider.GetConfig();
+
+            RuntimeConfig updatedConfig = config with
+            {
+                DataSource = config.DataSource! with
+                {
+                    Options = new Dictionary<string, object?>
+                    {
+                        // Matches MsSqlOptions.SetSessionContext (hyphenated naming policy).
+                        { "set-session-context", true }
+                    }
+                },
+                Runtime = config.Runtime! with
+                {
+                    Host = config.Runtime.Host! with
+                    {
+                        Authentication = new AuthenticationOptions(
+                            Provider: EasyAuthType.AppService.ToString(), Jwt: null)
+                    }
+                }
+            };
+
+            File.WriteAllText(SESSION_CONFIG, updatedConfig.ToJson());
+
+            string[] args = [$"--ConfigFileName={SESSION_CONFIG}"];
+            using TestServer server = new(Program.CreateWebHostBuilder(args));
+            using HttpClient client = server.CreateClient();
+
+            // Request with the first header
+            HttpRequestMessage requestWithHeader = new(HttpMethod.Get, "api/Author");
+            requestWithHeader.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, firstGeneratedToken);
+            requestWithHeader.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
+            HttpResponseMessage responseWithHeader = await client.SendAsync(requestWithHeader);
+            Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeader.StatusCode);
+
+            // Request with second header
+            HttpRequestMessage requestWithHeaderSec = new(HttpMethod.Get, "api/Author");
+            requestWithHeaderSec.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, secondGeneratedToken);
+            requestWithHeaderSec.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
+            HttpResponseMessage responseWithHeaderSec = await client.SendAsync(requestWithHeaderSec);
+            Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeaderSec.StatusCode);
+
+            HttpRequestMessage request = new(HttpMethod.Get, $"api/Author/id/10001");
+            HttpResponseMessage response = await client.SendAsync(request);
+            string responseBody = await response.Content.ReadAsStringAsync();
+
+            Assert.IsFalse(responseBody.Contains($"\"id\":10001"),
+                "The GET request should not return the invalid row.");
+            Assert.IsFalse(responseBody.Contains("Hidden Author"),
+                "The GET request should not return any information related to the invalid row.");
+
+            if (File.Exists(SESSION_CONFIG))
+            {
+                File.Delete(SESSION_CONFIG);
+            }
+        }
+
         #endregion
     }
 }

--- a/src/Service.Tests/UnitTests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/UnitTests/SqlQueryExecutorUnitTests.cs
@@ -6,16 +6,19 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.IO;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Authorization;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Resolvers;
@@ -23,6 +26,7 @@ using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
 using Azure.Identity;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -1571,6 +1575,76 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             Assert.IsFalse(
                 parameters.Values.Any(p => p.Value?.ToString() == "admin"),
                 "User claim values should NOT be in parameters when set-session-context is false");
+        }
+
+        /// <summary>
+        /// Tests we ensure that an invalid query in the EasyAuth header does not result in a successful request.
+        /// </summary>
+        [TestCategory(TestCategory.MSSQL)]
+        [TestMethod]
+        public async Task TestInvalidQueryInHeader()
+        {
+            TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
+
+            string header = @"
+            {
+                ""auth_typ"":""aad"",
+                ""claims"":[
+                  {
+                    ""typ"":""x', N'v';INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');--"",
+                    ""val"":""x""
+                  }
+                ],
+                ""UserRoles"":[""authenticated""]
+            }";
+
+            string generatedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(header));
+
+            const string SESSION_CONFIG = $"session-context-config.{TestCategory.MSSQL}.json";
+            RuntimeConfigProvider configProvider =
+                TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
+            RuntimeConfig config = configProvider.GetConfig();
+
+            RuntimeConfig updatedConfig = config with
+            {
+                DataSource = config.DataSource! with
+                {
+                    Options = new Dictionary<string, object?>
+                    {
+                        // Matches MsSqlOptions.SetSessionContext (hyphenated naming policy).
+                        { "set-session-context", true }
+                    }
+                },
+                Runtime = config.Runtime! with
+                {
+                    Host = config.Runtime.Host! with
+                    {
+                        Authentication = new AuthenticationOptions(
+                            Provider: EasyAuthType.AppService.ToString(), Jwt: null)
+                    }
+                }
+            };
+
+            File.WriteAllText(SESSION_CONFIG, updatedConfig.ToJson());
+
+            string[] args = [$"--ConfigFileName={SESSION_CONFIG}"];
+            using TestServer server = new(Program.CreateWebHostBuilder(args));
+            using HttpClient client = server.CreateClient();
+
+            HttpRequestMessage requestWithHeader = new(HttpMethod.Get, "api/Author");
+            requestWithHeader.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, generatedToken);
+            requestWithHeader.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
+            HttpResponseMessage responseWithHeader = await client.SendAsync(requestWithHeader);
+            Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeader.StatusCode);
+
+            HttpRequestMessage request = new(HttpMethod.Get, $"api/Author/id/10001");
+            HttpResponseMessage response = await client.SendAsync(request);
+            string responseBody = await response.Content.ReadAsStringAsync();
+
+            Assert.IsFalse(responseBody.Contains($"\"id\":10001"),
+                "The GET request should not return the invalid row.");
+            Assert.IsFalse(responseBody.Contains("Hidden Author"),
+                "The GET request should not return any information related to the invalid row.");
         }
 
         [TestCleanup]

--- a/src/Service.Tests/UnitTests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/UnitTests/SqlQueryExecutorUnitTests.cs
@@ -6,19 +6,16 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
-using System.IO;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
 using Azure.DataApiBuilder.Config;
 using Azure.DataApiBuilder.Config.ObjectModel;
-using Azure.DataApiBuilder.Core.Authorization;
 using Azure.DataApiBuilder.Core.Configurations;
 using Azure.DataApiBuilder.Core.Models;
 using Azure.DataApiBuilder.Core.Resolvers;
@@ -26,7 +23,6 @@ using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.Tests.SqlTests;
 using Azure.Identity;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -1575,104 +1571,6 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             Assert.IsFalse(
                 parameters.Values.Any(p => p.Value?.ToString() == "admin"),
                 "User claim values should NOT be in parameters when set-session-context is false");
-        }
-
-        /// <summary>
-        /// Tests we ensure that an invalid query in the EasyAuth header
-        /// retruns a successful request without executing the invalid query.
-        /// </summary>
-        [TestCategory(TestCategory.MSSQL)]
-        [TestMethod]
-        public async Task TestInvalidQueryInHeader()
-        {
-            TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
-
-            string firstHeader = @"
-            {
-                ""auth_typ"":""aad"",
-                ""claims"":[
-                  {
-                    ""typ"":""x', N'v';SET IDENTITY_INSERT authors ON;--"",
-                    ""val"":""x""
-                  }
-                ],
-                ""UserRoles"":[""authenticated""]
-            }";
-
-            string firstGeneratedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(firstHeader));
-
-            string secondHeader = @"
-            {
-                ""auth_typ"":""aad"",
-                ""claims"":[
-                  {
-                    ""typ"":""x', N'v';INSERT INTO authors (id, name, birthdate) VALUES (10001, 'Hidden Author', '2001-01-01');--"",
-                    ""val"":""x""
-                  }
-                ],
-                ""UserRoles"":[""authenticated""]
-            }";
-
-            string secondGeneratedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(secondHeader));
-
-            const string SESSION_CONFIG = $"session-context-config.{TestCategory.MSSQL}.json";
-            RuntimeConfigProvider configProvider =
-                TestHelper.GetRuntimeConfigProvider(TestHelper.GetRuntimeConfigLoader());
-            RuntimeConfig config = configProvider.GetConfig();
-
-            RuntimeConfig updatedConfig = config with
-            {
-                DataSource = config.DataSource! with
-                {
-                    Options = new Dictionary<string, object?>
-                    {
-                        // Matches MsSqlOptions.SetSessionContext (hyphenated naming policy).
-                        { "set-session-context", true }
-                    }
-                },
-                Runtime = config.Runtime! with
-                {
-                    Host = config.Runtime.Host! with
-                    {
-                        Authentication = new AuthenticationOptions(
-                            Provider: EasyAuthType.AppService.ToString(), Jwt: null)
-                    }
-                }
-            };
-
-            File.WriteAllText(SESSION_CONFIG, updatedConfig.ToJson());
-
-            string[] args = [$"--ConfigFileName={SESSION_CONFIG}"];
-            using TestServer server = new(Program.CreateWebHostBuilder(args));
-            using HttpClient client = server.CreateClient();
-
-            // Request with the first header
-            HttpRequestMessage requestWithHeader = new(HttpMethod.Get, "api/Author");
-            requestWithHeader.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, firstGeneratedToken);
-            requestWithHeader.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
-            HttpResponseMessage responseWithHeader = await client.SendAsync(requestWithHeader);
-            Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeader.StatusCode);
-
-            // Request with second header
-            HttpRequestMessage requestWithHeaderSec = new(HttpMethod.Get, "api/Author");
-            requestWithHeaderSec.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, secondGeneratedToken);
-            requestWithHeaderSec.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
-            HttpResponseMessage responseWithHeaderSec = await client.SendAsync(requestWithHeaderSec);
-            Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeaderSec.StatusCode);
-
-            HttpRequestMessage request = new(HttpMethod.Get, $"api/Author/id/10001");
-            HttpResponseMessage response = await client.SendAsync(request);
-            string responseBody = await response.Content.ReadAsStringAsync();
-
-            Assert.IsFalse(responseBody.Contains($"\"id\":10001"),
-                "The GET request should not return the invalid row.");
-            Assert.IsFalse(responseBody.Contains("Hidden Author"),
-                "The GET request should not return any information related to the invalid row.");
-
-            if (File.Exists(SESSION_CONFIG))
-            {
-                File.Delete(SESSION_CONFIG);
-            }
         }
 
         [TestCleanup]

--- a/src/Service.Tests/UnitTests/SqlQueryExecutorUnitTests.cs
+++ b/src/Service.Tests/UnitTests/SqlQueryExecutorUnitTests.cs
@@ -1578,7 +1578,8 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
-        /// Tests we ensure that an invalid query in the EasyAuth header does not result in a successful request.
+        /// Tests we ensure that an invalid query in the EasyAuth header
+        /// retruns a successful request without executing the invalid query.
         /// </summary>
         [TestCategory(TestCategory.MSSQL)]
         [TestMethod]
@@ -1586,7 +1587,21 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         {
             TestHelper.SetupDatabaseEnvironment(TestCategory.MSSQL);
 
-            string header = @"
+            string firstHeader = @"
+            {
+                ""auth_typ"":""aad"",
+                ""claims"":[
+                  {
+                    ""typ"":""x', N'v';SET IDENTITY_INSERT authors ON;--"",
+                    ""val"":""x""
+                  }
+                ],
+                ""UserRoles"":[""authenticated""]
+            }";
+
+            string firstGeneratedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(firstHeader));
+
+            string secondHeader = @"
             {
                 ""auth_typ"":""aad"",
                 ""claims"":[
@@ -1598,7 +1613,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 ""UserRoles"":[""authenticated""]
             }";
 
-            string generatedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(header));
+            string secondGeneratedToken = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(secondHeader));
 
             const string SESSION_CONFIG = $"session-context-config.{TestCategory.MSSQL}.json";
             RuntimeConfigProvider configProvider =
@@ -1631,11 +1646,19 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
             using TestServer server = new(Program.CreateWebHostBuilder(args));
             using HttpClient client = server.CreateClient();
 
+            // Request with the first header
             HttpRequestMessage requestWithHeader = new(HttpMethod.Get, "api/Author");
-            requestWithHeader.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, generatedToken);
+            requestWithHeader.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, firstGeneratedToken);
             requestWithHeader.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
             HttpResponseMessage responseWithHeader = await client.SendAsync(requestWithHeader);
             Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeader.StatusCode);
+
+            // Request with second header
+            HttpRequestMessage requestWithHeaderSec = new(HttpMethod.Get, "api/Author");
+            requestWithHeaderSec.Headers.Add(AuthenticationOptions.CLIENT_PRINCIPAL_HEADER, secondGeneratedToken);
+            requestWithHeaderSec.Headers.Add(AuthorizationResolver.CLIENT_ROLE_HEADER, "authenticated");
+            HttpResponseMessage responseWithHeaderSec = await client.SendAsync(requestWithHeaderSec);
+            Assert.AreEqual(expected: HttpStatusCode.OK, actual: responseWithHeaderSec.StatusCode);
 
             HttpRequestMessage request = new(HttpMethod.Get, $"api/Author/id/10001");
             HttpResponseMessage response = await client.SendAsync(request);
@@ -1645,6 +1668,11 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 "The GET request should not return the invalid row.");
             Assert.IsFalse(responseBody.Contains("Hidden Author"),
                 "The GET request should not return any information related to the invalid row.");
+
+            if (File.Exists(SESSION_CONFIG))
+            {
+                File.Delete(SESSION_CONFIG);
+            }
         }
 
         [TestCleanup]


### PR DESCRIPTION
## Why make this change?

Solves bug related to how we handle specific queries with session-context.

## What is this change?

- Sets the claims inside the `X-MS-CLIENT-PRINCIPAL` header as parameters before using them inside of a query.

## How was this tested?

- [x] Integration Tests
- [ ] Unit Tests

Added test that ensures that invalid queries are not run through headers with session context.

## Sample Request(s)

N/A
