### PR TITLE
[Phase 3b] MSSQL JSON - return json as string on read + OpenAPI/GraphQL tests

### DIFF
--- a/src/Core/Resolvers/MsSqlQueryBuilder.cs
+++ b/src/Core/Resolvers/MsSqlQueryBuilder.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Data;
 using System.Data.Common;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -456,8 +457,34 @@ namespace Azure.DataApiBuilder.Core.Resolvers
                 structure.Columns.Select(
                     c => structure.IsSubqueryColumn(c) ?
                         WrapSubqueryColumn(c, structure.JoinQueries[c.TableAlias!]) + $" AS {QuoteIdentifier(c.Label)}" :
-                        Build(c)
+                        BuildResultColumn(c, structure)
             ));
+        }
+
+        /// <summary>
+        /// Builds a top-level (non-subquery) result column.
+        /// A SQL Server native <c>json</c> column is cast to NVARCHAR(MAX) so that the trailing
+        /// FOR JSON PATH clause emits it as an escaped JSON string instead of inlining it as a nested
+        /// JSON value. DAB treats a json column as a normal string, so its raw JSON text must
+        /// round-trip as a string at the REST/GraphQL boundary.
+        /// </summary>
+        private string BuildResultColumn(LabelledColumn column, SqlQueryStructure structure)
+        {
+            if (IsJsonColumn(column, structure))
+            {
+                return $"CAST({Build(column as Column)} AS NVARCHAR(MAX)) AS {QuoteIdentifier(column.Label)}";
+            }
+
+            return Build(column);
+        }
+
+        /// <summary>
+        /// Returns true when the given column is backed by a SQL Server native <c>json</c> column.
+        /// </summary>
+        private static bool IsJsonColumn(LabelledColumn column, SqlQueryStructure structure)
+        {
+            return structure.GetUnderlyingSourceDefinition().Columns.TryGetValue(column.ColumnName, out ColumnDefinition? columnDefinition)
+                && columnDefinition.SqlDbType == SqlDbType.Json;
         }
 
         /// <summary>

--- a/src/Service.Tests/OpenApiDocumentor/JsonTypeSchemaTests.cs
+++ b/src/Service.Tests/OpenApiDocumentor/JsonTypeSchemaTests.cs
@@ -11,9 +11,10 @@ namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
 {
     /// <summary>
     /// Validates how a SQL Server 2025 native <c>json</c> column is surfaced in the generated
-    /// OpenAPI document. DAB does nothing special for a JSON column - it is treated as a normal
-    /// <c>string</c>, so it must be described with <c>type: string</c> and no custom <c>format</c>.
-    /// This is the schema-discovery counterpart to the REST round-trip coverage in
+    /// OpenAPI document. DAB treats a json column as a normal <c>string</c> for input and output,
+    /// so it must be described with <c>type: string</c> and no custom <c>format</c> in the response
+    /// schema as well as the POST / PUT / PATCH request-body schemas. This is the schema-discovery
+    /// counterpart to the REST round-trip coverage in
     /// <see cref="SqlTests.RestApiTests.MsSqlRestJsonTypesTests"/>.
     /// NOTE: The native JSON data type requires SQL Server 2025 / Azure SQL.
     /// </summary>
@@ -25,24 +26,36 @@ namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
         private const string DB_ENV = TestCategory.MSSQL;
 
         /// <summary>
-        /// The <c>profiles.metadata</c> (json) column must appear in the OpenAPI schema as a plain
-        /// string with no format - proving JSON is not given a bespoke scalar/format and is treated
-        /// exactly like any other string column. (DAB''s OpenAPI documentor does not express column
-        /// nullability on the property schema for any type, so that is not asserted here.)
+        /// The <c>profiles.metadata</c> (json) column must be described as a plain string with no format
+        /// in the response schema and in both request-body schemas (POST => <c>Profile_NoAutoPK</c>,
+        /// PUT/PATCH => <c>Profile_NoPK</c>) - proving json is treated like a normal string for both input
+        /// and output, with no bespoke scalar/format. (DAB does not express column nullability on the
+        /// property schema for any type, so that is not asserted here.)
         /// </summary>
         [TestMethod]
-        public async Task JsonColumn_IsDescribedAsStringWithoutFormat()
+        public async Task JsonColumn_IsDescribedAsStringWithoutFormat_InResponseAndRequestBodies()
         {
             OpenApiDocument doc = await GenerateProfileDocumentAsync();
 
-            Assert.IsTrue(doc.Components.Schemas.ContainsKey("Profile"), "Schema should exist for the Profile entity.");
+            // Response body schema, plus the POST and PUT/PATCH request-body schemas.
+            AssertMetadataIsPlainString(doc, "Profile");
+            AssertMetadataIsPlainString(doc, "Profile_NoAutoPK");
+            AssertMetadataIsPlainString(doc, "Profile_NoPK");
+        }
 
-            OpenApiSchema profileSchema = doc.Components.Schemas["Profile"];
-            Assert.IsTrue(profileSchema.Properties.ContainsKey("metadata"), "The json ''metadata'' column should be present in the schema.");
+        /// <summary>
+        /// Asserts the named component schema exposes <c>metadata</c> as a plain string with no format.
+        /// </summary>
+        private static void AssertMetadataIsPlainString(OpenApiDocument doc, string schemaName)
+        {
+            Assert.IsTrue(doc.Components.Schemas.ContainsKey(schemaName), $"Schema {schemaName} should exist.");
 
-            OpenApiSchema metadataSchema = profileSchema.Properties["metadata"];
-            Assert.AreEqual("string", metadataSchema.Type, "A json column must be described as a plain string (treated like any string column).");
-            Assert.IsTrue(string.IsNullOrEmpty(metadataSchema.Format), "A json column must not carry a bespoke OpenAPI format.");
+            OpenApiSchema schema = doc.Components.Schemas[schemaName];
+            Assert.IsTrue(schema.Properties.ContainsKey("metadata"), $"The json metadata column should be present in {schemaName}.");
+
+            OpenApiSchema metadataSchema = schema.Properties["metadata"];
+            Assert.AreEqual("string", metadataSchema.Type, $"A json column must be described as a plain string in {schemaName}.");
+            Assert.IsTrue(string.IsNullOrEmpty(metadataSchema.Format), $"A json column must not carry a bespoke OpenAPI format in {schemaName}.");
         }
 
         /// <summary>

--- a/src/Service.Tests/OpenApiDocumentor/JsonTypeSchemaTests.cs
+++ b/src/Service.Tests/OpenApiDocumentor/JsonTypeSchemaTests.cs
@@ -12,9 +12,8 @@ namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
     /// <summary>
     /// Validates how a SQL Server 2025 native <c>json</c> column is surfaced in the generated
     /// OpenAPI document. DAB does nothing special for a JSON column - it is treated as a normal
-    /// <c>string</c>, so it must be described with <c>type: string</c>, no custom <c>format</c>,
-    /// and honoring the column's nullability. This is the schema-discovery counterpart to the
-    /// REST round-trip coverage in
+    /// <c>string</c>, so it must be described with <c>type: string</c> and no custom <c>format</c>.
+    /// This is the schema-discovery counterpart to the REST round-trip coverage in
     /// <see cref="SqlTests.RestApiTests.MsSqlRestJsonTypesTests"/>.
     /// NOTE: The native JSON data type requires SQL Server 2025 / Azure SQL.
     /// </summary>
@@ -26,23 +25,24 @@ namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
         private const string DB_ENV = TestCategory.MSSQL;
 
         /// <summary>
-        /// The <c>profiles.metadata</c> (json, nullable) column must appear in the OpenAPI schema as
-        /// a plain nullable string with no format - proving JSON is not given a bespoke scalar/format.
+        /// The <c>profiles.metadata</c> (json) column must appear in the OpenAPI schema as a plain
+        /// string with no format - proving JSON is not given a bespoke scalar/format and is treated
+        /// exactly like any other string column. (DAB''s OpenAPI documentor does not express column
+        /// nullability on the property schema for any type, so that is not asserted here.)
         /// </summary>
         [TestMethod]
-        public async Task JsonColumn_IsDescribedAsNullableStringWithoutFormat()
+        public async Task JsonColumn_IsDescribedAsStringWithoutFormat()
         {
             OpenApiDocument doc = await GenerateProfileDocumentAsync();
 
             Assert.IsTrue(doc.Components.Schemas.ContainsKey("Profile"), "Schema should exist for the Profile entity.");
 
             OpenApiSchema profileSchema = doc.Components.Schemas["Profile"];
-            Assert.IsTrue(profileSchema.Properties.ContainsKey("metadata"), "The json 'metadata' column should be present in the schema.");
+            Assert.IsTrue(profileSchema.Properties.ContainsKey("metadata"), "The json ''metadata'' column should be present in the schema.");
 
             OpenApiSchema metadataSchema = profileSchema.Properties["metadata"];
             Assert.AreEqual("string", metadataSchema.Type, "A json column must be described as a plain string (treated like any string column).");
             Assert.IsTrue(string.IsNullOrEmpty(metadataSchema.Format), "A json column must not carry a bespoke OpenAPI format.");
-            Assert.IsTrue(metadataSchema.Nullable, "The nullable json column must be described as nullable.");
         }
 
         /// <summary>

--- a/src/Service.Tests/OpenApiDocumentor/JsonTypeSchemaTests.cs
+++ b/src/Service.Tests/OpenApiDocumentor/JsonTypeSchemaTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Microsoft.OpenApi.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Azure.DataApiBuilder.Service.Tests.OpenApiIntegration
+{
+    /// <summary>
+    /// Validates how a SQL Server 2025 native <c>json</c> column is surfaced in the generated
+    /// OpenAPI document. DAB does nothing special for a JSON column - it is treated as a normal
+    /// <c>string</c>, so it must be described with <c>type: string</c>, no custom <c>format</c>,
+    /// and honoring the column's nullability. This is the schema-discovery counterpart to the
+    /// REST round-trip coverage in
+    /// <see cref="SqlTests.RestApiTests.MsSqlRestJsonTypesTests"/>.
+    /// NOTE: The native JSON data type requires SQL Server 2025 / Azure SQL.
+    /// </summary>
+    [TestCategory(TestCategory.MSSQL)]
+    [TestClass]
+    public class JsonTypeSchemaTests
+    {
+        private const string CONFIG_FILE = "json-type-openapi-config.MsSql.json";
+        private const string DB_ENV = TestCategory.MSSQL;
+
+        /// <summary>
+        /// The <c>profiles.metadata</c> (json, nullable) column must appear in the OpenAPI schema as
+        /// a plain nullable string with no format - proving JSON is not given a bespoke scalar/format.
+        /// </summary>
+        [TestMethod]
+        public async Task JsonColumn_IsDescribedAsNullableStringWithoutFormat()
+        {
+            OpenApiDocument doc = await GenerateProfileDocumentAsync();
+
+            Assert.IsTrue(doc.Components.Schemas.ContainsKey("Profile"), "Schema should exist for the Profile entity.");
+
+            OpenApiSchema profileSchema = doc.Components.Schemas["Profile"];
+            Assert.IsTrue(profileSchema.Properties.ContainsKey("metadata"), "The json 'metadata' column should be present in the schema.");
+
+            OpenApiSchema metadataSchema = profileSchema.Properties["metadata"];
+            Assert.AreEqual("string", metadataSchema.Type, "A json column must be described as a plain string (treated like any string column).");
+            Assert.IsTrue(string.IsNullOrEmpty(metadataSchema.Format), "A json column must not carry a bespoke OpenAPI format.");
+            Assert.IsTrue(metadataSchema.Nullable, "The nullable json column must be described as nullable.");
+        }
+
+        /// <summary>
+        /// Builds an OpenAPI document for a Profile entity sourced from the <c>profiles</c> table,
+        /// with REST + GraphQL enabled and anonymous/authenticated CRUD permissions.
+        /// </summary>
+        private static async Task<OpenApiDocument> GenerateProfileDocumentAsync()
+        {
+            Entity entity = new(
+                Source: new("profiles", EntitySourceType.Table, null, null),
+                Fields: null,
+                GraphQL: new("Profile", "Profiles", true),
+                Rest: new(EntityRestOptions.DEFAULT_SUPPORTED_VERBS),
+                Permissions: OpenApiTestBootstrap.CreateBasicPermissions(),
+                Mappings: null,
+                Relationships: null);
+
+            RuntimeEntities entities = new(new Dictionary<string, Entity> { { "Profile", entity } });
+            return await OpenApiTestBootstrap.GenerateOpenApiDocumentAsync(entities, CONFIG_FILE, DB_ENV);
+        }
+    }
+}

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLJsonSchemaTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLJsonSchemaTests.cs
@@ -56,5 +56,31 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
             Assert.AreEqual("SCALAR", metadataType.GetProperty("kind").GetString(), "A json column must map to a scalar, not a custom object/scalar type.");
             Assert.AreEqual("String", metadataType.GetProperty("name").GetString(), "A json column must use the built-in String scalar (no bespoke JSON scalar).");
         }
+
+        /// <summary>
+        /// profile_by_pk(id: 1) { metadata } - Verify that reading the json-backed field through GraphQL
+        /// succeeds and returns the payload as a JSON string. The String leaf resolver calls
+        /// JsonElement.GetString(), which only works because the engine casts the json column to
+        /// NVARCHAR(MAX) so it is emitted as an escaped string rather than an inlined JSON object.
+        /// This guards against the introspection test passing while a real read throws a GraphQLMapping error.
+        /// </summary>
+        [TestMethod]
+        public async Task JsonColumn_GraphQLRead_ReturnsPayloadAsString()
+        {
+            string query = @"{
+                profile_by_pk(id: 1) {
+                    metadata
+                }
+            }";
+
+            JsonElement result = await ExecuteGraphQLRequestAsync(query, "profile_by_pk", isAuthenticated: false);
+
+            JsonElement metadata = result.GetProperty("metadata");
+            Assert.AreEqual(JsonValueKind.String, metadata.ValueKind, "A json column must be returned as a JSON string through GraphQL (treated as a normal string).");
+
+            JsonElement parsed = JsonDocument.Parse(metadata.GetString()!).RootElement;
+            Assert.AreEqual("admin", parsed.GetProperty("role").GetString());
+            Assert.AreEqual(3, parsed.GetProperty("tier").GetInt32());
+        }
     }
 }

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLJsonSchemaTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLJsonSchemaTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
+{
+    /// <summary>
+    /// GraphQL schema-discovery (introspection) tests for a SQL Server 2025 native <c>json</c> column.
+    /// DAB does nothing special for a JSON column - it is treated as a normal <c>string</c>, so the
+    /// GraphQL schema must expose it using the built-in <c>String</c> scalar (no bespoke JSON scalar),
+    /// honoring the column's nullability. This is the GraphQL counterpart to the REST/OpenAPI coverage
+    /// in <see cref="RestApiTests.MsSqlRestJsonTypesTests"/> and <c>JsonTypeSchemaTests</c>.
+    /// NOTE: The native JSON data type requires SQL Server 2025 / Azure SQL.
+    /// </summary>
+    [TestClass, TestCategory(TestCategory.MSSQL)]
+    public class MsSqlGraphQLJsonSchemaTests : SqlTestBase
+    {
+        [ClassInitialize]
+        public static async Task SetupAsync(TestContext context)
+        {
+            DatabaseEngine = TestCategory.MSSQL;
+            await InitializeTestFixture();
+        }
+
+        /// <summary>
+        /// Introspecting the Profile type must report its json-backed <c>metadata</c> field as the
+        /// built-in nullable <c>String</c> scalar - proving JSON gets no custom scalar in the schema.
+        /// </summary>
+        [TestMethod]
+        public async Task JsonColumn_IsIntrospectedAsBuiltInStringScalar()
+        {
+            string introspectionQuery = @"{
+                __type(name: ""Profile"") {
+                    name
+                    fields {
+                        name
+                        type { kind name ofType { kind name } }
+                    }
+                }
+            }";
+
+            JsonElement type = await ExecuteGraphQLRequestAsync(introspectionQuery, "__type", isAuthenticated: false);
+
+            Assert.AreEqual("Profile", type.GetProperty("name").GetString(), "Introspection should resolve the Profile GraphQL type.");
+
+            JsonElement metadataField = type.GetProperty("fields").EnumerateArray()
+                .Single(f => f.GetProperty("name").GetString() == "metadata");
+
+            // A nullable column surfaces as the bare scalar (no NON_NULL wrapper), so type.kind/name
+            // describe the scalar directly.
+            JsonElement metadataType = metadataField.GetProperty("type");
+            Assert.AreEqual("SCALAR", metadataType.GetProperty("kind").GetString(), "A json column must map to a scalar, not a custom object/scalar type.");
+            Assert.AreEqual("String", metadataType.GetProperty("name").GetString(), "A json column must use the built-in String scalar (no bespoke JSON scalar).");
+        }
+    }
+}

--- a/src/Service.Tests/SqlTests/RestApiTests/MsSqlRestJsonTypesTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/MsSqlRestJsonTypesTests.cs
@@ -12,12 +12,10 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests
 {
     /// <summary>
     /// Tests for SQL Server native JSON column support via REST endpoints (read and write).
-    /// DAB does nothing special for a JSON column - it is written from the request payload and
-    /// read back with no custom handling, new scalar, or format. On read, SQL Server's
-    /// FOR JSON PATH projection (which DAB uses to shape every result) inlines a native json
-    /// column as a nested JSON value, so the metadata surfaces at the REST boundary as a JSON
-    /// object rather than an escaped string. Writes still supply the payload as a JSON string,
-    /// exactly as a normal string column would be written.
+    /// DAB treats a JSON column exactly like a string: the raw JSON text is written from the
+    /// request payload and read back as a JSON string (the MSSQL query builder casts the native
+    /// json column to NVARCHAR(MAX) so FOR JSON PATH emits it as an escaped string rather than
+    /// inlining it as a nested object). No new scalar or format is involved.
     /// Assertions compare the returned metadata semantically so they are robust to any
     /// whitespace / key-order normalization the engine applies to the JSON type.
     /// NOTE: The native JSON data type requires SQL Server 2025 / Azure SQL.
@@ -38,7 +36,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests
 
         /// <summary>
         /// GET /api/Profile - Verify the whole collection (5 seeded rows) is returned and that
-        /// each metadata value renders either as a native JSON object payload or null (row 5).
+        /// each metadata value renders either as a JSON string payload or null (row 5).
         /// </summary>
         [TestMethod]
         public async Task GetJsonTypeList()
@@ -50,13 +48,13 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests
                 .RootElement.GetProperty("value");
             Assert.AreEqual(5, items.GetArrayLength(), "Expected the 5 seeded profile rows.");
 
-            // Rows 1-4 carry a JSON payload (inlined as a native JSON object); row 5 is null.
+            // Rows 1-4 carry a JSON payload (returned as an escaped JSON string); row 5 is null.
             foreach (JsonElement record in items.EnumerateArray())
             {
                 JsonValueKind metadataKind = record.GetProperty("metadata").ValueKind;
                 Assert.IsTrue(
-                    metadataKind is JsonValueKind.Object or JsonValueKind.Null,
-                    $"Expected metadata to be a JSON object or null, but was {metadataKind}.");
+                    metadataKind is JsonValueKind.String or JsonValueKind.Null,
+                    $"Expected metadata to be a JSON string or null, but was {metadataKind}.");
             }
         }
 
@@ -248,19 +246,19 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests
         }
 
         /// <summary>
-        /// Returns the metadata field as a JSON element. DAB applies no special handling to a JSON
-        /// column, so SQL Server's FOR JSON PATH projection inlines it as a native JSON object at the
-        /// REST boundary. This helper asserts the value is a JSON object and returns it for inspection.
+        /// Returns the metadata field parsed as a JSON element. DAB treats a JSON column as a string,
+        /// so a non-null metadata value arrives at the REST boundary as a JSON string carrying the
+        /// payload. This helper asserts that and parses the string payload for semantic inspection.
         /// </summary>
         private static JsonElement ParseMetadata(JsonElement record)
         {
             JsonElement metadata = record.GetProperty("metadata");
             Assert.AreEqual(
-                JsonValueKind.Object,
+                JsonValueKind.String,
                 metadata.ValueKind,
-                "A native JSON column is inlined as a JSON object at the REST boundary via FOR JSON PATH.");
+                "A json column must be returned as a JSON string at the REST boundary (treated as a normal string).");
 
-            return metadata.Clone();
+            return JsonDocument.Parse(metadata.GetString()!).RootElement.Clone();
         }
 
         #endregion


### PR DESCRIPTION
## Why

Part of MSSQL native `JSON` support (#2768). Started as Phase 3b **schema-discovery tests**, but review (thanks @aaronburtle) surfaced a real product inconsistency that this PR now also fixes.

**The problem:** #2768 requires a `JSON` column to be treated as a normal `string` for **input and output**. But the MSSQL read path (`FOR JSON PATH`) was *inlining* a native `json` column as a nested JSON **object**. Consequences:
- REST returned `"metadata": {"role":"admin"}` (object) instead of `"metadata": "{\"role\":\"admin\"}"` (string).
- A GraphQL read of the `String`-typed field threw a `GraphQLMapping` error — the `String` leaf resolver calls `JsonElement.GetString()`, which fails on an object. So schema introspection could pass while `profile_by_pk(id:1){ metadata }` failed at runtime.
- OpenAPI/GraphQL advertised `string`, contradicting the object runtime — generated clients would mis-model the field.

## What

**Engine fix** (`MsSqlQueryBuilder`): the read path now casts a native `json` column (`SqlDbType.Json`) to `NVARCHAR(MAX)` in `WrappedColumns`, so `FOR JSON PATH` emits it as an escaped JSON **string** rather than inlining it as an object. This is the single choke point for REST **and** GraphQL reads. Regular `nvarchar` columns are untouched. Mutations already return `json` as a string via the tabular `OUTPUT` clause, so no change was needed there.

**Tests:**

| Layer | Test | Asserts |
|------|------|---------|
| OpenAPI | `JsonTypeSchemaTests` | `metadata` is `type: string` with no `format` in the **response** and both **request-body** schemas (`Profile_NoAutoPK` for POST, `Profile_NoPK` for PUT/PATCH) |
| GraphQL introspection | `MsSqlGraphQLJsonSchemaTests` | `Profile.metadata` is the built-in `String` scalar (no custom JSON scalar) |
| GraphQL read (new) | `MsSqlGraphQLJsonSchemaTests` | `profile_by_pk(id:1){ metadata }` returns the payload as a JSON **string** — guards against introspection passing while a real read throws |
| REST | `MsSqlRestJsonTypesTests` (updated) | flipped back to the string contract: `metadata` is returned as a JSON **string** (`ParseMetadata`/`GetJsonTypeList` assert `JsonValueKind.String`) |

> Note: DAB's OpenAPI documentor does not emit `Nullable` on the property schema for **any** column type, so the schema tests assert `type: string` + no `format` (not nullability).

## Intentionally omitted

- **MCP `describe_entities` (T010)**: it projects only the config field `name`/`description`, not DB column data types, so there is no JSON-specific behavior to assert.

## Notes

- **This PR now includes a product (engine) change**, not tests only.
- Requires SQL Server 2025 / Azure SQL (native `json`); CI already runs SQL 2025.
- Cannot be run locally (no SQL 2025 here) — relying on CI.

## Delivery plan

| Phase | What | Status |
|-------|------|--------|
| 1 | .NET 10 + SqlClient 6.x | ✅ Merged (#3697/#3656) |
| 2 | JSON type + error mapping (engine) | ✅ Merged (#3691) |
| 3 | Test fixture + REST CRUD tests | ✅ Merged (#3720) |
| **3b** | **json-as-string read fix + OpenAPI/GraphQL discovery & read tests (this PR)** | 🚧 |
| 4 | Error/filter edge cases + regression + polish | Next |
