### PR TITLE
[Phase 4] MSSQL JSON - malformed-JSON (400) + filter edge-case tests

### DIFF
--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLJsonSchemaTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLJsonSchemaTests.cs
@@ -98,9 +98,10 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
                 }
             }";
 
-            JsonElement result = await ExecuteGraphQLRequestAsync(createMutation, createMutationName, isAuthenticated: false, expectsError: true);
+            JsonElement errors = await ExecuteGraphQLRequestAsync(createMutation, createMutationName, isAuthenticated: false);
 
-            SqlTestHelper.TestForErrorInGraphQLResponse(result.ToString());
+            Assert.AreEqual(JsonValueKind.Array, errors.ValueKind, "Expected a GraphQL errors array for malformed JSON payload.");
+            Assert.IsTrue(errors.GetArrayLength() > 0, "Expected at least one GraphQL error.");
         }
     }
 }

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLJsonSchemaTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLJsonSchemaTests.cs
@@ -82,5 +82,25 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
             Assert.AreEqual("admin", parsed.GetProperty("role").GetString());
             Assert.AreEqual(3, parsed.GetProperty("tier").GetInt32());
         }
+
+        /// <summary>
+        /// createProfile with malformed JSON in the metadata field must fail with a GraphQL error
+        /// (surfaced from SQL Server's json validation) rather than persisting invalid data.
+        /// </summary>
+        [TestMethod]
+        public async Task JsonColumn_GraphQLCreateWithMalformedJson_Fails()
+        {
+            string createMutationName = "createProfile";
+            string createMutation = @"mutation {
+                createProfile(item: { metadata: ""{ not valid json"" }) {
+                    id
+                    metadata
+                }
+            }";
+
+            JsonElement result = await ExecuteGraphQLRequestAsync(createMutation, createMutationName, isAuthenticated: false, expectsError: true);
+
+            SqlTestHelper.TestForErrorInGraphQLResponse(result.ToString());
+        }
     }
 }

--- a/src/Service.Tests/SqlTests/RestApiTests/MsSqlRestJsonTypesTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/MsSqlRestJsonTypesTests.cs
@@ -114,6 +114,21 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests
             Assert.AreEqual("éü😀", metadata.GetProperty("unicode").GetString());
         }
 
+        /// <summary>
+        /// GET /api/Profile?$filter=metadata ne null - Verify filtering a json column (treated as a
+        /// string) passes through to SQL: the 4 non-null rows match and the null row (id 5) does not.
+        /// </summary>
+        [TestMethod]
+        public async Task FilterJsonColumnIsNotNull_Succeeds()
+        {
+            HttpResponseMessage response = await HttpClient.GetAsync($"{JSON_TYPE_REST_PATH}?$filter=metadata ne null");
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Filtering a json column as a string should pass through and succeed.");
+
+            JsonElement items = JsonDocument.Parse(await response.Content.ReadAsStringAsync())
+                .RootElement.GetProperty("value");
+            Assert.AreEqual(4, items.GetArrayLength(), "Only the 4 rows with non-null metadata should match.");
+        }
+
         #endregion
 
         #region Write Tests
@@ -219,6 +234,26 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests
                     new StringContent("{ \"metadata\": \"{\\\"tags\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"]}\" }", Encoding.UTF8, "application/json"));
                 Assert.AreEqual(HttpStatusCode.OK, restore.StatusCode);
             }
+        }
+
+        /// <summary>
+        /// POST /api/Profile - Verify that supplying invalid JSON for the json column is rejected by
+        /// SQL Server and surfaced as HTTP 400 (a client input error), not a 500. DAB treats the value
+        /// as a normal string, so JSON validation happens at the database boundary.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("{ \"metadata\": \"{ not valid json\" }", DisplayName = "Unclosed / unquoted object")]
+        [DataRow("{ \"metadata\": \"{\\\"key\\\": }\" }", DisplayName = "Missing value")]
+        public async Task InsertMalformedJson_ReturnsBadRequest(string requestBody)
+        {
+            HttpResponseMessage response = await HttpClient.PostAsync(
+                JSON_TYPE_REST_PATH,
+                new StringContent(requestBody, Encoding.UTF8, "application/json"));
+
+            Assert.AreEqual(
+                HttpStatusCode.BadRequest,
+                response.StatusCode,
+                "SQL Server rejects invalid JSON for a native json column; DAB must surface it as HTTP 400.");
         }
 
         #endregion

--- a/src/Service.Tests/SqlTests/RestApiTests/MsSqlRestJsonTypesTests.cs
+++ b/src/Service.Tests/SqlTests/RestApiTests/MsSqlRestJsonTypesTests.cs
@@ -121,7 +121,7 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.RestApiTests
         [TestMethod]
         public async Task FilterJsonColumnIsNotNull_Succeeds()
         {
-            HttpResponseMessage response = await HttpClient.GetAsync($"{JSON_TYPE_REST_PATH}?$filter=metadata ne null");
+            HttpResponseMessage response = await HttpClient.GetAsync($"{JSON_TYPE_REST_PATH}?$filter=metadata%20ne%20null");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Filtering a json column as a string should pass through and succeed.");
 
             JsonElement items = JsonDocument.Parse(await response.Content.ReadAsStringAsync())


### PR DESCRIPTION
Resolves #3752

## Why

Phase 4 of MSSQL native `JSON` support (#2768) — error-handling and filter edge cases. Builds on the merged engine + schema-discovery work (#3691, #3720, #3738).

## What

| User story | Test | Asserts |
|-----------|------|---------|
| **US7 — REST** | `InsertMalformedJson_ReturnsBadRequest` | Posting invalid JSON for the `json` column is rejected by SQL Server and surfaced as **HTTP 400** (not 500), exercising the `13608–13614 → BadRequest` mapping |
| **US7 — GraphQL** | `JsonColumn_GraphQLCreateWithMalformedJson_Fails` | A `createProfile` mutation with malformed JSON fails with a GraphQL error (mirrors the merged vector-type pattern in `MsSqlGraphQLVectorTypesTests`) |
| **US9 — REST** | `FilterJsonColumnIsNotNull_Succeeds` | Filtering a `json` column as a string (`$filter=metadata ne null`) passes through to SQL and returns the 4 non-null rows |

Because DAB treats `json` as a normal string and does no pre-validation, invalid JSON is caught at the database boundary and mapped to a client error — consistent with the "nothing special" contract.

## Deferred (pending CI observation)

- **Pruning `13608–13614`**: kept the full documented JSON-validation range for now. Removing a code that actually fires would regress it to a 500, so I'd rather confirm the exact code(s) SQL 2025 emits (via this PR's CI run) before narrowing the list.
- **Sort / equality on a `json` column**: SQL Server disallows comparing/sorting the native `json` type (except `IS [NOT] NULL`), so `$orderby=metadata` / `metadata eq '…'` behavior + error-code mapping needs CI confirmation before I assert on it.

## Notes

- Tests only — no product code changes.
- Requires SQL Server 2025 / Azure SQL (native `json`); CI already runs SQL 2025.
- Cannot be run locally (no SQL 2025 here) — relying on CI.

## Delivery plan

| Phase | What | Status |
|-------|------|--------|
| 1 | .NET 10 + SqlClient 6.x | ✅ Merged (#3697/#3656) |
| 2 | JSON type + error mapping (engine) | ✅ Merged (#3691) |
| 3 | Test fixture + REST CRUD tests | ✅ Merged (#3720) |
| 3b | json-as-string read fix + OpenAPI/GraphQL tests | ✅ Merged (#3738) |
| **4** | **Error / filter edge cases (this PR)** | 🚧 |
