### PR TITLE
fix: update ChilliCream license URL to new path after repo restructure

### DIFF
--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -9,7 +9,7 @@ param (
 
 # Download and save the ChilliCream License 1.0 from ChilliCream/graphql-platform GitHub repo
 $chiliCreamLicenseSavePath = "$BuildArtifactStagingDir/chillicreamlicense.txt"
-$chiliCreamLicenseMetadataURL = "https://raw.githubusercontent.com/ChilliCream/graphql-platform/main/website/src/basic/licensing/chillicream-license.md"
+$chiliCreamLicenseMetadataURL = "https://raw.githubusercontent.com/ChilliCream/graphql-platform/main/website/content/licensing/chillicream-license.md"
 Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Select-Object -ExpandProperty Content |
  Out-File $chiliCreamLicenseSavePath


### PR DESCRIPTION
## Why make this change?

- Fixes a 404 in the notice-generation pipeline step "Add Additional Licenses to NOTICE file for Package".
- ChilliCream restructured their `graphql-platform` repo and moved the license file from `website/src/basic/licensing/chillicream-license.md` to `website/content/licensing/chillicream-license.md`. The old URL no longer exists and returns a 404, causing the pipeline to fail.

## What is this change?

- One-line update in `scripts/notice-generation.ps1`: the `$chiliCreamLicenseMetadataURL` variable is updated to point to the new path `website/content/licensing/chillicream-license.md` on the `main` branch.
- The license text itself (`ChilliCream License 1.0`) has not changed — only the path in the repo has moved.

## How was this tested?

- [x] Manually verified the new URL returns the raw license text (not HTML) using `Invoke-WebRequest`.

## Sample Request(s)

N/A — this is a pipeline script fix with no REST/GraphQL/CLI surface.
