### PR TITLE
Cherry pick PR 3763: Bump version to 2.1

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <BaseOutputPath>..\out</BaseOutputPath>
-    <Version>2.0</Version>
+    <Version>2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
## Why make this change?

Cherry-pick of #3763 from `main` to `release/2.1` to bump the product version in preparation for the 2.1 release.

## What is this change?

- Updates `<Version>` in `src/Directory.Build.props` from `2.0` to `2.1`.
- The release pipeline reads this value to stamp all build outputs and NuGet packages.

## How was this tested?

- [ ] Integration Tests
- [ ] Unit Tests

No functional code changed; version string update only.

## Sample Request(s)

N/A — no API or CLI behavior changed.
