### PR TITLE
fix: port ChilliCream license URL fix (#3762) to release/2.0

### DIFF
--- a/scripts/notice-generation.ps1
+++ b/scripts/notice-generation.ps1
@@ -9,7 +9,7 @@ param (
 
 # Download and save the ChilliCream License 1.0 from ChilliCream/graphql-platform GitHub repo
 $chiliCreamLicenseSavePath = "$BuildArtifactStagingDir/chillicreamlicense.txt"
-$chiliCreamLicenseMetadataURL = "https://raw.githubusercontent.com/ChilliCream/graphql-platform/main/website/src/basic/licensing/chillicream-license.md"
+$chiliCreamLicenseMetadataURL = "https://raw.githubusercontent.com/ChilliCream/graphql-platform/main/website/content/licensing/chillicream-license.md"
 Invoke-WebRequest $chiliCreamLicenseMetadataURL -UseBasicParsing |
  Select-Object -ExpandProperty Content |
  Out-File $chiliCreamLicenseSavePath


### PR DESCRIPTION
## Why make this change?

Ports #3762 to `release/2.0`.

Fixes a 404 in the notice-generation pipeline step "Add Additional Licenses to NOTICE file for Package" when building `release/2.0`. ChilliCream restructured their `graphql-platform` repo and moved the license file from `website/src/basic/licensing/chillicream-license.md` to `website/content/licensing/chillicream-license.md`. The old URL returns a 404, causing the pipeline to fail.

The fix (#3762) was merged to `main` only; `release/2.0` still references the old path, so the release/2.0 build fails at the NOTICE step.

## What is this change?

Cherry-pick of the one-line update in `scripts/notice-generation.ps1`: `$chiliCreamLicenseMetadataURL` now points to `website/content/licensing/chillicream-license.md`. The license text itself (ChilliCream License 1.0) is unchanged — only the upstream path moved.

## How was this tested?

Verified the new URL returns the raw license text (not HTML) via `Invoke-WebRequest`.
