### PR TITLE
fix: don't enforce many-to-one/one-to-many relationships for DWSQL

### DIFF
--- a/src/Core/Services/GraphQLSchemaCreator.cs
+++ b/src/Core/Services/GraphQLSchemaCreator.cs
@@ -318,7 +318,8 @@ namespace Azure.DataApiBuilder.Core.Services
                             configEntity: entity,
                             entities: entities,
                             rolesAllowedForEntity: rolesAllowedForEntity,
-                            rolesAllowedForFields: rolesAllowedForFields);
+                            rolesAllowedForFields: rolesAllowedForFields,
+                            databaseType: sqlMetadataProvider.GetDatabaseType());
 
                         if (databaseObject.SourceType is not EntitySourceType.StoredProcedure)
                         {
@@ -560,7 +561,8 @@ namespace Azure.DataApiBuilder.Core.Services
                                 configEntity: linkingEntity,
                                 entities: new(new Dictionary<string, Entity>()),
                                 rolesAllowedForEntity: new List<string>(),
-                                rolesAllowedForFields: new Dictionary<string, IEnumerable<string>>()
+                                rolesAllowedForFields: new Dictionary<string, IEnumerable<string>>(),
+                                databaseType: sqlMetadataProvider.GetDatabaseType()
                             );
 
                         linkingObjectTypes.Add(linkingEntityName, node);

--- a/src/Service.GraphQLBuilder/Sql/SchemaConverter.cs
+++ b/src/Service.GraphQLBuilder/Sql/SchemaConverter.cs
@@ -48,7 +48,8 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
             Entity configEntity,
             RuntimeEntities entities,
             IEnumerable<string> rolesAllowedForEntity,
-            IDictionary<string, IEnumerable<string>> rolesAllowedForFields)
+            IDictionary<string, IEnumerable<string>> rolesAllowedForFields,
+            DatabaseType databaseType = DatabaseType.MSSQL)
         {
             ObjectTypeDefinitionNode objectDefinitionNode;
             switch (databaseObject.SourceType)
@@ -69,7 +70,8 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
                         configEntity: configEntity,
                         entities: entities,
                         rolesAllowedForEntity: rolesAllowedForEntity,
-                        rolesAllowedForFields: rolesAllowedForFields);
+                        rolesAllowedForFields: rolesAllowedForFields,
+                        databaseType: databaseType);
                     break;
                 default:
                     throw new DataApiBuilderException(
@@ -170,7 +172,8 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
             Entity configEntity,
             RuntimeEntities entities,
             IEnumerable<string> rolesAllowedForEntity,
-            IDictionary<string, IEnumerable<string>> rolesAllowedForFields)
+            IDictionary<string, IEnumerable<string>> rolesAllowedForFields,
+            DatabaseType databaseType = DatabaseType.MSSQL)
         {
             Dictionary<string, FieldDefinitionNode> fieldDefinitionNodes = new();
             SourceDefinition sourceDefinition = databaseObject.SourceDefinition;
@@ -225,7 +228,8 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
                             databaseObject,
                             entities,
                             relationshipName,
-                            relationship);
+                            relationship,
+                            databaseType);
                         fieldDefinitionNodes.Add(relationshipField.Name.Value, relationshipField);
                     }
                 }
@@ -474,13 +478,14 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
             DatabaseObject databaseObject,
             RuntimeEntities entities,
             string relationshipName,
-            EntityRelationship relationship)
+            EntityRelationship relationship,
+            DatabaseType databaseType = DatabaseType.MSSQL)
         {
             // Generate the field that represents the relationship to ObjectType, so you can navigate through it
             // and walk the graph.
             string targetEntityName = relationship.TargetEntity.Split('.').Last();
             Entity referencedEntity = entities[targetEntityName];
-            bool isNullableRelationship = FindNullabilityOfRelationship(entityName, databaseObject, targetEntityName);
+            bool isNullableRelationship = FindNullabilityOfRelationship(entityName, databaseObject, targetEntityName, databaseType);
 
             INullableTypeNode targetField = relationship.Cardinality switch
             {
@@ -631,8 +636,15 @@ namespace Azure.DataApiBuilder.Service.GraphQLBuilder.Sql
         private static bool FindNullabilityOfRelationship(
             string entityName,
             DatabaseObject databaseObject,
-            string targetEntityName)
+            string targetEntityName,
+            DatabaseType databaseType = DatabaseType.MSSQL)
         {
+            // DWSQL does not enforce foreign key constraints, so relationship fields are always nullable.
+            if (databaseType == DatabaseType.DWSQL)
+            {
+                return true;
+            }
+
             bool isNullableRelationship = false;
             SourceDefinition sourceDefinition = databaseObject.SourceDefinition;
             if (// Retrieve all the relationship information for the source entity which is backed by this table definition

--- a/src/Service.Tests/GraphQLBuilder/Sql/SchemaConverterTests.cs
+++ b/src/Service.Tests/GraphQLBuilder/Sql/SchemaConverterTests.cs
@@ -361,6 +361,21 @@ namespace Azure.DataApiBuilder.Service.Tests.GraphQLBuilder.Sql
             Assert.AreEqual(expected: isNullable, actual: field.Type is INullableTypeNode);
         }
 
+        // A NOT NULL foreign-key column yields a non-nullable relationship field for MSSQL, but a
+        // nullable one for DWSQL since DWSQL does not enforce foreign key constraints.
+        [DataRow(DatabaseType.DWSQL, Cardinality.One, true, DisplayName = "Many-to-one relationship field is nullable for DWSQL despite NOT NULL FK.")]
+        [DataRow(DatabaseType.DWSQL, Cardinality.Many, true, DisplayName = "One-to-many relationship field is nullable for DWSQL despite NOT NULL FK.")]
+        [DataRow(DatabaseType.MSSQL, Cardinality.One, false, DisplayName = "Many-to-one relationship field is non-nullable for MSSQL with NOT NULL FK.")]
+        [DataRow(DatabaseType.MSSQL, Cardinality.Many, false, DisplayName = "One-to-many relationship field is non-nullable for MSSQL with NOT NULL FK.")]
+        [TestMethod]
+        public void RelationshipFieldIsNullableForDwSqlDespiteNonNullableForeignKey(DatabaseType databaseType, Cardinality cardinality, bool expectedNullable)
+        {
+            ObjectTypeDefinitionNode od =
+                GenerateObjectWithRelationship(cardinality, isNullableRelationship: false, databaseType: databaseType);
+            FieldDefinitionNode field = od.Fields.First(f => f.Name.Value == FIELD_NAME_FOR_TARGET);
+            Assert.AreEqual(expectedNullable, field.Type is INullableTypeNode);
+        }
+
         [TestMethod]
         public void WhenForeignKeyDefinedButNoRelationship_GraphQLWontModelIt()
         {
@@ -756,7 +771,7 @@ namespace Azure.DataApiBuilder.Service.Tests.GraphQLBuilder.Sql
             );
         }
 
-        private static ObjectTypeDefinitionNode GenerateObjectWithRelationship(Cardinality cardinality, bool isNullableRelationship = false)
+        private static ObjectTypeDefinitionNode GenerateObjectWithRelationship(Cardinality cardinality, bool isNullableRelationship = false, DatabaseType databaseType = DatabaseType.MSSQL)
         {
             SourceDefinition table = GenerateTableWithForeignKeyDefinition(isNullableRelationship);
 
@@ -786,7 +801,8 @@ namespace Azure.DataApiBuilder.Service.Tests.GraphQLBuilder.Sql
                 dbObject,
                 configEntity, new(new Dictionary<string, Entity>() { { TARGET_ENTITY, relationshipEntity } }),
                 rolesAllowedForEntity: GetRolesAllowedForEntity(),
-                rolesAllowedForFields: GetFieldToRolesMap()
+                rolesAllowedForFields: GetFieldToRolesMap(),
+                databaseType: databaseType
                 );
         }
 

--- a/src/Service.Tests/GraphQLBuilder/Sql/SchemaConverterTests.cs
+++ b/src/Service.Tests/GraphQLBuilder/Sql/SchemaConverterTests.cs
@@ -364,9 +364,9 @@ namespace Azure.DataApiBuilder.Service.Tests.GraphQLBuilder.Sql
         // A NOT NULL foreign-key column yields a non-nullable relationship field for MSSQL, but a
         // nullable one for DWSQL since DWSQL does not enforce foreign key constraints.
         [DataRow(DatabaseType.DWSQL, Cardinality.One, true, DisplayName = "Many-to-one relationship field is nullable for DWSQL despite NOT NULL FK.")]
-        [DataRow(DatabaseType.DWSQL, Cardinality.Many, true, DisplayName = "One-to-many relationship field is nullable for DWSQL despite NOT NULL FK.")]
+        [DataRow(DatabaseType.DWSQL, Cardinality.Many, true, DisplayName = "Cardinality.Many relationship field is nullable for DWSQL despite NOT NULL FK metadata.")]
         [DataRow(DatabaseType.MSSQL, Cardinality.One, false, DisplayName = "Many-to-one relationship field is non-nullable for MSSQL with NOT NULL FK.")]
-        [DataRow(DatabaseType.MSSQL, Cardinality.Many, false, DisplayName = "One-to-many relationship field is non-nullable for MSSQL with NOT NULL FK.")]
+        [DataRow(DatabaseType.MSSQL, Cardinality.Many, false, DisplayName = "Cardinality.Many relationship field is non-nullable for MSSQL with NOT NULL FK metadata.")]
         [TestMethod]
         public void RelationshipFieldIsNullableForDwSqlDespiteNonNullableForeignKey(DatabaseType databaseType, Cardinality cardinality, bool expectedNullable)
         {


### PR DESCRIPTION
## What's the problem?

When Data API builder serves a Fabric Warehouse (DWSQL) database, a GraphQL query that follows a relationship between two tables could fail with this error:

```
"Cannot return null for non-nullable field." (HC0018)
```

...even when the query was perfectly valid and the data was fine. Instead of returning the row, the whole query blew up.

## Why does it happen?

Most databases guarantee that if a row points to a "parent" row (a foreign key), that parent actually exists. DAB relies on that guarantee: if a foreign-key column is marked "required" (NOT NULL), DAB assumes the related object is always there, and tells GraphQL "this related field will never be null."

**Fabric Warehouse is different — it does not enforce foreign keys.** So a child row can happily point at a parent that doesn't exist (an "orphaned" row). When GraphQL asks for that missing parent, DAB has nothing to return, but it already promised the field would never be null. GraphQL sees a broken promise and throws HC0018.

Example: an `Enrollment` row has a `studentId` that no `Student` matches. Asking for `enrollment.student` returns nothing, and the query fails.

## What does this change do?

For Fabric Warehouse (DWSQL) only, DAB no longer assumes related rows always exist. It marks the related fields on many-to-one and one-to-many relationships as nullable. That way, when a related row is genuinely missing, the query simply returns `null` for that field instead of failing the entire request.

Behavior for all other databases (SQL Server, PostgreSQL, MySQL) is unchanged, since they do enforce foreign keys.

## How was it verified?

- Added unit tests covering both DWSQL (field is now nullable) and SQL Server (field stays non-nullable) for both relationship directions.
- Manually validated end-to-end against a Fabric Warehouse: the query that previously failed now returns the row with `student: null`.

#### Before
<img width="854" height="730" alt="Screenshot 2026-08-12 143540" src="https://github.com/user-attachments/assets/9b4585e5-5cb8-456f-8efb-0eda22f68994" />


#### After
<img width="1053" height="514" alt="Screenshot 2026-08-12 141456" src="https://github.com/user-attachments/assets/cbb42b63-c867-4804-bc10-6d7a4c1c643b" />
