### PR TITLE
Bound GraphQL nested-filter recursion depth

### DIFF
--- a/src/Core/Models/GraphQLFilterParsers.cs
+++ b/src/Core/Models/GraphQLFilterParsers.cs
@@ -39,6 +39,40 @@ public class GQLFilterParser
         _metadataProviderFactory = metadataProviderFactory;
     }
 
+    // Absolute ceiling on relationship-nesting depth within a single GraphQL filter argument.
+    // Applied when no stricter runtime.graphql.depth-limit is configured, to prevent nested-filter depth-bomb DoS
+    // (deeply nested filters amplify into correlated EXISTS subqueries that HotChocolate's execution-depth rule does not bound).
+    internal const int MAX_NESTED_FILTER_DEPTH = 20;
+
+    /// <summary>
+    /// Returns the maximum allowed relationship-nesting depth for GraphQL filters:
+    /// the configured runtime.graphql.depth-limit when set and stricter, otherwise the hardcoded safety ceiling.
+    /// </summary>
+    internal int GetMaxNestedFilterDepth()
+    {
+        int? configuredDepthLimit = _configProvider.GetConfig().Runtime?.GraphQL?.DepthLimit;
+        if (configuredDepthLimit is > 0 && configuredDepthLimit.Value < MAX_NESTED_FILTER_DEPTH)
+        {
+            return configuredDepthLimit.Value;
+        }
+
+        return MAX_NESTED_FILTER_DEPTH;
+    }
+
+    /// <summary>
+    /// Enforces the relationship-nesting depth limit for GraphQL filters, throwing a BadRequest when exceeded.
+    /// </summary>
+    internal static void EnsureWithinNestedFilterDepth(int nestingLevel, int maxNestedFilterDepth)
+    {
+        if (nestingLevel > maxNestedFilterDepth)
+        {
+            throw new DataApiBuilderException(
+                message: $"The provided GraphQL filter exceeds the maximum allowed nesting depth of {maxNestedFilterDepth}.",
+                statusCode: HttpStatusCode.BadRequest,
+                subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
+        }
+    }
+
     /// <summary>
     /// Parse a predicate for a *FilterInput input type
     /// </summary>
@@ -53,8 +87,11 @@ public class GQLFilterParser
         IMiddlewareContext ctx,
         IInputValueDefinition filterArgumentSchema,
         List<ObjectFieldNode> fields,
-        BaseQueryStructure queryStructure)
+        BaseQueryStructure queryStructure,
+        int nestingLevel = 0)
     {
+        EnsureWithinNestedFilterDepth(nestingLevel, GetMaxNestedFilterDepth());
+
         string schemaName = queryStructure.DatabaseObject.SchemaName;
         string sourceName = queryStructure.DatabaseObject.Name;
         string sourceAlias = queryStructure.SourceAlias;
@@ -113,7 +150,8 @@ public class GQLFilterParser
                     filterArgumentSchema: filterArgumentSchema,
                     otherPredicates,
                     queryStructure,
-                    op)));
+                    op,
+                    nestingLevel)));
             }
             else
             {
@@ -185,7 +223,8 @@ public class GQLFilterParser
                             subfields,
                             predicates,
                             queryStructure,
-                            metadataProvider);
+                            metadataProvider,
+                            nestingLevel);
                     }
                     else if (queryStructure is CosmosQueryStructure cosmosQueryStructure)
                     {
@@ -212,7 +251,8 @@ public class GQLFilterParser
                                 nestedFieldTypeName,
                                 predicates,
                                 cosmosQueryStructure,
-                                metadataProvider);
+                                metadataProvider,
+                                nestingLevel);
                         }
                         else
                         {
@@ -223,7 +263,8 @@ public class GQLFilterParser
                             predicates.Push(new PredicateOperand(Parse(ctx,
                                 filterArgumentObject.Fields[name],
                                 subfields,
-                                cosmosQueryStructure)));
+                                cosmosQueryStructure,
+                                nestingLevel + 1)));
 
                             cosmosQueryStructure.DatabaseObject.Name = sourceName;
                             cosmosQueryStructure.SourceAlias = sourceAlias;
@@ -292,7 +333,8 @@ public class GQLFilterParser
         string entityType,
         List<PredicateOperand> predicates,
         CosmosQueryStructure queryStructure,
-        ISqlMetadataProvider metadataProvider)
+        ISqlMetadataProvider metadataProvider,
+        int nestingLevel)
     {
         // Validate that the field referenced in the nested input filter can be accessed.
         bool entityAccessPermitted = queryStructure.AuthorizationResolver.AreRoleAndOperationDefinedForEntity(
@@ -327,7 +369,8 @@ public class GQLFilterParser
         Predicate existsQueryFilterPredicate = Parse(ctx,
                 filterField,
                 subfields,
-                existsQuery);
+                existsQuery,
+                nestingLevel + 1);
 
         predicatesForExistsQuery.Push(existsQueryFilterPredicate);
 
@@ -369,7 +412,8 @@ public class GQLFilterParser
         List<ObjectFieldNode> subfields,
         List<PredicateOperand> predicates,
         BaseQueryStructure queryStructure,
-        ISqlMetadataProvider metadataProvider)
+        ISqlMetadataProvider metadataProvider,
+        int nestingLevel)
     {
         string? targetGraphQLTypeNameForFilter = RelationshipDirectiveType.GetTarget(filterField);
 
@@ -416,7 +460,8 @@ public class GQLFilterParser
         Predicate existsQueryFilterPredicate = Parse(ctx,
                 filterField,
                 subfields,
-                existsQuery);
+                existsQuery,
+                nestingLevel + 1);
         predicatesForExistsQuery.Push(existsQueryFilterPredicate);
 
         // Add JoinPredicates to the subquery query structure so a predicate connecting
@@ -531,7 +576,8 @@ public class GQLFilterParser
         IInputValueDefinition filterArgumentSchema,
         List<IValueNode> fields,
         BaseQueryStructure baseQuery,
-        PredicateOperation op)
+        PredicateOperation op,
+        int nestingLevel)
     {
         if (fields.Count == 0)
         {
@@ -573,7 +619,8 @@ public class GQLFilterParser
                 Parse(ctx,
                     filterArgumentSchema,
                     subfields,
-                    baseQuery)));
+                    baseQuery,
+                    nestingLevel)));
         }
 
         return MakeChainPredicate(operands, op);

--- a/src/Core/Models/GraphQLFilterParsers.cs
+++ b/src/Core/Models/GraphQLFilterParsers.cs
@@ -87,8 +87,20 @@ public class GQLFilterParser
         IMiddlewareContext ctx,
         IInputValueDefinition filterArgumentSchema,
         List<ObjectFieldNode> fields,
+        BaseQueryStructure queryStructure)
+    {
+        return Parse(ctx, filterArgumentSchema, fields, queryStructure, nestingLevel: 0);
+    }
+
+    /// <summary>
+    /// Recursive overload that tracks and bounds the relationship-nesting depth of the filter being parsed.
+    /// </summary>
+    private Predicate Parse(
+        IMiddlewareContext ctx,
+        IInputValueDefinition filterArgumentSchema,
+        List<ObjectFieldNode> fields,
         BaseQueryStructure queryStructure,
-        int nestingLevel = 0)
+        int nestingLevel)
     {
         EnsureWithinNestedFilterDepth(nestingLevel, GetMaxNestedFilterDepth());
 

--- a/src/Core/Models/GraphQLFilterParsers.cs
+++ b/src/Core/Models/GraphQLFilterParsers.cs
@@ -66,10 +66,11 @@ public class GQLFilterParser
     {
         if (nestingLevel > maxNestedFilterDepth)
         {
+            // DatabaseInputError is the substatus the GraphQL status-code middleware maps to HTTP 400.
             throw new DataApiBuilderException(
                 message: $"The provided GraphQL filter exceeds the maximum allowed nesting depth of {maxNestedFilterDepth}.",
                 statusCode: HttpStatusCode.BadRequest,
-                subStatusCode: DataApiBuilderException.SubStatusCodes.BadRequest);
+                subStatusCode: DataApiBuilderException.SubStatusCodes.DatabaseInputError);
         }
     }
 

--- a/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
+++ b/src/Service.Tests/SqlTests/GraphQLQueryTests/MsSqlGraphQLQueryTests.cs
@@ -4,12 +4,18 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Service.Exceptions;
 using Azure.DataApiBuilder.Service.GraphQLBuilder.Queries;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
@@ -31,6 +37,58 @@ namespace Azure.DataApiBuilder.Service.Tests.SqlTests.GraphQLQueryTests
         }
 
         #region Tests
+        /// <summary>
+        /// Endpoint-level boundary test for the GraphQL nested-filter depth guard.
+        /// A filter nesting the maximum allowed number of relationship levels (20) executes and returns HTTP 200,
+        /// while one additional level (21) is rejected with HTTP 400 and a DatabaseInputError code.
+        /// </summary>
+        [TestMethod]
+        public async Task NestedFilterDepthLimit_BoundaryTest()
+        {
+            // 20 relationship levels: at the maximum, allowed.
+            HttpResponseMessage okResponse = await PostNestedRelationshipFilterQueryAsync(relationshipDepth: 20);
+            string okBody = await okResponse.Content.ReadAsStringAsync();
+            Assert.AreEqual(HttpStatusCode.OK, okResponse.StatusCode,
+                $"A nested filter at the maximum allowed depth (20) should succeed. Body: {okBody}");
+            Assert.IsFalse(okBody.Contains("maximum allowed nesting depth"),
+                $"A depth-20 nested filter should not trigger the depth guard. Body: {okBody}");
+
+            // 21 relationship levels: over the maximum, rejected with HTTP 400.
+            HttpResponseMessage badResponse = await PostNestedRelationshipFilterQueryAsync(relationshipDepth: 21);
+            string badBody = await badResponse.Content.ReadAsStringAsync();
+            Assert.AreEqual(HttpStatusCode.BadRequest, badResponse.StatusCode,
+                $"A nested filter exceeding the maximum depth (21) should return HTTP 400. Body: {badBody}");
+            StringAssert.Contains(badBody, "maximum allowed nesting depth");
+            StringAssert.Contains(badBody, nameof(DataApiBuilderException.SubStatusCodes.DatabaseInputError));
+        }
+
+        /// <summary>
+        /// Posts a books query whose filter nests the books/authors relationship to the requested depth.
+        /// </summary>
+        private static async Task<HttpResponseMessage> PostNestedRelationshipFilterQueryAsync(int relationshipDepth)
+        {
+            // Build an alternating books/authors relationship filter of the requested depth around a scalar leaf.
+            // The outermost relationship from the books entity is 'authors', then it alternates each level.
+            string filter = "{ id: { eq: 1 } }";
+            for (int level = relationshipDepth; level >= 1; level--)
+            {
+                string relationshipField = (level % 2 == 1) ? "authors" : "books";
+                filter = $"{{ {relationshipField}: {filter} }}";
+            }
+
+            string query = $"{{ books(filter: {filter}) {{ items {{ id }} }} }}";
+
+            RuntimeConfigProvider configProvider = _application.Services.GetService<RuntimeConfigProvider>();
+            string graphQLEndpoint = configProvider.GetConfig().GraphQLPath;
+
+            HttpRequestMessage request = new(HttpMethod.Post, graphQLEndpoint)
+            {
+                Content = JsonContent.Create(new { query })
+            };
+
+            return await HttpClient.SendAsync(request);
+        }
+
         /// <summary>
         /// Gets array of results for querying more than one item.
         /// </summary>

--- a/src/Service.Tests/UnitTests/GraphQLFilterParserUnitTests.cs
+++ b/src/Service.Tests/UnitTests/GraphQLFilterParserUnitTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Azure.DataApiBuilder.Config.ObjectModel;
+using Azure.DataApiBuilder.Core.Configurations;
+using Azure.DataApiBuilder.Core.Models;
+using Azure.DataApiBuilder.Core.Services.MetadataProviders;
+using Azure.DataApiBuilder.Service.Exceptions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Azure.DataApiBuilder.Service.Tests.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the GraphQL nested-filter depth guard in <see cref="GQLFilterParser"/>.
+    /// The guard bounds relationship-nesting depth of filter arguments (e.g. filter:{rel:{rel:{...}}}),
+    /// which HotChocolate's execution-depth rule does not cover, to prevent nested-filter depth-bomb DoS.
+    /// </summary>
+    [TestClass]
+    public class GraphQLFilterParserUnitTests
+    {
+        /// <summary>
+        /// A nesting level beyond the maximum is rejected with a BadRequest.
+        /// </summary>
+        [TestMethod]
+        public void EnsureWithinNestedFilterDepth_ThrowsWhenExceeded()
+        {
+            DataApiBuilderException ex = Assert.ThrowsException<DataApiBuilderException>(
+                () => GQLFilterParser.EnsureWithinNestedFilterDepth(nestingLevel: 21, maxNestedFilterDepth: 20));
+
+            Assert.AreEqual(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
+            Assert.AreEqual(DataApiBuilderException.SubStatusCodes.BadRequest, ex.SubStatusCode);
+        }
+
+        /// <summary>
+        /// A nesting level at or below the maximum is allowed.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(0)]
+        [DataRow(1)]
+        [DataRow(20)]
+        public void EnsureWithinNestedFilterDepth_DoesNotThrowWithinLimit(int nestingLevel)
+        {
+            // Should not throw.
+            GQLFilterParser.EnsureWithinNestedFilterDepth(nestingLevel, maxNestedFilterDepth: 20);
+        }
+
+        /// <summary>
+        /// The effective nested-filter depth limit falls back to the hardcoded safety ceiling when
+        /// runtime.graphql.depth-limit is not configured, uses the depth-limit only when it is stricter,
+        /// and never exceeds the ceiling even when depth-limit is larger or set to -1 (unlimited).
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(null, GQLFilterParser.MAX_NESTED_FILTER_DEPTH, DisplayName = "No depth-limit -> safety ceiling")]
+        [DataRow(5, 5, DisplayName = "Stricter depth-limit is used")]
+        [DataRow(50, GQLFilterParser.MAX_NESTED_FILTER_DEPTH, DisplayName = "Higher depth-limit is capped at ceiling")]
+        [DataRow(-1, GQLFilterParser.MAX_NESTED_FILTER_DEPTH, DisplayName = "Unlimited (-1) depth-limit still capped at ceiling")]
+        public void GetMaxNestedFilterDepth_ResolvesEffectiveLimit(int? depthLimit, int expected)
+        {
+            GQLFilterParser parser = CreateParserWithDepthLimit(depthLimit);
+            Assert.AreEqual(expected, parser.GetMaxNestedFilterDepth());
+        }
+
+        private static GQLFilterParser CreateParserWithDepthLimit(int? depthLimit)
+        {
+            RuntimeConfig config = new(
+                Schema: "",
+                DataSource: new(DatabaseType.MSSQL, "", new()),
+                Runtime: new(
+                    Rest: new(),
+                    GraphQL: new(DepthLimit: depthLimit) { UserProvidedDepthLimit = depthLimit is not null },
+                    Mcp: new(),
+                    Host: new(null, null)),
+                Entities: new(new Dictionary<string, Entity>()));
+
+            RuntimeConfigProvider provider = TestHelper.GenerateInMemoryRuntimeConfigProvider(config);
+            Mock<IMetadataProviderFactory> metadataProviderFactory = new();
+            return new GQLFilterParser(provider, metadataProviderFactory.Object);
+        }
+    }
+}

--- a/src/Service.Tests/UnitTests/GraphQLFilterParserUnitTests.cs
+++ b/src/Service.Tests/UnitTests/GraphQLFilterParserUnitTests.cs
@@ -30,7 +30,7 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 () => GQLFilterParser.EnsureWithinNestedFilterDepth(nestingLevel: 21, maxNestedFilterDepth: 20));
 
             Assert.AreEqual(System.Net.HttpStatusCode.BadRequest, ex.StatusCode);
-            Assert.AreEqual(DataApiBuilderException.SubStatusCodes.BadRequest, ex.SubStatusCode);
+            Assert.AreEqual(DataApiBuilderException.SubStatusCodes.DatabaseInputError, ex.SubStatusCode);
         }
 
         /// <summary>


### PR DESCRIPTION
### Summary
Bounds the relationship-nesting depth of GraphQL filter arguments (e.g. `filter:{rel:{rel:{...}}}`). Deeply nested filters expand into correlated `EXISTS` subqueries that the HotChocolate execution-depth rule does not cover, so a small deeply-nested request could amplify into a very expensive query.

### Change
- Thread a nesting-level counter through the recursive filter parser (`GQLFilterParser.Parse` / `HandleNestedFilter*` / `ParseAndOr`).
- Reject filters whose relationship nesting exceeds `runtime.graphql.depth-limit` (when set and stricter) or a hardcoded safety ceiling (20) with an HTTP 400.
- Backward compatible: the new `Parse` parameter is optional; external callers are unchanged.

### Tests
- Unit tests for the depth-limit resolution and the enforcement threshold, including the `depth-limit = -1` (unlimited) case still capped at the ceiling.

### Note
Filters nesting beyond 20 relationship levels now return 400 instead of executing; this is far above typical usage.