### PR TITLE
Fix solution file name in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Data API builder (DAB) is a .NET application written in C#, consisting of severa
 
 ### Running locally
 
-Before running the code, ensure you have the correct version of .NET installed (refer to the [global.json](global.json) file) and open the solution from `src/Azure.DataApiBuilder.Service.sln` in Visual Studio (or other editor of choice).
+Before running the code, ensure you have the correct version of .NET installed (refer to the [global.json](global.json) file) and open the solution from `src/Azure.DataApiBuilder.sln` in Visual Studio (or other editor of choice).
 
 The next step is to ensure you have a config file for DAB defined. You can pick a sample one from the `src/Service.Tests` project and copy the `dab-config.<engine>.json` file to the `src/Service` directory (and if the database is CosmosDb_NoSql the GraphQL schema file too). You can also use the [generator tool](#an-alternative-way-to-generate-config-files) described below. Note these sample configuration files expect the backend database schema to be created from the respective `src/Service.Tests/DatabaseSchema-<engine>.sql` schema file in the `src/Service.Tests` project.
 
@@ -30,7 +30,7 @@ Make sure the config has a valid connection string, or you use the [`@env` synta
 
 Before running the sample code in Visual Studio, you must be sure to have your config file correctly populated with a valid connection string for your configured back end. Once you have the back end running and your configuration file set correctly, you may do the following to run the code in Visual Studio without using the CLI.
 
-1. Open the solution `src/Azure.DataApiBuilder.Service.sln`
+1. Open the solution `src/Azure.DataApiBuilder.sln`
 2. Select the **Startup Project** `Azure.DataApiBuilder.Service`.
 3. Select a **debug profile** for database type: `MsSql`, `PostgreSql`,`CosmosDb_NoSql`, or `MySql`.
 4. Select **Clean Solution**


### PR DESCRIPTION
## Why make this change?

- Replace outdated references to `src/Azure.DataApiBuilder.Service.sln` with `src/Azure.DataApiBuilder.sln`.
- Ensure the local development instructions reference the solution file that exists in the repository.
