### PR TITLE
Fix whitespace handling in MCP read_records select lists

### DIFF
--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ReadRecordsTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ReadRecordsTool.cs
@@ -201,7 +201,7 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                 if (!string.IsNullOrWhiteSpace(select))
                 {
                     // Update the context to specify which fields will be returned from the entity.
-                    IEnumerable<string> fieldsReturnedForFind = select.Split(",").ToList();
+                    IEnumerable<string> fieldsReturnedForFind = select.Split(',').Select(field => field.Trim()).ToList();
                     context.UpdateReturnFields(fieldsReturnedForFind);
                 }
 

--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ReadRecordsTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ReadRecordsTool.cs
@@ -201,7 +201,12 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                 if (!string.IsNullOrWhiteSpace(select))
                 {
                     // Update the context to specify which fields will be returned from the entity.
-                    IEnumerable<string> fieldsReturnedForFind = select.Split(',').Select(field => field.Trim()).ToList();
+                    List<string> fieldsReturnedForFind = select.Split(',').Select(field => field.Trim()).ToList();
+                    if (fieldsReturnedForFind.Any(string.IsNullOrEmpty))
+                    {
+                        return McpResponseBuilder.BuildErrorResult(toolName, "InvalidArguments", "The 'select' argument cannot contain empty field names.", logger);
+                    }
+
                     context.UpdateReturnFields(fieldsReturnedForFind);
                 }
 

--- a/src/Service.Tests/Mcp/ReadRecordsToolMsSqlIntegrationTests.cs
+++ b/src/Service.Tests/Mcp/ReadRecordsToolMsSqlIntegrationTests.cs
@@ -79,6 +79,20 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
         }
 
         /// <summary>
+        /// Rejects empty field names in the select clause with a clear error.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("id,title,")]
+        [DataRow("id,,title")]
+        public async Task ReadRecords_WithEmptySelectField_ReturnsInvalidArguments(string select)
+        {
+            CallToolResult result = await ExecuteReadAsync("Book", select: select);
+
+            AssertError(result, "The 'select' argument cannot contain empty field names.");
+            Assert.AreEqual("InvalidArguments", ParseResultRoot(result).GetProperty("error").GetProperty("type").GetString());
+        }
+
+        /// <summary>
         /// Reads records with an OData filter expression and verifies filtered results are returned.
         /// </summary>
         [TestMethod]

--- a/src/Service.Tests/Mcp/ReadRecordsToolMsSqlIntegrationTests.cs
+++ b/src/Service.Tests/Mcp/ReadRecordsToolMsSqlIntegrationTests.cs
@@ -88,8 +88,10 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
         {
             CallToolResult result = await ExecuteReadAsync("Book", select: select);
 
-            AssertError(result, "The 'select' argument cannot contain empty field names.");
-            Assert.AreEqual("InvalidArguments", ParseResultRoot(result).GetProperty("error").GetProperty("type").GetString());
+            AssertError(result);
+            JsonElement error = ParseResultRoot(result).GetProperty("error");
+            Assert.AreEqual("InvalidArguments", error.GetProperty("type").GetString());
+            Assert.AreEqual("The 'select' argument cannot contain empty field names.", error.GetProperty("message").GetString());
         }
 
         /// <summary>

--- a/src/Service.Tests/Mcp/ReadRecordsToolMsSqlIntegrationTests.cs
+++ b/src/Service.Tests/Mcp/ReadRecordsToolMsSqlIntegrationTests.cs
@@ -62,6 +62,23 @@ namespace Azure.DataApiBuilder.Service.Tests.Mcp
         }
 
         /// <summary>
+        /// Reads records with whitespace after a comma in the select clause.
+        /// </summary>
+        [TestMethod]
+        public async Task ReadRecords_WithWhitespaceAfterSelectComma_ReturnsSelectedFields()
+        {
+            CallToolResult result = await ExecuteReadAsync("Book", select: "id, title");
+
+            AssertSuccess(result, "ReadRecords with whitespace after a select comma should succeed.");
+
+            JsonElement root = ParseResultRoot(result);
+            JsonElement records = GetRecordsArray(root);
+            JsonElement firstRecord = records[0];
+            Assert.IsTrue(firstRecord.TryGetProperty("id", out _), "Expected 'id' field in result.");
+            Assert.IsTrue(firstRecord.TryGetProperty("title", out _), "Expected 'title' field in result.");
+        }
+
+        /// <summary>
         /// Reads records with an OData filter expression and verifies filtered results are returned.
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
## Why make this change?

Closes https://github.com/Azure/data-api-builder/issues/3771

## What is this change?

- Trim whitespace from each field after splitting the comma-separated `select` value.
- Add a regression integration test covering a space after the comma.

## How was this tested?

- [x] Integration Tests
  - Added `ReadRecords_WithWhitespaceAfterSelectComma_ReturnsSelectedFields`.
- [x] Unit Tests
  - All 309 non-database MCP tests passed.
  - The service test project builds successfully.

## Sample Request(s)

Example MCP `read_records` arguments:

    {
      "entity": "Book",
      "select": "id, title"
    }

The request now succeeds and returns the selected `id` and `title` fields.

CLI, REST, and GraphQL samples are not applicable because this change affects the MCP `read_records` tool only.