### PR TITLE
adding in readonly annotations to support M365 federated connections

### DIFF
--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/AggregateRecordsTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/AggregateRecordsTool.cs
@@ -133,7 +133,11 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                     },
                     ""required"": [""entity"", ""function""]
                 }"
-            )
+            ),
+            Annotations = new ToolAnnotations()
+            {
+                ReadOnlyHint = true
+            }
         };
 
         /// <summary>

--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/DescribeEntitiesTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/DescribeEntitiesTool.cs
@@ -57,7 +57,11 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                             }
                         }
                     }"
-                )
+                ),
+                Annotations = new ToolAnnotations()
+                {
+                    ReadOnlyHint = true
+                }
             };
         }
 

--- a/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ReadRecordsTool.cs
+++ b/src/Azure.DataApiBuilder.Mcp/BuiltInTools/ReadRecordsTool.cs
@@ -71,7 +71,11 @@ namespace Azure.DataApiBuilder.Mcp.BuiltInTools
                         },
                         ""required"": [""entity""]
                     }"
-                )
+                ),
+                Annotations = new ToolAnnotations()
+                {
+                    ReadOnlyHint = true
+                }
             };
         }
 


### PR DESCRIPTION
## Summary

Adds read-only annotations to the MCP aggregate records tool so it is correctly advertised as a non-mutating operation for M365 federated connections. Solving #3798 

## What changed

- Updated `AggregateRecordsTool` to include `ToolAnnotations`
- Set `ReadOnlyHint = true` on the tool definition

## Why

This helps the MCP tool metadata reflect that the aggregate records operation is read-only, which is important for M365 federated connection support and for consumers that rely on tool annotations to understand operation safety.

## Impact

- No functional query behavior change
- Improves tool metadata and compatibility
- Helps downstream clients and orchestration layers treat the tool as non-mutating

## Files changed

- `src/Azure.DataApiBuilder.Mcp/BuiltInTools/AggregateRecordsTool.cs`
- `src/Azure.DataApiBuilder.Mcp/BuiltInTools/DescribeEntitiesTool.cs‎`
- `src/Azure.DataApiBuilder.Mcp/BuiltInTools/ReadRecordsTool.cs`

## Notes

This is a small metadata-only change with low risk.