### PR TITLE
Skip unsupported column data types during schema discovery

### DIFF
--- a/config-generators/mssql-commands.txt
+++ b/config-generators/mssql-commands.txt
@@ -22,7 +22,7 @@ add VectorType --config "dab-config.MsSql.json" --source vector_type_table --res
 update VectorType --config "dab-config.MsSql.json" --permissions "authenticated:create,read,delete,update"
 update VectorOwner --config "dab-config.MsSql.json" --relationship vectors --target.entity VectorType --cardinality many --relationship.fields "id:owner_id"
 update VectorType --config "dab-config.MsSql.json" --relationship owner --target.entity VectorOwner --cardinality one --relationship.fields "owner_id:id"
-add GeometryType --config "dab-config.MsSql.json" --source geometry_type_table --rest true --graphql true --permissions "anonymous:read" --fields.include "id,name"
+add GeometryType --config "dab-config.MsSql.json" --source geometry_type_table --rest true --graphql true --permissions "anonymous:read"
 add Profile --config "dab-config.MsSql.json" --source profiles --rest true --graphql true --permissions "anonymous:create,read,delete,update"
 update Profile --config "dab-config.MsSql.json" --permissions "authenticated:create,read,delete,update"
 add stocks_price --config "dab-config.MsSql.json" --source stocks_price --permissions "authenticated:create,read,update,delete"

--- a/config-generators/mssql-commands.txt
+++ b/config-generators/mssql-commands.txt
@@ -22,6 +22,7 @@ add VectorType --config "dab-config.MsSql.json" --source vector_type_table --res
 update VectorType --config "dab-config.MsSql.json" --permissions "authenticated:create,read,delete,update"
 update VectorOwner --config "dab-config.MsSql.json" --relationship vectors --target.entity VectorType --cardinality many --relationship.fields "id:owner_id"
 update VectorType --config "dab-config.MsSql.json" --relationship owner --target.entity VectorOwner --cardinality one --relationship.fields "owner_id:id"
+add GeometryType --config "dab-config.MsSql.json" --source geometry_type_table --rest true --graphql true --permissions "anonymous:read" --fields.include "id,name"
 add Profile --config "dab-config.MsSql.json" --source profiles --rest true --graphql true --permissions "anonymous:create,read,delete,update"
 update Profile --config "dab-config.MsSql.json" --permissions "authenticated:create,read,delete,update"
 add stocks_price --config "dab-config.MsSql.json" --source stocks_price --permissions "authenticated:create,read,update,delete"

--- a/src/Core/Services/MetadataProviders/MsSqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/MsSqlMetadataProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using System.Data;
 using System.Data.Common;
 using System.Net;
@@ -43,6 +44,23 @@ namespace Azure.DataApiBuilder.Core.Services
         {
             _runtimeConfigProvider = runtimeConfigProvider;
         }
+
+        /// <summary>
+        /// SQL Server CLR user-defined types. Microsoft.Data.SqlClient resolves their CLR type
+        /// through the Microsoft.SqlServer.Types assembly, which Data API builder does not
+        /// reference, so the reader reports no type for the column and the data adapter fails.
+        /// Deliberately limited to the types that cannot be read at all: timestamp, xml and vector
+        /// columns do resolve to a CLR type and are left untouched.
+        /// </summary>
+        private static readonly ImmutableHashSet<string> _unsupportedColumnDataTypes =
+            ImmutableHashSet.Create(
+                StringComparer.OrdinalIgnoreCase,
+                "geometry",
+                "geography",
+                "hierarchyid");
+
+        /// <inheritdoc/>
+        protected override ImmutableHashSet<string> UnsupportedColumnDataTypes => _unsupportedColumnDataTypes;
 
         public override string GetDefaultSchemaName()
         {

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -69,6 +69,11 @@ namespace Azure.DataApiBuilder.Core.Services
 
         protected const int NUMBER_OF_RESTRICTIONS = 4;
 
+        /// <summary>
+        /// Wildcard used in the permissions "fields" section to denote every field.
+        /// </summary>
+        private const string FIELD_WILDCARD = "*";
+
         protected string ConnectionString { get; init; }
 
         protected IQueryBuilder SqlQueryBuilder { get; init; }
@@ -1528,9 +1533,25 @@ namespace Azure.DataApiBuilder.Core.Services
             using DataTableReader reader = new(dataTable);
             DataTable schemaTable = reader.GetSchemaTable();
             RuntimeConfig runtimeConfig = _runtimeConfigProvider.GetConfig();
+
+            // Columns the entity's permissions allow to be read. The schema DataTable is cached
+            // per schema.table and may therefore carry columns permitted only for a sibling
+            // entity, so the restriction is re-applied per entity here.
+            PermittedColumns? permittedColumns = entity is null
+                ? null
+                : ResolvePermittedColumnsForEntity(entity);
+
             foreach (DataRow columnInfoFromAdapter in schemaTable.Rows)
             {
                 string columnName = columnInfoFromAdapter["ColumnName"].ToString()!;
+
+                if (permittedColumns is not null
+                    && !permittedColumns.IsUnrestricted
+                    && !permittedColumns.IsColumnPermitted(columnName)
+                    && !sourceDefinition.PrimaryKey.Contains(columnName))
+                {
+                    continue;
+                }
 
                 if (runtimeConfig.IsGraphQLEnabled
                     && entity is not null
@@ -1685,7 +1706,7 @@ namespace Azure.DataApiBuilder.Core.Services
             {
                 try
                 {
-                    dataTable = await FillSchemaForTableAsync(schemaName, tableName);
+                    dataTable = await FillSchemaForTableAsync(schemaName, tableName, entityName);
                 }
                 catch (Exception ex) when (ex is not DataApiBuilderException)
                 {
@@ -1753,10 +1774,16 @@ namespace Azure.DataApiBuilder.Core.Services
         /// <summary>
         /// Using a data adapter, obtains the schema of the given table name
         /// and adds the corresponding DataTable to the entities data set.
+        /// When the entities backed by this database object restrict the readable
+        /// fields through permissions ("fields.include"/"fields.exclude"), the projection
+        /// is narrowed to those columns instead of "SELECT *". This avoids the provider
+        /// having to materialize CLR types it cannot handle (e.g. geometry/geography/hierarchyid),
+        /// which otherwise fails during schema discovery even though the column is not exposed.
         /// </summary>
         private async Task<DataTable> FillSchemaForTableAsync(
             string schemaName,
-            string tableName)
+            string tableName,
+            string? entityName = null)
         {
             using ConnectionT conn = new();
             // If connection string is set to empty string
@@ -1802,12 +1829,328 @@ namespace Azure.DataApiBuilder.Core.Services
             };
 
             string tableNameWithSchemaPrefix = GetTableNameWithSchemaPrefix(schemaName, tableName);
+
+            // Resolve the columns the configuration actually allows to be read for this
+            // database object. When nothing is restricted, the original SELECT * is preserved.
+            PermittedColumns permittedColumns = ResolvePermittedColumnsForDatabaseObject(
+                schemaName: schemaName,
+                tableName: tableName,
+                entityName: entityName);
+
+            string projection = await BuildSchemaProjectionAsync(schemaName, tableName, permittedColumns);
+
             selectCommand.CommandText
-                = $"SELECT * FROM {tableNameWithSchemaPrefix}";
+                = $"SELECT {projection} FROM {tableNameWithSchemaPrefix}";
             adapterForTable.SelectCommand = selectCommand;
 
             DataTable[] dataTable = adapterForTable.FillSchema(EntitiesDataSet, SchemaType.Source, tableNameWithSchemaPrefix);
             return dataTable[0];
+        }
+
+        /// <summary>
+        /// Describes which backing (database) columns of a database object the runtime
+        /// configuration allows to be read.
+        /// </summary>
+        /// <param name="AllColumns">
+        /// True when at least one permission reads every field ("fields" absent, "include" absent,
+        /// or "include": ["*"]).
+        /// </param>
+        /// <param name="Included">Backing columns explicitly listed in an "include" section.</param>
+        /// <param name="Excluded">
+        /// Backing columns excluded from every wildcard permission and never explicitly included.
+        /// </param>
+        private sealed record PermittedColumns(bool AllColumns, HashSet<string> Included, HashSet<string> Excluded)
+        {
+            /// <summary>
+            /// No column restriction could be derived from the configuration.
+            /// </summary>
+            public bool IsUnrestricted => AllColumns && Excluded.Count == 0;
+
+            /// <summary>
+            /// Whether the given backing column is readable per the configuration.
+            /// </summary>
+            public bool IsColumnPermitted(string columnName)
+            {
+                if (Included.Contains(columnName))
+                {
+                    return true;
+                }
+
+                if (Excluded.Contains(columnName))
+                {
+                    return false;
+                }
+
+                return AllColumns;
+            }
+        }
+
+        /// <summary>
+        /// Resolves the readable columns for a database object.
+        /// Because the schema DataTable is cached per schema.table, the result combines the
+        /// permissions of every entity in this data source backed by that same object: a column
+        /// has to be read if any of those entities can read it.
+        /// </summary>
+        /// <param name="schemaName">Schema of the database object.</param>
+        /// <param name="tableName">Name of the database object.</param>
+        /// <param name="entityName">Entity that triggered the schema discovery, when known.</param>
+        private PermittedColumns ResolvePermittedColumnsForDatabaseObject(
+            string schemaName,
+            string tableName,
+            string? entityName)
+        {
+            HashSet<string> included = new(StringComparer.Ordinal);
+            HashSet<string>? excluded = null;
+            bool allColumns = false;
+            bool matchedAnyEntity = false;
+
+            foreach ((string candidateEntityName, Entity candidateEntity) in Entities)
+            {
+                // Only consider entities backed by the same database object.
+                if (EntityToDatabaseObject.TryGetValue(candidateEntityName, out DatabaseObject? databaseObject))
+                {
+                    if (!string.Equals(databaseObject.SchemaName, schemaName, StringComparison.OrdinalIgnoreCase)
+                        || !string.Equals(databaseObject.Name, tableName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+                }
+                else if (!string.Equals(candidateEntityName, entityName, StringComparison.Ordinal))
+                {
+                    // Database object not inferred yet: only the entity that triggered the read applies.
+                    continue;
+                }
+
+                matchedAnyEntity = true;
+                PermittedColumns entityPermittedColumns = ResolvePermittedColumnsForEntity(candidateEntity);
+
+                included.UnionWith(entityPermittedColumns.Included);
+
+                if (entityPermittedColumns.AllColumns)
+                {
+                    allColumns = true;
+
+                    // A column is only droppable when every wildcard permission excludes it.
+                    if (excluded is null)
+                    {
+                        excluded = new(entityPermittedColumns.Excluded, StringComparer.Ordinal);
+                    }
+                    else
+                    {
+                        excluded.IntersectWith(entityPermittedColumns.Excluded);
+                    }
+                }
+            }
+
+            if (!matchedAnyEntity)
+            {
+                return new(AllColumns: true, Included: new(StringComparer.Ordinal), Excluded: new(StringComparer.Ordinal));
+            }
+
+            excluded ??= new(StringComparer.Ordinal);
+            excluded.ExceptWith(included);
+
+            return new(allColumns, included, excluded);
+        }
+
+        /// <summary>
+        /// Resolves the readable columns of a single entity from the "fields.include" /
+        /// "fields.exclude" sections of its permissions. Exposed names (mappings and field
+        /// aliases) are translated back to their database column names, and configured primary
+        /// key fields are always kept, since the runtime cannot operate on the entity without them.
+        /// </summary>
+        private static PermittedColumns ResolvePermittedColumnsForEntity(Entity entity)
+        {
+            HashSet<string> included = new(StringComparer.Ordinal);
+            HashSet<string>? excluded = null;
+            bool allColumns = false;
+
+            // Exposed name -> backing column name.
+            Dictionary<string, string> exposedToBackingName = new(StringComparer.Ordinal);
+
+            if (entity.Mappings is not null)
+            {
+                foreach ((string backingName, string exposedName) in entity.Mappings)
+                {
+                    if (!string.IsNullOrWhiteSpace(exposedName))
+                    {
+                        exposedToBackingName[exposedName] = backingName;
+                    }
+                }
+            }
+
+            if (entity.Fields is not null)
+            {
+                foreach (FieldMetadata field in entity.Fields)
+                {
+                    if (!string.IsNullOrWhiteSpace(field.Alias))
+                    {
+                        exposedToBackingName[field.Alias!] = field.Name;
+                    }
+                }
+            }
+
+            if (entity.Permissions is null || entity.Permissions.Length == 0)
+            {
+                // Nothing configured: the whole object is read, as before.
+                return new(AllColumns: true, included, new HashSet<string>(StringComparer.Ordinal));
+            }
+
+            foreach (EntityPermission permission in entity.Permissions)
+            {
+                if (permission.Actions is null)
+                {
+                    allColumns = true;
+                    excluded = new(StringComparer.Ordinal);
+                    continue;
+                }
+
+                foreach (EntityAction action in permission.Actions)
+                {
+                    EntityActionFields? fields = action.Fields;
+
+                    HashSet<string> actionExcluded = new(StringComparer.Ordinal);
+                    if (fields?.Exclude is not null)
+                    {
+                        if (fields.Exclude.Contains(FIELD_WILDCARD))
+                        {
+                            // This permission reads no field at all, so it contributes no column.
+                            continue;
+                        }
+
+                        foreach (string field in fields.Exclude)
+                        {
+                            actionExcluded.Add(ResolveBackingName(field, exposedToBackingName));
+                        }
+                    }
+
+                    // No "fields" section, no "include" section, or an explicit wildcard,
+                    // means every column not listed in "exclude" is readable.
+                    bool includesEveryField = fields is null
+                        || fields.Include is null
+                        || fields.Include.Contains(FIELD_WILDCARD);
+
+                    if (includesEveryField)
+                    {
+                        allColumns = true;
+
+                        if (excluded is null)
+                        {
+                            excluded = actionExcluded;
+                        }
+                        else
+                        {
+                            excluded.IntersectWith(actionExcluded);
+                        }
+
+                        continue;
+                    }
+
+                    foreach (string field in fields!.Include!)
+                    {
+                        string backingName = ResolveBackingName(field, exposedToBackingName);
+                        if (!actionExcluded.Contains(backingName))
+                        {
+                            included.Add(backingName);
+                        }
+                    }
+                }
+            }
+
+            // Primary keys are structural: never drop them from the projection.
+            if (entity.Source is not null && entity.Source.KeyFields is not null)
+            {
+                foreach (string keyField in entity.Source.KeyFields)
+                {
+                    included.Add(ResolveBackingName(keyField, exposedToBackingName));
+                }
+            }
+
+            if (entity.Fields is not null)
+            {
+                foreach (FieldMetadata field in entity.Fields.Where(f => f.PrimaryKey))
+                {
+                    included.Add(ResolveBackingName(field.Name, exposedToBackingName));
+                }
+            }
+
+            excluded ??= new(StringComparer.Ordinal);
+            excluded.ExceptWith(included);
+
+            return new(allColumns, included, excluded);
+        }
+
+        /// <summary>
+        /// Translates a configured (exposed) field name into its backing column name.
+        /// </summary>
+        private static string ResolveBackingName(string fieldName, Dictionary<string, string> exposedToBackingName)
+        {
+            return exposedToBackingName.TryGetValue(fieldName, out string? backingName) ? backingName : fieldName;
+        }
+
+        /// <summary>
+        /// Builds the projection used to read the schema of a database object, narrowed to the
+        /// columns the configuration allows to be read. Returns "*" when no restriction applies
+        /// or when the column list cannot be determined.
+        /// </summary>
+        private async Task<string> BuildSchemaProjectionAsync(
+            string schemaName,
+            string tableName,
+            PermittedColumns permittedColumns)
+        {
+            if (permittedColumns.IsUnrestricted)
+            {
+                return "*";
+            }
+
+            List<string> columnsToRead;
+
+            if (permittedColumns.AllColumns)
+            {
+                // "include": ["*"] with an "exclude" list: enumerate the columns from the catalog
+                // (metadata only, so unsupported CLR types are never materialized) and drop the
+                // excluded ones.
+                List<string> allColumnNames = new();
+                try
+                {
+                    DataTable columnsInTable = await GetColumnsAsync(schemaName, tableName);
+
+                    foreach (DataRow columnInfo in columnsInTable.Rows)
+                    {
+                        if (columnInfo["COLUMN_NAME"] is string columnName)
+                        {
+                            allColumnNames.Add(columnName);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(
+                        "Unable to enumerate the columns of {schemaName}.{tableName} to honor the configured field exclusions: {message}",
+                        schemaName,
+                        tableName,
+                        ex.Message);
+                    return "*";
+                }
+
+                if (allColumnNames.Count == 0)
+                {
+                    return "*";
+                }
+
+                columnsToRead = allColumnNames.Where(permittedColumns.IsColumnPermitted).ToList();
+            }
+            else
+            {
+                columnsToRead = permittedColumns.Included.ToList();
+            }
+
+            if (columnsToRead.Count == 0)
+            {
+                return "*";
+            }
+
+            return string.Join(", ", columnsToRead.Select(column => SqlQueryBuilder.QuoteIdentifier(column)));
         }
 
         /// <summary>

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1959,9 +1959,17 @@ namespace Azure.DataApiBuilder.Core.Services
         /// <summary>
         /// Resolves the readable columns of a single entity from the "fields.include" /
         /// "fields.exclude" sections of its permissions. Exposed names (mappings and field
-        /// aliases) are translated back to their database column names, and configured primary
-        /// key fields are always kept, since the runtime cannot operate on the entity without them.
+        /// aliases) are translated back to their database column names, and the configured
+        /// primary key is always kept, since the runtime cannot operate on the entity without it.
         /// </summary>
+        /// <remarks>
+        /// The projection is only narrowed for entities whose primary key is known from the
+        /// configuration ("fields[].primary-key" or "source.key-fields"). When the primary key is
+        /// instead inferred from the schema read itself - see the fallback to
+        /// <c>DataTable.PrimaryKey</c> in <c>PopulateObjectDefinitionForEntity</c> - narrowing
+        /// could drop the key column and leave the entity with no primary key, so every column is
+        /// read as before.
+        /// </remarks>
         private static PermittedColumns ResolvePermittedColumnsForEntity(Entity entity)
         {
             HashSet<string> included = new(StringComparer.OrdinalIgnoreCase);
@@ -1993,9 +2001,28 @@ namespace Azure.DataApiBuilder.Core.Services
                 }
             }
 
-            if (entity.Permissions is null || entity.Permissions.Length == 0)
+            HashSet<string> configuredPrimaryKey = new(StringComparer.OrdinalIgnoreCase);
+
+            if (entity.Fields is not null)
             {
-                // Nothing configured: the whole object is read, as before.
+                foreach (FieldMetadata field in entity.Fields.Where(f => f.PrimaryKey))
+                {
+                    configuredPrimaryKey.Add(ResolveBackingName(field.Name, exposedToBackingName));
+                }
+            }
+
+            if (configuredPrimaryKey.Count == 0 && entity.Source is not null && entity.Source.KeyFields is not null)
+            {
+                foreach (string keyField in entity.Source.KeyFields)
+                {
+                    configuredPrimaryKey.Add(ResolveBackingName(keyField, exposedToBackingName));
+                }
+            }
+
+            // Without a configured primary key, the key itself is inferred from this schema read,
+            // so a narrowed projection could drop it and leave the entity unusable. Read it all.
+            if (entity.Permissions is null || entity.Permissions.Length == 0 || configuredPrimaryKey.Count == 0)
+            {
                 return new(AllColumns: true, included, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
             }
 
@@ -2060,22 +2087,8 @@ namespace Azure.DataApiBuilder.Core.Services
                 }
             }
 
-            // Primary keys are structural: never drop them from the projection.
-            if (entity.Source is not null && entity.Source.KeyFields is not null)
-            {
-                foreach (string keyField in entity.Source.KeyFields)
-                {
-                    included.Add(ResolveBackingName(keyField, exposedToBackingName));
-                }
-            }
-
-            if (entity.Fields is not null)
-            {
-                foreach (FieldMetadata field in entity.Fields.Where(f => f.PrimaryKey))
-                {
-                    included.Add(ResolveBackingName(field.Name, exposedToBackingName));
-                }
-            }
+            // The primary key is structural: never drop it from the projection.
+            included.UnionWith(configuredPrimaryKey);
 
             excluded ??= new(StringComparer.OrdinalIgnoreCase);
             excluded.ExceptWith(included);

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1548,7 +1548,7 @@ namespace Azure.DataApiBuilder.Core.Services
                 if (permittedColumns is not null
                     && !permittedColumns.IsUnrestricted
                     && !permittedColumns.IsColumnPermitted(columnName)
-                    && !sourceDefinition.PrimaryKey.Contains(columnName))
+                    && !sourceDefinition.PrimaryKey.Contains(columnName, StringComparer.OrdinalIgnoreCase))
                 {
                     continue;
                 }
@@ -1850,6 +1850,9 @@ namespace Azure.DataApiBuilder.Core.Services
         /// <summary>
         /// Describes which backing (database) columns of a database object the runtime
         /// configuration allows to be read.
+        /// Column names are matched case-insensitively, consistent with the comparer used by
+        /// SourceDefinition.Columns and with the field name lookups in this class, so a
+        /// configuration whose casing differs from the database schema still resolves.
         /// </summary>
         /// <param name="AllColumns">
         /// True when at least one permission reads every field ("fields" absent, "include" absent,
@@ -1899,7 +1902,7 @@ namespace Azure.DataApiBuilder.Core.Services
             string tableName,
             string? entityName)
         {
-            HashSet<string> included = new(StringComparer.Ordinal);
+            HashSet<string> included = new(StringComparer.OrdinalIgnoreCase);
             HashSet<string>? excluded = null;
             bool allColumns = false;
             bool matchedAnyEntity = false;
@@ -1933,7 +1936,7 @@ namespace Azure.DataApiBuilder.Core.Services
                     // A column is only droppable when every wildcard permission excludes it.
                     if (excluded is null)
                     {
-                        excluded = new(entityPermittedColumns.Excluded, StringComparer.Ordinal);
+                        excluded = new(entityPermittedColumns.Excluded, StringComparer.OrdinalIgnoreCase);
                     }
                     else
                     {
@@ -1944,10 +1947,10 @@ namespace Azure.DataApiBuilder.Core.Services
 
             if (!matchedAnyEntity)
             {
-                return new(AllColumns: true, Included: new(StringComparer.Ordinal), Excluded: new(StringComparer.Ordinal));
+                return new(AllColumns: true, Included: new(StringComparer.OrdinalIgnoreCase), Excluded: new(StringComparer.OrdinalIgnoreCase));
             }
 
-            excluded ??= new(StringComparer.Ordinal);
+            excluded ??= new(StringComparer.OrdinalIgnoreCase);
             excluded.ExceptWith(included);
 
             return new(allColumns, included, excluded);
@@ -1961,12 +1964,12 @@ namespace Azure.DataApiBuilder.Core.Services
         /// </summary>
         private static PermittedColumns ResolvePermittedColumnsForEntity(Entity entity)
         {
-            HashSet<string> included = new(StringComparer.Ordinal);
+            HashSet<string> included = new(StringComparer.OrdinalIgnoreCase);
             HashSet<string>? excluded = null;
             bool allColumns = false;
 
             // Exposed name -> backing column name.
-            Dictionary<string, string> exposedToBackingName = new(StringComparer.Ordinal);
+            Dictionary<string, string> exposedToBackingName = new(StringComparer.OrdinalIgnoreCase);
 
             if (entity.Mappings is not null)
             {
@@ -1993,7 +1996,7 @@ namespace Azure.DataApiBuilder.Core.Services
             if (entity.Permissions is null || entity.Permissions.Length == 0)
             {
                 // Nothing configured: the whole object is read, as before.
-                return new(AllColumns: true, included, new HashSet<string>(StringComparer.Ordinal));
+                return new(AllColumns: true, included, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
             }
 
             foreach (EntityPermission permission in entity.Permissions)
@@ -2001,7 +2004,7 @@ namespace Azure.DataApiBuilder.Core.Services
                 if (permission.Actions is null)
                 {
                     allColumns = true;
-                    excluded = new(StringComparer.Ordinal);
+                    excluded = new(StringComparer.OrdinalIgnoreCase);
                     continue;
                 }
 
@@ -2009,7 +2012,7 @@ namespace Azure.DataApiBuilder.Core.Services
                 {
                     EntityActionFields? fields = action.Fields;
 
-                    HashSet<string> actionExcluded = new(StringComparer.Ordinal);
+                    HashSet<string> actionExcluded = new(StringComparer.OrdinalIgnoreCase);
                     if (fields?.Exclude is not null)
                     {
                         if (fields.Exclude.Contains(FIELD_WILDCARD))
@@ -2074,7 +2077,7 @@ namespace Azure.DataApiBuilder.Core.Services
                 }
             }
 
-            excluded ??= new(StringComparer.Ordinal);
+            excluded ??= new(StringComparer.OrdinalIgnoreCase);
             excluded.ExceptWith(included);
 
             return new(allColumns, included, excluded);

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Data;
 using System.Data.Common;
@@ -70,9 +71,15 @@ namespace Azure.DataApiBuilder.Core.Services
         protected const int NUMBER_OF_RESTRICTIONS = 4;
 
         /// <summary>
-        /// Wildcard used in the permissions "fields" section to denote every field.
+        /// Column data types, as reported by the "Columns" schema collection, that the data
+        /// provider cannot map to a CLR type. Reading such a column makes
+        /// <see cref="DbDataAdapter.FillSchema(DataSet, SchemaType)"/> fail with
+        /// "DataReader.GetFieldType(N) returned null", which takes down the whole database object
+        /// even when the column itself is never exposed. They are therefore left out of the
+        /// projection used for schema discovery.
+        /// Empty by default: a provider only lists a type here when it genuinely cannot resolve it.
         /// </summary>
-        private const string FIELD_WILDCARD = "*";
+        protected virtual ImmutableHashSet<string> UnsupportedColumnDataTypes => ImmutableHashSet<string>.Empty;
 
         protected string ConnectionString { get; init; }
 
@@ -1534,24 +1541,9 @@ namespace Azure.DataApiBuilder.Core.Services
             DataTable schemaTable = reader.GetSchemaTable();
             RuntimeConfig runtimeConfig = _runtimeConfigProvider.GetConfig();
 
-            // Columns the entity's permissions allow to be read. The schema DataTable is cached
-            // per schema.table and may therefore carry columns permitted only for a sibling
-            // entity, so the restriction is re-applied per entity here.
-            PermittedColumns? permittedColumns = entity is null
-                ? null
-                : ResolvePermittedColumnsForEntity(entity);
-
             foreach (DataRow columnInfoFromAdapter in schemaTable.Rows)
             {
                 string columnName = columnInfoFromAdapter["ColumnName"].ToString()!;
-
-                if (permittedColumns is not null
-                    && !permittedColumns.IsUnrestricted
-                    && !permittedColumns.IsColumnPermitted(columnName)
-                    && !sourceDefinition.PrimaryKey.Contains(columnName, StringComparer.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
 
                 if (runtimeConfig.IsGraphQLEnabled
                     && entity is not null
@@ -1706,7 +1698,7 @@ namespace Azure.DataApiBuilder.Core.Services
             {
                 try
                 {
-                    dataTable = await FillSchemaForTableAsync(schemaName, tableName, entityName);
+                    dataTable = await FillSchemaForTableAsync(schemaName, tableName);
                 }
                 catch (Exception ex) when (ex is not DataApiBuilderException)
                 {
@@ -1774,16 +1766,13 @@ namespace Azure.DataApiBuilder.Core.Services
         /// <summary>
         /// Using a data adapter, obtains the schema of the given table name
         /// and adds the corresponding DataTable to the entities data set.
-        /// When the entities backed by this database object restrict the readable
-        /// fields through permissions ("fields.include"/"fields.exclude"), the projection
-        /// is narrowed to those columns instead of "SELECT *". This avoids the provider
-        /// having to materialize CLR types it cannot handle (e.g. geometry/geography/hierarchyid),
-        /// which otherwise fails during schema discovery even though the column is not exposed.
+        /// Columns whose data type the data provider cannot map to a CLR type are left out of the
+        /// projection, because the data adapter refuses to build a schema mapping for them and the
+        /// whole object would otherwise be unreachable. See <see cref="UnsupportedColumnDataTypes"/>.
         /// </summary>
         private async Task<DataTable> FillSchemaForTableAsync(
             string schemaName,
-            string tableName,
-            string? entityName = null)
+            string tableName)
         {
             using ConnectionT conn = new();
             // If connection string is set to empty string
@@ -1830,14 +1819,7 @@ namespace Azure.DataApiBuilder.Core.Services
 
             string tableNameWithSchemaPrefix = GetTableNameWithSchemaPrefix(schemaName, tableName);
 
-            // Resolve the columns the configuration actually allows to be read for this
-            // database object. When nothing is restricted, the original SELECT * is preserved.
-            PermittedColumns permittedColumns = ResolvePermittedColumnsForDatabaseObject(
-                schemaName: schemaName,
-                tableName: tableName,
-                entityName: entityName);
-
-            string projection = await BuildSchemaProjectionAsync(schemaName, tableName, permittedColumns);
+            string projection = await BuildSchemaProjectionAsync(schemaName, tableName);
 
             selectCommand.CommandText
                 = $"SELECT {projection} FROM {tableNameWithSchemaPrefix}";
@@ -1848,325 +1830,70 @@ namespace Azure.DataApiBuilder.Core.Services
         }
 
         /// <summary>
-        /// Describes which backing (database) columns of a database object the runtime
-        /// configuration allows to be read.
-        /// Column names are matched case-insensitively, consistent with the comparer used by
-        /// SourceDefinition.Columns and with the field name lookups in this class, so a
-        /// configuration whose casing differs from the database schema still resolves.
+        /// Builds the projection used to read the schema of a database object. Returns "*" unless
+        /// the object holds columns whose data type this provider cannot map to a CLR type, in
+        /// which case those columns are named out of the projection so the rest stays reachable.
+        /// The column list comes from the "Columns" schema collection, which reads catalog metadata
+        /// only and therefore never has to materialize the offending type.
         /// </summary>
-        /// <param name="AllColumns">
-        /// True when at least one permission reads every field ("fields" absent, "include" absent,
-        /// or "include": ["*"]).
-        /// </param>
-        /// <param name="Included">Backing columns explicitly listed in an "include" section.</param>
-        /// <param name="Excluded">
-        /// Backing columns excluded from every wildcard permission and never explicitly included.
-        /// </param>
-        private sealed record PermittedColumns(bool AllColumns, HashSet<string> Included, HashSet<string> Excluded)
+        private async Task<string> BuildSchemaProjectionAsync(string schemaName, string tableName)
         {
-            /// <summary>
-            /// No column restriction could be derived from the configuration.
-            /// </summary>
-            public bool IsUnrestricted => AllColumns && Excluded.Count == 0;
-
-            /// <summary>
-            /// Whether the given backing column is readable per the configuration.
-            /// </summary>
-            public bool IsColumnPermitted(string columnName)
+            if (UnsupportedColumnDataTypes.Count == 0)
             {
-                if (Included.Contains(columnName))
-                {
-                    return true;
-                }
-
-                if (Excluded.Contains(columnName))
-                {
-                    return false;
-                }
-
-                return AllColumns;
+                return "*";
             }
-        }
 
-        /// <summary>
-        /// Resolves the readable columns for a database object.
-        /// Because the schema DataTable is cached per schema.table, the result combines the
-        /// permissions of every entity in this data source backed by that same object: a column
-        /// has to be read if any of those entities can read it.
-        /// </summary>
-        /// <param name="schemaName">Schema of the database object.</param>
-        /// <param name="tableName">Name of the database object.</param>
-        /// <param name="entityName">Entity that triggered the schema discovery, when known.</param>
-        private PermittedColumns ResolvePermittedColumnsForDatabaseObject(
-            string schemaName,
-            string tableName,
-            string? entityName)
-        {
-            HashSet<string> included = new(StringComparer.OrdinalIgnoreCase);
-            HashSet<string>? excluded = null;
-            bool allColumns = false;
-            bool matchedAnyEntity = false;
+            List<string> readableColumns = new();
+            List<string> skippedColumns = new();
 
-            foreach ((string candidateEntityName, Entity candidateEntity) in Entities)
+            try
             {
-                // Only consider entities backed by the same database object.
-                if (EntityToDatabaseObject.TryGetValue(candidateEntityName, out DatabaseObject? databaseObject))
+                DataTable columnsInTable = await GetColumnsAsync(schemaName, tableName);
+
+                foreach (DataRow columnInfo in columnsInTable.Rows)
                 {
-                    if (!string.Equals(databaseObject.SchemaName, schemaName, StringComparison.OrdinalIgnoreCase)
-                        || !string.Equals(databaseObject.Name, tableName, StringComparison.OrdinalIgnoreCase))
+                    if (columnInfo["COLUMN_NAME"] is not string columnName)
                     {
                         continue;
                     }
-                }
-                else if (!string.Equals(candidateEntityName, entityName, StringComparison.Ordinal))
-                {
-                    // Database object not inferred yet: only the entity that triggered the read applies.
-                    continue;
-                }
 
-                matchedAnyEntity = true;
-                PermittedColumns entityPermittedColumns = ResolvePermittedColumnsForEntity(candidateEntity);
+                    string? dataType = columnInfo["DATA_TYPE"] as string;
 
-                included.UnionWith(entityPermittedColumns.Included);
-
-                if (entityPermittedColumns.AllColumns)
-                {
-                    allColumns = true;
-
-                    // A column is only droppable when every wildcard permission excludes it.
-                    if (excluded is null)
+                    if (dataType is not null && UnsupportedColumnDataTypes.Contains(dataType))
                     {
-                        excluded = new(entityPermittedColumns.Excluded, StringComparer.OrdinalIgnoreCase);
+                        skippedColumns.Add($"{columnName} ({dataType})");
                     }
                     else
                     {
-                        excluded.IntersectWith(entityPermittedColumns.Excluded);
+                        readableColumns.Add(columnName);
                     }
                 }
             }
-
-            if (!matchedAnyEntity)
+            catch (Exception ex) when (ex is not DataApiBuilderException)
             {
-                return new(AllColumns: true, Included: new(StringComparer.OrdinalIgnoreCase), Excluded: new(StringComparer.OrdinalIgnoreCase));
+                // The column list is a best-effort optimization: without it the read below behaves
+                // exactly as it did before, failing loudly if an unsupported type is present.
+                _logger.LogDebug(
+                    "Unable to enumerate the columns of {schemaName}.{tableName}: {message}",
+                    schemaName,
+                    tableName,
+                    ex.Message);
+                return "*";
             }
 
-            excluded ??= new(StringComparer.OrdinalIgnoreCase);
-            excluded.ExceptWith(included);
-
-            return new(allColumns, included, excluded);
-        }
-
-        /// <summary>
-        /// Resolves the readable columns of a single entity from the "fields.include" /
-        /// "fields.exclude" sections of its permissions. Exposed names (mappings and field
-        /// aliases) are translated back to their database column names, and the configured
-        /// primary key is always kept, since the runtime cannot operate on the entity without it.
-        /// </summary>
-        /// <remarks>
-        /// The projection is only narrowed for entities whose primary key is known from the
-        /// configuration ("fields[].primary-key" or "source.key-fields"). When the primary key is
-        /// instead inferred from the schema read itself - see the fallback to
-        /// <c>DataTable.PrimaryKey</c> in <c>PopulateObjectDefinitionForEntity</c> - narrowing
-        /// could drop the key column and leave the entity with no primary key, so every column is
-        /// read as before.
-        /// </remarks>
-        private static PermittedColumns ResolvePermittedColumnsForEntity(Entity entity)
-        {
-            HashSet<string> included = new(StringComparer.OrdinalIgnoreCase);
-            HashSet<string>? excluded = null;
-            bool allColumns = false;
-
-            // Exposed name -> backing column name.
-            Dictionary<string, string> exposedToBackingName = new(StringComparer.OrdinalIgnoreCase);
-
-            if (entity.Mappings is not null)
-            {
-                foreach ((string backingName, string exposedName) in entity.Mappings)
-                {
-                    if (!string.IsNullOrWhiteSpace(exposedName))
-                    {
-                        exposedToBackingName[exposedName] = backingName;
-                    }
-                }
-            }
-
-            if (entity.Fields is not null)
-            {
-                foreach (FieldMetadata field in entity.Fields)
-                {
-                    if (!string.IsNullOrWhiteSpace(field.Alias))
-                    {
-                        exposedToBackingName[field.Alias!] = field.Name;
-                    }
-                }
-            }
-
-            HashSet<string> configuredPrimaryKey = new(StringComparer.OrdinalIgnoreCase);
-
-            if (entity.Fields is not null)
-            {
-                foreach (FieldMetadata field in entity.Fields.Where(f => f.PrimaryKey))
-                {
-                    configuredPrimaryKey.Add(ResolveBackingName(field.Name, exposedToBackingName));
-                }
-            }
-
-            if (configuredPrimaryKey.Count == 0 && entity.Source is not null && entity.Source.KeyFields is not null)
-            {
-                foreach (string keyField in entity.Source.KeyFields)
-                {
-                    configuredPrimaryKey.Add(ResolveBackingName(keyField, exposedToBackingName));
-                }
-            }
-
-            // Without a configured primary key, the key itself is inferred from this schema read,
-            // so a narrowed projection could drop it and leave the entity unusable. Read it all.
-            if (entity.Permissions is null || entity.Permissions.Length == 0 || configuredPrimaryKey.Count == 0)
-            {
-                return new(AllColumns: true, included, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
-            }
-
-            foreach (EntityPermission permission in entity.Permissions)
-            {
-                if (permission.Actions is null)
-                {
-                    allColumns = true;
-                    excluded = new(StringComparer.OrdinalIgnoreCase);
-                    continue;
-                }
-
-                foreach (EntityAction action in permission.Actions)
-                {
-                    EntityActionFields? fields = action.Fields;
-
-                    HashSet<string> actionExcluded = new(StringComparer.OrdinalIgnoreCase);
-                    if (fields?.Exclude is not null)
-                    {
-                        if (fields.Exclude.Contains(FIELD_WILDCARD))
-                        {
-                            // This permission reads no field at all, so it contributes no column.
-                            continue;
-                        }
-
-                        foreach (string field in fields.Exclude)
-                        {
-                            actionExcluded.Add(ResolveBackingName(field, exposedToBackingName));
-                        }
-                    }
-
-                    // No "fields" section, no "include" section, or an explicit wildcard,
-                    // means every column not listed in "exclude" is readable.
-                    bool includesEveryField = fields is null
-                        || fields.Include is null
-                        || fields.Include.Contains(FIELD_WILDCARD);
-
-                    if (includesEveryField)
-                    {
-                        allColumns = true;
-
-                        if (excluded is null)
-                        {
-                            excluded = actionExcluded;
-                        }
-                        else
-                        {
-                            excluded.IntersectWith(actionExcluded);
-                        }
-
-                        continue;
-                    }
-
-                    foreach (string field in fields!.Include!)
-                    {
-                        string backingName = ResolveBackingName(field, exposedToBackingName);
-                        if (!actionExcluded.Contains(backingName))
-                        {
-                            included.Add(backingName);
-                        }
-                    }
-                }
-            }
-
-            // The primary key is structural: never drop it from the projection.
-            included.UnionWith(configuredPrimaryKey);
-
-            excluded ??= new(StringComparer.OrdinalIgnoreCase);
-            excluded.ExceptWith(included);
-
-            return new(allColumns, included, excluded);
-        }
-
-        /// <summary>
-        /// Translates a configured (exposed) field name into its backing column name.
-        /// </summary>
-        private static string ResolveBackingName(string fieldName, Dictionary<string, string> exposedToBackingName)
-        {
-            return exposedToBackingName.TryGetValue(fieldName, out string? backingName) ? backingName : fieldName;
-        }
-
-        /// <summary>
-        /// Builds the projection used to read the schema of a database object, narrowed to the
-        /// columns the configuration allows to be read. Returns "*" when no restriction applies
-        /// or when the column list cannot be determined.
-        /// </summary>
-        private async Task<string> BuildSchemaProjectionAsync(
-            string schemaName,
-            string tableName,
-            PermittedColumns permittedColumns)
-        {
-            if (permittedColumns.IsUnrestricted)
+            if (skippedColumns.Count == 0 || readableColumns.Count == 0)
             {
                 return "*";
             }
 
-            List<string> columnsToRead;
+            _logger.LogWarning(
+                "Skipping column(s) of {schemaName}.{tableName} whose data type is not supported: {skippedColumns}. "
+                + "They are not exposed through REST, GraphQL or MCP.",
+                schemaName,
+                tableName,
+                string.Join(", ", skippedColumns));
 
-            if (permittedColumns.AllColumns)
-            {
-                // "include": ["*"] with an "exclude" list: enumerate the columns from the catalog
-                // (metadata only, so unsupported CLR types are never materialized) and drop the
-                // excluded ones.
-                List<string> allColumnNames = new();
-                try
-                {
-                    DataTable columnsInTable = await GetColumnsAsync(schemaName, tableName);
-
-                    foreach (DataRow columnInfo in columnsInTable.Rows)
-                    {
-                        if (columnInfo["COLUMN_NAME"] is string columnName)
-                        {
-                            allColumnNames.Add(columnName);
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogDebug(
-                        "Unable to enumerate the columns of {schemaName}.{tableName} to honor the configured field exclusions: {message}",
-                        schemaName,
-                        tableName,
-                        ex.Message);
-                    return "*";
-                }
-
-                if (allColumnNames.Count == 0)
-                {
-                    return "*";
-                }
-
-                columnsToRead = allColumnNames.Where(permittedColumns.IsColumnPermitted).ToList();
-            }
-            else
-            {
-                columnsToRead = permittedColumns.Included.ToList();
-            }
-
-            if (columnsToRead.Count == 0)
-            {
-                return "*";
-            }
-
-            return string.Join(", ", columnsToRead.Select(column => SqlQueryBuilder.QuoteIdentifier(column)));
+            return string.Join(", ", readableColumns.Select(column => SqlQueryBuilder.QuoteIdentifier(column)));
         }
 
         /// <summary>

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1834,20 +1834,22 @@ namespace Azure.DataApiBuilder.Core.Services
                     innerException: ex);
             }
 
+            string tableNameWithSchemaPrefix = GetTableNameWithSchemaPrefix(schemaName, tableName);
+
+            // Resolved before the connection below is opened. Reading the catalog uses a connection
+            // of its own, and nesting that inside an already open one exhausts a small pool: with
+            // "Max Pool Size=1" the inner open waits for a connection the outer scope still holds.
+            string projection = await BuildSchemaProjectionAsync(schemaName, tableName);
+
             await conn.OpenAsync();
 
             DataAdapterT adapterForTable = new();
             CommandT selectCommand = new()
             {
-                Connection = conn
+                Connection = conn,
+                CommandText
+                = $"SELECT {projection} FROM {tableNameWithSchemaPrefix}"
             };
-
-            string tableNameWithSchemaPrefix = GetTableNameWithSchemaPrefix(schemaName, tableName);
-
-            string projection = await BuildSchemaProjectionAsync(schemaName, tableName);
-
-            selectCommand.CommandText
-                = $"SELECT {projection} FROM {tableNameWithSchemaPrefix}";
             adapterForTable.SelectCommand = selectCommand;
 
             DataTable[] dataTable = adapterForTable.FillSchema(EntitiesDataSet, SchemaType.Source, tableNameWithSchemaPrefix);
@@ -1984,11 +1986,14 @@ namespace Azure.DataApiBuilder.Core.Services
         }
 
         /// <summary>
-        /// Key used by the per-object metadata caches held during initialization.
+        /// Key used by the per-object metadata caches held during initialization. The schema name is
+        /// length-prefixed rather than joined with a dot, because bracketed identifiers may contain
+        /// dots: <c>[a.b].[c]</c> and <c>[a].[b.c]</c> are different objects that a "schema.table"
+        /// key would collide, letting one reuse the other's catalog rows.
         /// </summary>
         private static string GetObjectCacheKey(string schemaName, string tableName)
         {
-            return $"{schemaName}.{tableName}";
+            return $"{schemaName.Length}:{schemaName}{tableName}";
         }
 
         /// <summary>

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -100,15 +100,21 @@ namespace Azure.DataApiBuilder.Core.Services
         /// Caches the "Columns" schema collection per database object for the duration of metadata
         /// initialization, so schema discovery and column definition population share one catalog
         /// round trip instead of querying twice per object. Cleared once initialization completes.
+        /// The key is compared with an ordinal comparer: under a case-sensitive collation
+        /// <c>dbo.Foo</c> and <c>dbo.foo</c> are distinct objects, and aliasing them would serve one
+        /// object's catalog rows for the other. Case-insensitive collations are unaffected, since
+        /// they cannot hold both names at once.
         /// </summary>
-        private readonly ConcurrentDictionary<string, DataTable> _columnsMetadataCache = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, DataTable> _columnsMetadataCache = new(StringComparer.Ordinal);
 
         /// <summary>
         /// Columns left out of the schema projection per database object, mapped to the data type
         /// that made them unreadable. Used to explain the omission when a configured primary key
-        /// turns out to be one of them.
+        /// turns out to be one of them. Keyed by object with an ordinal comparer for the reason
+        /// above; the inner column names stay case-insensitive, matching how this class resolves
+        /// configured field names against the schema.
         /// </summary>
-        private readonly ConcurrentDictionary<string, Dictionary<string, string>> _skippedColumnsByObject = new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, Dictionary<string, string>> _skippedColumnsByObject = new(StringComparer.Ordinal);
 
         protected IAbstractQueryManagerFactory QueryManagerFactory { get; init; }
 

--- a/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
+++ b/src/Core/Services/MetadataProviders/SqlMetadataProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Data;
@@ -94,6 +95,20 @@ namespace Azure.DataApiBuilder.Core.Services
         private Dictionary<string, Dictionary<string, string>> EntityBackingColumnsToExposedNames { get; } = new();
 
         private Dictionary<string, Dictionary<string, string>> EntityExposedNamesToBackingColumnNames { get; } = new();
+
+        /// <summary>
+        /// Caches the "Columns" schema collection per database object for the duration of metadata
+        /// initialization, so schema discovery and column definition population share one catalog
+        /// round trip instead of querying twice per object. Cleared once initialization completes.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, DataTable> _columnsMetadataCache = new(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Columns left out of the schema projection per database object, mapped to the data type
+        /// that made them unreadable. Used to explain the omission when a configured primary key
+        /// turns out to be one of them.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, Dictionary<string, string>> _skippedColumnsByObject = new(StringComparer.OrdinalIgnoreCase);
 
         protected IAbstractQueryManagerFactory QueryManagerFactory { get; init; }
 
@@ -347,7 +362,16 @@ namespace Azure.DataApiBuilder.Core.Services
             _runtimeConfigValidator.ValidateEntityAndAutoentityConfigurations(runtimeConfig);
 
             GenerateDatabaseObjectForEntities();
-            await PopulateObjectDefinitionForEntities();
+
+            try
+            {
+                await PopulateObjectDefinitionForEntities();
+            }
+            finally
+            {
+                ReleaseCatalogMetadataCaches();
+            }
+
             GenerateExposedToBackingColumnMapsForEntities();
 
             // When IsLateConfigured is true we are in a hosted scenario and do not reveal primary key information.
@@ -1540,7 +1564,6 @@ namespace Azure.DataApiBuilder.Core.Services
             using DataTableReader reader = new(dataTable);
             DataTable schemaTable = reader.GetSchemaTable();
             RuntimeConfig runtimeConfig = _runtimeConfigProvider.GetConfig();
-
             foreach (DataRow columnInfoFromAdapter in schemaTable.Rows)
             {
                 string columnName = columnInfoFromAdapter["ColumnName"].ToString()!;
@@ -1582,7 +1605,9 @@ namespace Azure.DataApiBuilder.Core.Services
                 sourceDefinition.Columns.TryAdd(columnName, column);
             }
 
-            DataTable columnsInTable = await GetColumnsAsync(schemaName, tableName);
+            RejectPrimaryKeyOnUnsupportedColumn(schemaName, tableName, sourceDefinition);
+
+            DataTable columnsInTable = await GetCachedColumnsAsync(schemaName, tableName);
 
             PopulateColumnDefinitionWithHasDefaultAndDbType(
                 sourceDefinition,
@@ -1836,6 +1861,11 @@ namespace Azure.DataApiBuilder.Core.Services
         /// The column list comes from the "Columns" schema collection, which reads catalog metadata
         /// only and therefore never has to materialize the offending type.
         /// </summary>
+        /// <exception cref="DataApiBuilderException">
+        /// Thrown when every column of the object has an unsupported data type. Returning "*" there
+        /// would re-issue the projection that cannot be read, hiding the reason behind the
+        /// provider's own error.
+        /// </exception>
         private async Task<string> BuildSchemaProjectionAsync(string schemaName, string tableName)
         {
             if (UnsupportedColumnDataTypes.Count == 0)
@@ -1844,11 +1874,11 @@ namespace Azure.DataApiBuilder.Core.Services
             }
 
             List<string> readableColumns = new();
-            List<string> skippedColumns = new();
+            Dictionary<string, string> skippedColumns = new(StringComparer.OrdinalIgnoreCase);
 
             try
             {
-                DataTable columnsInTable = await GetColumnsAsync(schemaName, tableName);
+                DataTable columnsInTable = await GetCachedColumnsAsync(schemaName, tableName);
 
                 foreach (DataRow columnInfo in columnsInTable.Rows)
                 {
@@ -1857,11 +1887,16 @@ namespace Azure.DataApiBuilder.Core.Services
                         continue;
                     }
 
-                    string? dataType = columnInfo["DATA_TYPE"] as string;
-
-                    if (dataType is not null && UnsupportedColumnDataTypes.Contains(dataType))
+                    if (columnInfo["DATA_TYPE"] is not string dataType)
                     {
-                        skippedColumns.Add($"{columnName} ({dataType})");
+                        // The catalog did not report a usable type name, so this column cannot be
+                        // classified. Leave the projection alone rather than guess.
+                        return "*";
+                    }
+
+                    if (UnsupportedColumnDataTypes.Contains(dataType))
+                    {
+                        skippedColumns[columnName] = dataType;
                     }
                     else
                     {
@@ -1881,19 +1916,114 @@ namespace Azure.DataApiBuilder.Core.Services
                 return "*";
             }
 
-            if (skippedColumns.Count == 0 || readableColumns.Count == 0)
+            if (skippedColumns.Count == 0)
             {
                 return "*";
             }
+
+            if (readableColumns.Count == 0)
+            {
+                // Falling back to "*" here would re-issue the very projection that fails, so the
+                // caller would see the opaque provider error instead of the reason for it.
+                throw new DataApiBuilderException(
+                    message: $"Every column of {schemaName}.{tableName} has a data type that is not supported: "
+                        + $"{FormatSkippedColumns(skippedColumns)}. The object cannot be exposed.",
+                    statusCode: HttpStatusCode.ServiceUnavailable,
+                    subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
+            }
+
+            _skippedColumnsByObject[GetObjectCacheKey(schemaName, tableName)] = skippedColumns;
 
             _logger.LogWarning(
                 "Skipping column(s) of {schemaName}.{tableName} whose data type is not supported: {skippedColumns}. "
                 + "They are not exposed through REST, GraphQL or MCP.",
                 schemaName,
                 tableName,
-                string.Join(", ", skippedColumns));
+                FormatSkippedColumns(skippedColumns));
 
             return string.Join(", ", readableColumns.Select(column => SqlQueryBuilder.QuoteIdentifier(column)));
+        }
+
+        /// <summary>
+        /// Fails initialization when a configured primary key names a column that was left out of
+        /// the projection because its data type is not supported. The key would otherwise stay in
+        /// <see cref="SourceDefinition.PrimaryKey"/> while being absent from
+        /// <see cref="SourceDefinition.Columns"/>, and the inconsistency surfaces much later as a
+        /// lookup failure while building queries, the OpenAPI document or the EDM model.
+        /// </summary>
+        private void RejectPrimaryKeyOnUnsupportedColumn(
+            string schemaName,
+            string tableName,
+            SourceDefinition sourceDefinition)
+        {
+            if (!_skippedColumnsByObject.TryGetValue(GetObjectCacheKey(schemaName, tableName), out Dictionary<string, string>? skippedColumns))
+            {
+                return;
+            }
+
+            foreach (string primaryKey in sourceDefinition.PrimaryKey)
+            {
+                if (skippedColumns.TryGetValue(primaryKey, out string? dataType))
+                {
+                    throw new DataApiBuilderException(
+                        message: $"The primary key column {primaryKey} of {schemaName}.{tableName} has the data type "
+                            + $"{dataType}, which is not supported. A primary key cannot be omitted from the object "
+                            + "metadata, so this object cannot be exposed.",
+                        statusCode: HttpStatusCode.ServiceUnavailable,
+                        subStatusCode: DataApiBuilderException.SubStatusCodes.ErrorInInitialization);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Renders skipped columns as "name (type)" pairs for log and error messages.
+        /// </summary>
+        private static string FormatSkippedColumns(Dictionary<string, string> skippedColumns)
+        {
+            return string.Join(", ", skippedColumns.Select(entry => $"{entry.Key} ({entry.Value})"));
+        }
+
+        /// <summary>
+        /// Key used by the per-object metadata caches held during initialization.
+        /// </summary>
+        private static string GetObjectCacheKey(string schemaName, string tableName)
+        {
+            return $"{schemaName}.{tableName}";
+        }
+
+        /// <summary>
+        /// Releases the catalog metadata gathered during initialization. Nothing reads these caches
+        /// once object definitions are populated, and the cached tables are disposable.
+        /// </summary>
+        private void ReleaseCatalogMetadataCaches()
+        {
+            foreach (DataTable columnsInTable in _columnsMetadataCache.Values)
+            {
+                columnsInTable.Dispose();
+            }
+
+            _columnsMetadataCache.Clear();
+            _skippedColumnsByObject.Clear();
+        }
+
+        /// <summary>
+        /// Returns the "Columns" schema collection for a database object, reading it from the
+        /// catalog once per object. Schema discovery and column definition population both need it,
+        /// and each <see cref="GetColumnsAsync"/> call opens its own connection.
+        /// </summary>
+        private async Task<DataTable> GetCachedColumnsAsync(string schemaName, string tableName)
+        {
+            string cacheKey = GetObjectCacheKey(schemaName, tableName);
+
+            if (_columnsMetadataCache.TryGetValue(cacheKey, out DataTable? cachedColumns))
+            {
+                return cachedColumns;
+            }
+
+            DataTable columnsInTable = await GetColumnsAsync(schemaName, tableName);
+            _columnsMetadataCache[cacheKey] = columnsInTable;
+
+            return columnsInTable;
         }
 
         /// <summary>

--- a/src/Service.Tests/DatabaseSchema-MsSql.sql
+++ b/src/Service.Tests/DatabaseSchema-MsSql.sql
@@ -44,6 +44,7 @@ DROP TABLE IF EXISTS brokers;
 DROP TABLE IF EXISTS type_table;
 DROP TABLE IF EXISTS vector_type_table;
 DROP TABLE IF EXISTS vector_owners;
+DROP TABLE IF EXISTS geometry_type_table;
 DROP TABLE IF EXISTS profiles;
 DROP TABLE IF EXISTS trees;
 DROP TABLE IF EXISTS fungi;
@@ -250,6 +251,12 @@ CREATE TABLE vector_type_table(
     vector_data vector(3),
     vector_data_max vector(1998),
     CONSTRAINT FK_vector_type_table_owner FOREIGN KEY (owner_id) REFERENCES vector_owners(id) ON DELETE CASCADE
+);
+
+CREATE TABLE geometry_type_table(
+    id int IDENTITY(5001, 1) PRIMARY KEY,
+    name varchar(100) NOT NULL,
+    geom geometry NULL
 );
 
 CREATE TABLE profiles(
@@ -655,6 +662,13 @@ VALUES (7, CAST('[' + (
     FROM GENERATE_SERIES(1, 1998)
 ) + ']' AS vector(1998)));
 SET IDENTITY_INSERT vector_type_table OFF
+
+SET IDENTITY_INSERT geometry_type_table ON
+INSERT INTO geometry_type_table(id, name, geom)
+VALUES
+    (1, 'point', geometry::STGeomFromText('POINT(1 2)', 0)),
+    (2, 'null geometry', NULL);
+SET IDENTITY_INSERT geometry_type_table OFF
 
 SET IDENTITY_INSERT profiles ON
 INSERT INTO profiles(id, metadata)

--- a/src/Service.Tests/DatabaseSchema-MsSql.sql
+++ b/src/Service.Tests/DatabaseSchema-MsSql.sql
@@ -11,6 +11,7 @@ DROP VIEW IF EXISTS books_view_with_mapping;
 DROP VIEW IF EXISTS stocks_view_selected;
 DROP VIEW IF EXISTS books_publishers_view_composite;
 DROP VIEW IF EXISTS books_publishers_view_composite_insertable;
+DROP VIEW IF EXISTS geometry_only_view;
 DROP PROCEDURE IF EXISTS get_books;
 DROP PROCEDURE IF EXISTS get_book_by_id;
 DROP PROCEDURE IF EXISTS get_publisher_by_id;
@@ -768,6 +769,7 @@ EXEC('CREATE VIEW books_publishers_view_composite_insertable as SELECT
       books.id, books.title, publishers.name, books.publisher_id
       FROM dbo.books,dbo.publishers
       where publishers.id = books.publisher_id');
+EXEC('CREATE VIEW geometry_only_view AS SELECT geom FROM dbo.geometry_type_table');
 EXEC('CREATE PROCEDURE get_book_by_id @id int AS
       SELECT * FROM dbo.books
       WHERE id = @id');

--- a/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
+++ b/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
@@ -1911,6 +1911,38 @@
       }
     },
     {
+      GeometryType: {
+        Source: {
+          Object: geometry_type_table,
+          Type: Table
+        },
+        GraphQL: {
+          Singular: GeometryType,
+          Plural: GeometryTypes,
+          Enabled: true
+        },
+        Rest: {
+          Enabled: true
+        },
+        Permissions: [
+          {
+            Role: anonymous,
+            Actions: [
+              {
+                Action: Read,
+                Fields: {
+                  Include: [
+                    id,
+                    name
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
       Profile: {
         Source: {
           Object: profiles,

--- a/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
+++ b/src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt
@@ -1929,13 +1929,7 @@
             Role: anonymous,
             Actions: [
               {
-                Action: Read,
-                Fields: {
-                  Include: [
-                    id,
-                    name
-                  ]
-                }
+                Action: Read
               }
             ]
           }

--- a/src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs
@@ -397,14 +397,15 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
-        /// Test to validate that a table holding a column whose CLR type the data provider cannot
-        /// resolve - here a geometry column - is still usable when the entity permissions enumerate
-        /// the readable fields and that column is not among them.
-        /// Metadata inference must succeed and the unreadable column must be absent from the
-        /// inferred source definition, so it never reaches the OData or GraphQL type maps.
+        /// Test to validate that a table holding a column whose data type the data provider cannot
+        /// map to a CLR type - here a geometry column - is still usable: metadata inference must
+        /// succeed and the unsupported column must be absent from the inferred source definition,
+        /// so it never reaches the OData or GraphQL type maps.
+        /// The entity places no field restriction, so this covers the column being skipped on the
+        /// strength of its type alone.
         /// </summary>
         [TestMethod, TestCategory(TestCategory.MSSQL)]
-        public async Task ValidateColumnExcludedByFieldPermissionsIsNotInferred()
+        public async Task ValidateUnsupportedColumnTypeIsNotInferred()
         {
             DatabaseEngine = TestCategory.MSSQL;
             await SetupTestFixtureAndInferMetadata();
@@ -420,10 +421,10 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
                 message: "The primary key column is expected in the source definition.");
             Assert.IsTrue(
                 sourceDefinition.Columns.ContainsKey("name"),
-                message: "A column listed in fields.include is expected in the source definition.");
+                message: "A column with a supported data type is expected in the source definition.");
             Assert.IsFalse(
                 sourceDefinition.Columns.ContainsKey("geom"),
-                message: "A column absent from fields.include is not expected in the source definition.");
+                message: "A column whose data type cannot be mapped is not expected in the source definition.");
 
             TestHelper.UnsetAllDABEnvironmentVariables();
         }

--- a/src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs
@@ -397,6 +397,38 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
+        /// Test to validate that a table holding a column whose CLR type the data provider cannot
+        /// resolve - here a geometry column - is still usable when the entity permissions enumerate
+        /// the readable fields and that column is not among them.
+        /// Metadata inference must succeed and the unreadable column must be absent from the
+        /// inferred source definition, so it never reaches the OData or GraphQL type maps.
+        /// </summary>
+        [TestMethod, TestCategory(TestCategory.MSSQL)]
+        public async Task ValidateColumnExcludedByFieldPermissionsIsNotInferred()
+        {
+            DatabaseEngine = TestCategory.MSSQL;
+            await SetupTestFixtureAndInferMetadata();
+
+            Assert.IsTrue(
+                _sqlMetadataProvider.GetEntityNamesAndDbObjects().TryGetValue("GeometryType", out DatabaseObject databaseObject),
+                message: "Metadata inference failed for the entity backed by a table with a geometry column.");
+
+            SourceDefinition sourceDefinition = databaseObject.SourceDefinition;
+
+            Assert.IsTrue(
+                sourceDefinition.Columns.ContainsKey("id"),
+                message: "The primary key column is expected in the source definition.");
+            Assert.IsTrue(
+                sourceDefinition.Columns.ContainsKey("name"),
+                message: "A column listed in fields.include is expected in the source definition.");
+            Assert.IsFalse(
+                sourceDefinition.Columns.ContainsKey("geom"),
+                message: "A column absent from fields.include is not expected in the source definition.");
+
+            TestHelper.UnsetAllDABEnvironmentVariables();
+        }
+
+        /// <summary>
         /// Test to validate successful inference of relationship data based on data provided in the config and the metadata
         /// collected from the MySql database.
         /// </summary>

--- a/src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs
@@ -485,6 +485,59 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
+        /// Test to validate that a configured primary key naming a column of an unsupported data
+        /// type fails initialization instead of producing a source definition whose primary key is
+        /// absent from its columns. The error names both the column and the offending type.
+        /// The entity is declared in an in-memory config for the same reason as the test above.
+        /// </summary>
+        [TestMethod, TestCategory(TestCategory.MSSQL)]
+        public async Task ValidatePrimaryKeyOnUnsupportedColumnFailsInitialization()
+        {
+            DatabaseEngine = TestCategory.MSSQL;
+            TestHelper.SetupDatabaseEnvironment(DatabaseEngine);
+
+            Dictionary<string, Entity> entities = new()
+            {
+                {
+                    "GeometryKeyed",
+                    new Entity(
+                        Source: new("dbo.geometry_type_table", EntitySourceType.Table, null, new string[] { "geom" }),
+                        Fields: null,
+                        Rest: new(Enabled: true),
+                        GraphQL: new("GeometryKeyed", "GeometryKeyeds", Enabled: true),
+                        Permissions: new EntityPermission[]
+                        {
+                            new(Role: "anonymous",
+                                Actions: new EntityAction[] { new(Action: EntityActionOperation.Read, Fields: null, Policy: null) })
+                        },
+                        Relationships: null,
+                        Mappings: null)
+                }
+            };
+
+            RuntimeConfig runtimeConfig = SqlTestHelper.SetupRuntimeConfig() with { Entities = new RuntimeEntities(entities) };
+            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
+            SetUpSQLMetadataProvider(runtimeConfigProvider);
+            await ResetDbStateAsync();
+
+            try
+            {
+                await _sqlMetadataProvider.InitializeAsync();
+                Assert.Fail("Expected DataApiBuilderException was not thrown for a primary key of an unsupported data type.");
+            }
+            catch (DataApiBuilderException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex.StatusCode);
+                Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ErrorInInitialization, ex.SubStatusCode);
+                Assert.IsTrue(
+                    ex.Message.Contains("geom") && ex.Message.Contains("geometry"),
+                    message: $"The error is expected to name the column and its data type. Actual message: {ex.Message}");
+            }
+
+            TestHelper.UnsetAllDABEnvironmentVariables();
+        }
+
+        /// <summary>
         /// Test to validate successful inference of relationship data based on data provided in the config and the metadata
         /// collected from the MySql database.
         /// </summary>

--- a/src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs
+++ b/src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs
@@ -430,6 +430,61 @@ namespace Azure.DataApiBuilder.Service.Tests.UnitTests
         }
 
         /// <summary>
+        /// Test to validate that a database object whose every column has a data type the data
+        /// provider cannot map fails initialization with a specific error, rather than falling back
+        /// to reading every column and surfacing the provider's opaque failure instead of the reason.
+        /// The entity is declared in an in-memory config rather than in dab-config.MsSql.json,
+        /// because this object fails by design and every MSSQL fixture initializes every configured
+        /// entity.
+        /// </summary>
+        [TestMethod, TestCategory(TestCategory.MSSQL)]
+        public async Task ValidateObjectWithOnlyUnsupportedColumnsFailsInitialization()
+        {
+            DatabaseEngine = TestCategory.MSSQL;
+            TestHelper.SetupDatabaseEnvironment(DatabaseEngine);
+
+            Dictionary<string, Entity> entities = new()
+            {
+                {
+                    "GeometryOnlyView",
+                    new Entity(
+                        Source: new("dbo.geometry_only_view", EntitySourceType.View, null, new string[] { "geom" }),
+                        Fields: null,
+                        Rest: new(Enabled: true),
+                        GraphQL: new("GeometryOnlyView", "GeometryOnlyViews", Enabled: true),
+                        Permissions: new EntityPermission[]
+                        {
+                            new(Role: "anonymous",
+                                Actions: new EntityAction[] { new(Action: EntityActionOperation.Read, Fields: null, Policy: null) })
+                        },
+                        Relationships: null,
+                        Mappings: null)
+                }
+            };
+
+            RuntimeConfig runtimeConfig = SqlTestHelper.SetupRuntimeConfig() with { Entities = new RuntimeEntities(entities) };
+            RuntimeConfigProvider runtimeConfigProvider = TestHelper.GenerateInMemoryRuntimeConfigProvider(runtimeConfig);
+            SetUpSQLMetadataProvider(runtimeConfigProvider);
+            await ResetDbStateAsync();
+
+            try
+            {
+                await _sqlMetadataProvider.InitializeAsync();
+                Assert.Fail("Expected DataApiBuilderException was not thrown for an object whose every column has an unsupported data type.");
+            }
+            catch (DataApiBuilderException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex.StatusCode);
+                Assert.AreEqual(DataApiBuilderException.SubStatusCodes.ErrorInInitialization, ex.SubStatusCode);
+                Assert.IsTrue(
+                    ex.Message.Contains("has a data type that is not supported"),
+                    message: $"Unexpected exception message: {ex.Message}");
+            }
+
+            TestHelper.UnsetAllDABEnvironmentVariables();
+        }
+
+        /// <summary>
         /// Test to validate successful inference of relationship data based on data provided in the config and the metadata
         /// collected from the MySql database.
         /// </summary>

--- a/src/Service.Tests/dab-config.MsSql.json
+++ b/src/Service.Tests/dab-config.MsSql.json
@@ -1990,6 +1990,39 @@
         }
       }
     },
+    "GeometryType": {
+      "source": {
+        "object": "geometry_type_table",
+        "type": "table"
+      },
+      "graphql": {
+        "enabled": true,
+        "type": {
+          "singular": "GeometryType",
+          "plural": "GeometryTypes"
+        }
+      },
+      "rest": {
+        "enabled": true
+      },
+      "permissions": [
+        {
+          "role": "anonymous",
+          "actions": [
+            {
+              "action": "read",
+              "fields": {
+                "exclude": [],
+                "include": [
+                  "id",
+                  "name"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
     "Profile": {
       "source": {
         "object": "profiles",

--- a/src/Service.Tests/dab-config.MsSql.json
+++ b/src/Service.Tests/dab-config.MsSql.json
@@ -2010,14 +2010,7 @@
           "role": "anonymous",
           "actions": [
             {
-              "action": "read",
-              "fields": {
-                "exclude": [],
-                "include": [
-                  "id",
-                  "name"
-                ]
-              }
+              "action": "read"
             }
           ]
         }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Why make this change?</h2>
<ul>
<li>Closes <a href="https://github.com/Azure/data-api-builder/issues/3801">[Bug]: Table with a geometry column fails schema discovery ("GetFieldType returned null") even when fields.include excludes it #3801</a></li>
</ul>
<p>A table holding a <code>geometry</code> column cannot be exposed at all. <code>FillSchemaForTableAsync</code> reads the
object shape with <code>SELECT *</code>, and <code>DbDataAdapter.FillSchema</code> needs a CLR type for every column in
the projection. For a SQL Server CLR user-defined type the reader reports no CLR type, so
<code>SchemaMapping</code> fails with <code>DataReader.GetFieldType(N) returned null</code> and takes the whole object
down. DAB does not reference <code>Microsoft.SqlServer.Types</code>. The entity never loads, and there is no
configuration-side workaround — excluding the column through permissions does not help, because
discovery runs before authorization is consulted.</p>
<h2>What is this change?</h2>
<p>Schema discovery leaves out columns whose data type the provider cannot map to a CLR type, so the
rest of the object stays reachable.</p>
<p><code>SqlMetadataProvider</code> gains a virtual <code>UnsupportedColumnDataTypes</code>, empty by default. When it is
empty the projection stays <code>SELECT *</code>, so PostgreSQL, MySQL and Cosmos are untouched.
<code>MsSqlMetadataProvider</code> overrides it with the three SQL Server CLR user-defined types:
<code>geometry</code>, <code>geography</code>, <code>hierarchyid</code>.</p>
<p>When a provider declares such types, the projection is built from the catalog and names the
remaining columns. Identifiers come from the catalog's own <code>COLUMN_NAME</code>, so casing and quoting
match the database rather than the config. The catalog is read once per object and shared with
column definition population, instead of being queried twice.</p>
<p>The projection reproduces the set of columns <code>SELECT *</code> exposes before subtracting the
unsupported types. This matters because the catalog also reports columns declared
<code>GENERATED ALWAYS AS ROW START/END HIDDEN</code>, which <code>SELECT *</code> does not return: naming them would
widen the exposed contract rather than preserve it, and since the read-only classification does
not recognize generated-always period columns, an overwriting PUT would target them. They are
excluded through <code>sys.columns.is_hidden</code>, and they are not reported as skipped — they were never
part of the object's shape as the engine sees it.</p>
<p>When — and only when — the projection is narrowed, the shape is read with
<code>CommandBehavior.SchemaOnly</code> rather than through <code>DbDataAdapter.FillSchema</code>. <code>FillSchema</code> runs
with <code>KeyInfo</code>, under which the provider performs its own key discovery and returns key columns
absent from the <code>SELECT</code> list as hidden reader columns; an unsupported type among them
reintroduces <code>DataReader.GetFieldType(N) returned null</code> even though the projection excluded it.
That is reachable through the object's own primary key and through any unique index, including
when a supported key is configured through <code>source.key-fields</code>. Without <code>KeyInfo</code> the projection
is authoritative, and the primary key comes from the catalog instead. When nothing is skipped,
<code>FillSchema</code> still runs with <code>KeyInfo</code> exactly as before, so ordinary primary-key inference is
untouched for every object that works today.</p>
<p>The primary key comes from the object's own key when it has one. Absent a primary key, the first
unique index whose every key column is non-nullable and readable is used, in index order — which
is what the data adapter reports as <code>DataTable.PrimaryKey</code> on the unnarrowed path, so the two
paths agree and the narrowed one does not start demanding <code>source.key-fields</code> for an object the
other resolves on its own.</p>
<p>Identity columns are carried from <code>sys.columns.is_identity</code> rather than through
<code>DataColumn.AutoIncrement</code>. That setter coerces a DataType it cannot increment to <code>Int32</code>, and SQL
Server allows identity on <code>tinyint</code>, <code>numeric</code> and <code>decimal</code>, so using it as the transport would
report the wrong <code>SystemType</code> and reach parameter typing and the generated API schemas.</p>
<p>A primary key that cannot be read is rejected at initialization, with the column and its data
type named. This covers a key configured over such a column, and the object's own database key
when no key is configured — single column or one member of a composite key. Omitting it would
leave the key in <code>SourceDefinition.PrimaryKey</code> while absent from <code>SourceDefinition.Columns</code>, and
that inconsistency surfaces much later as a lookup failure. The generic "primary key not
configured" error is not used for these, because it reads as something the user forgot to
configure even though no configuration can express that key.</p>
<p>Configuration naming a column left out of the projection also fails initialization. The exposed
and backing column maps are built from entity fields and mappings without requiring the column to
exist in <code>SourceDefinition.Columns</code>, and the authorization resolver accepts explicitly included
field names, so such a reference keeps resolving after the column is gone and then fails per
request rather than at startup. <code>mappings</code>, <code>fields</code>, a permission's <code>fields.include</code> and a
database policy are all rejected; <code>exclude</code> is left alone, since it asks for what already
happened. The policy case matters for the same reason the field-permission approach was withdrawn:
a policy is parsed per request against the OData model, which <code>EdmModelBuilder</code> builds from
<code>SourceDefinition.Columns</code>, so one naming an absent column returns 400 on every request for that
role.</p>
<p>The catalog facts that the <code>Columns</code> schema collection does not carry — which columns the
database hides from <code>SELECT *</code>, and which columns form the object's primary key — come from a new
provider hook, <code>GetObjectCatalogMetadataAsync</code>, which returns null in the base class. Only
<code>MsSqlMetadataProvider</code> implements it, reading <code>sys.columns</code> joined to <code>sys.indexes</code> /
<code>sys.index_columns</code>, cached once per object for the duration of initialization. Providers that
declare no unsupported types never call it, and neither does an object that holds none: the
classification runs first over the <code>Columns</code> schema collection, which is read for every object
anyway, so only an object whose projection must be narrowed pays the additional query.</p>
<p>If nothing unsupported is present, or the catalog cannot be read, or it does not report a usable
type name, the projection falls back to <code>SELECT *</code> and behavior is exactly what it is today. That
last case includes an engine without <code>sys.columns.is_hidden</code>, which exists from SQL Server 2016
on, and a login without <code>VIEW DEFINITION</code>. When every column of an object is unsupported it fails
with a clear initialization error instead, since falling back there would re-issue the projection
that cannot be read.</p>
<p>Skipped columns are logged once per object at Warning level, naming each column and its type, so
the omission is discoverable rather than silent.</p>
<h3>Deliberately limited to three types</h3>
<p><code>MsSqlQueryBuilder</code>'s autoentity discovery skips objects containing <code>geography</code>, <code>geometry</code>,
<code>hierarchyid</code>, <code>sql_variant</code>, <code>xml</code>, <code>rowversion</code> or <code>vector</code>. That list is intentionally not
reused here: <code>SqlTypeConstants.SupportedSqlDbTypes</code> marks <code>timestamp</code> and <code>vector</code> as supported,
and there are dedicated <code>vector</code> tests, so excluding them would regress shipped behavior. This
change is scoped to the CLR user-defined types, which are the ones whose CLR type the provider
does not report.</p>
<h3>Why not honor <code>fields.include</code> instead</h3>
<p>An earlier revision of this PR narrowed the projection to the columns the permissions allow to be
read. I withdrew it: read permission and physical existence are different things, and several
paths need a column to be in <code>SourceDefinition.Columns</code> without needing it to be readable. A
database policy on an excluded column stops parsing against the EDM model (<code>EdmModelBuilder</code>
iterates <code>Columns</code>) and returns 400 on every request in that role; entities sharing a
<code>source.object</code> share one <code>SourceDefinition</code>, so a per-entity filter cannot isolate anything;
multiple-create indexes <code>Columns</code> by relationship column name; REST PUT stops nulling the hidden
columns. Skipping by type has none of that blast radius, because a column the provider cannot
type was never usable in any of those paths.</p>
<h2>Compatibility impact</h2>
<p>Skipping is provider-wide and driven by the column's data type alone, so it does not consult
permissions: a <code>geometry</code>, <code>geography</code> or <code>hierarchyid</code> column is left out even for a role that
grants unrestricted read, and <code>fields.include</code> / <code>fields.exclude</code> no longer narrow discovery.
They are not ignored either — naming one of these columns in <code>fields</code>, <code>mappings</code> or a
permission's <code>fields.include</code> now fails initialization, because the reference cannot be honored
once the column is not part of the exposed contract.</p>
<p>That is a deliberate widening, and it takes nothing away in practice. Those three types cannot be
read today at all — the object fails discovery and the entity never loads, which is #3801. The
observable change is that such an entity now loads with the column absent, instead of not
loading. No column that previously reached <code>SourceDefinition.Columns</code> stops reaching it, so REST,
GraphQL, OpenAPI, MCP and database policies see exactly what they see today for every object that
works today.</p>
<p>Objects that fail today now fail with a specific reason instead of the provider's opaque error:
one whose configured or database primary key is of an unsupported type, and one whose every
column is. Providers other than MSSQL and DWSQL declare no unsupported types and keep
<code>SELECT *</code>. DWSQL shares <code>MsSqlMetadataProvider</code> and therefore inherits the override, which is
inert there since Synapse has no spatial types.</p>
<p>The one thing worth reviewing is discoverability: an omitted column is now a Warning in the log
rather than a startup failure. I chose the Warning deliberately, but if you would rather the
engine keep failing loudly and require an explicit opt-in per entity, that is a small change and
I am happy to make it.</p>
<h2>How was this tested?</h2>
<ul>
<li>[x] Integration Tests</li>
<li>[ ] Unit Tests</li>
</ul>
<p>Eleven tests in <code>src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs</code> infer metadata
against a live MSSQL instance:</p>

Test | What it asserts
-- | --
ValidateUnsupportedColumnTypeIsNotInferred | a geometry column is absent from the inferred SourceDefinition while the supported columns are present, on the strength of its type alone
ValidateObjectWithOnlyUnsupportedColumnsFailsInitialization | an object whose every column is unsupported fails with a specific error instead of the provider's opaque one
ValidatePrimaryKeyOnUnsupportedColumnFailsInitialization | a configured key naming an unsupported column fails, naming the column and its type
ValidateHiddenPeriodColumnsAreNotInferred | the HIDDEN period columns of a temporal table stay out of the exposed contract, as does the spatial column
ValidateUnsupportedDatabasePrimaryKeyFailsInitialization | an object whose own database key is of an unsupported type is rejected before adapter execution, with the reason
ValidateUnsupportedColumnInCompositeDatabasePrimaryKeyFailsInitialization | the same when the unsupported column is one member of a composite key
ValidateConfiguredKeyIsUsedWhenUniqueIndexColumnIsUnsupported | an object whose unique index covers an unsupported column loads when a supported key is configured through source.key-fields
ValidateUniqueKeyIsInferredWhenNoDatabasePrimaryKeyExists | an object with no database primary key has its non-nullable unique key inferred, with no source.key-fields configured
ValidateConfiguredReferenceToUnsupportedColumnFailsInitialization | a mappings entry over an unsupported column fails initialization
ValidateDatabasePolicyOverUnsupportedColumnFailsInitialization | a database policy referencing an unsupported column fails initialization
ValidateIdentityTypeIsPreservedOnTheNarrowedPath | a decimal identity column keeps its reported type and is still marked auto-generated


<p>Run against SQL Server 2025 (RTM-CU8-GDR) 17.0.4085.5, Developer Edition, in a local Linux
container, with <code>DatabaseSchema-MsSql.sql</code> applied in full:</p>
<pre><code>total: 11; failed: 0; passed: 11
</code></pre>
<p>MSSQL only. DWSQL, MySQL and PostgreSQL need engines I do not have locally, so CI remains the
check for those suites — no fixture of theirs is touched by this change.</p>
<p>The fixtures follow the pattern already used for <code>vector</code> columns, in
<code>src/Service.Tests/DatabaseSchema-MsSql.sql</code>:</p>
<ul>
<li><code>geometry_type_table</code> and <code>geometry_only_view</code> — a spatial column, and an object whose every
column is spatial.</li>
<li><code>temporal_geometry_type_table</code> — system-versioned, with <code>HIDDEN</code> period columns and a spatial
column.</li>
<li><code>hierarchyid_pk_table</code> and <code>hierarchyid_composite_pk_table</code> — an unsupported type as the
database primary key, alone and as one member of a composite key.</li>
<li><code>hierarchyid_unique_table</code> — no database primary key, an unsupported column under a unique
index, and a supported column to configure as the key.</li>
<li><code>unique_key_geometry_table</code> — no database primary key, a non-nullable unique index over a
supported column, and a spatial column.</li>
<li><code>decimal_identity_geometry_table</code> — a <code>decimal(18, 0)</code> identity column, whose CLR type
<code>DataColumn.AutoIncrement</code> would coerce to <code>Int32</code>, and a spatial column.</li>
</ul>
<p><code>config-generators/mssql-commands.txt</code> and <code>src/Service.Tests/dab-config.MsSql.json</code> carry the
<code>GeometryType</code> entity, and
<code>src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt</code>
has the matching block. I added only that block rather than accepting the full received file: on
my machine the committed <code>dab-config.MsSql.json</code> and the committed snapshot already disagree on
action ordering for <code>Book</code> and <code>WebsiteUser</code>, and I did not want to bake that local difference
into the snapshot. Happy to regenerate both properly if you prefer.</p>
<p>The entities for the objects added in the latest round are declared in memory inside the tests
rather than in <code>dab-config.MsSql.json</code>, since several of them fail by design and every MSSQL
fixture initializes every configured entity. No further snapshot regeneration is involved.</p>
<h2>Sample Request(s)</h2>
<p>Table:</p>
<pre><code class="language-sql">create table dbo.Geom
(
    Id       int identity(1,1) not null primary key,
    Name     nvarchar(100)     not null,
    Location geometry          null
);
</code></pre>
<p>Entity — no special configuration needed:</p>
<pre><code class="language-json">"Geom": {
  "source": { "object": "dbo.Geom", "type": "table" },
  "permissions": [
    { "role": "anonymous", "actions": [ { "action": "read" } ] }
  ]
}
</code></pre>
<p>Before this change the engine fails while reading metadata for <code>Geom</code>. After it, the entity loads
and responds:</p>
<pre><code>GET /api/Geom
</code></pre>
<pre><code class="language-json">{ "value": [ { "Id": 1, "Name": "Shaft collar" } ] }
</code></pre>
<p>with this in the log at startup:</p>
<pre><code>warn: Skipping column(s) of dbo.Geom whose data type is not supported: Location (geometry).
      They are not exposed through REST, GraphQL or MCP.
</code></pre></body></html><!--EndFragment-->
</body>
</html>## Why make this change?

- Closes [[[Bug]: Table with a geometry column fails schema discovery ("GetFieldType returned null") even when fields.include excludes it #3801](https://github.com/Azure/data-api-builder/issues/3801)](https://github.com/Azure/data-api-builder/issues/3801)

A table holding a `geometry` column cannot be exposed at all. `FillSchemaForTableAsync` reads the
object shape with `SELECT *`, and `DbDataAdapter.FillSchema` needs a CLR type for every column in
the projection. For a SQL Server CLR user-defined type the reader reports no CLR type, so
`SchemaMapping` fails with `DataReader.GetFieldType(N) returned null` and takes the whole object
down. DAB does not reference `Microsoft.SqlServer.Types`. The entity never loads, and there is no
configuration-side workaround — excluding the column through permissions does not help, because
discovery runs before authorization is consulted.

## What is this change?

Schema discovery leaves out columns whose data type the provider cannot map to a CLR type, so the
rest of the object stays reachable.

`SqlMetadataProvider` gains a virtual `UnsupportedColumnDataTypes`, empty by default. When it is
empty the projection stays `SELECT *`, so PostgreSQL, MySQL and Cosmos are untouched.
`MsSqlMetadataProvider` overrides it with the three SQL Server CLR user-defined types:
`geometry`, `geography`, `hierarchyid`.

When a provider declares such types, the projection is built from the catalog and names the
remaining columns. Identifiers come from the catalog's own `COLUMN_NAME`, so casing and quoting
match the database rather than the config. The catalog is read once per object and shared with
column definition population, instead of being queried twice.

The projection reproduces the set of columns `SELECT *` exposes before subtracting the
unsupported types. This matters because the catalog also reports columns declared
`GENERATED ALWAYS AS ROW START/END HIDDEN`, which `SELECT *` does not return: naming them would
widen the exposed contract rather than preserve it, and since the read-only classification does
not recognize generated-always period columns, an overwriting PUT would target them. They are
excluded through `sys.columns.is_hidden`, and they are not reported as skipped — they were never
part of the object's shape as the engine sees it.

When — and only when — the projection is narrowed, the shape is read with
`CommandBehavior.SchemaOnly` rather than through `DbDataAdapter.FillSchema`. `FillSchema` runs
with `KeyInfo`, under which the provider performs its own key discovery and returns key columns
absent from the `SELECT` list as hidden reader columns; an unsupported type among them
reintroduces `DataReader.GetFieldType(N) returned null` even though the projection excluded it.
That is reachable through the object's own primary key and through any unique index, including
when a supported key is configured through `source.key-fields`. Without `KeyInfo` the projection
is authoritative, and the primary key comes from the catalog instead. When nothing is skipped,
`FillSchema` still runs with `KeyInfo` exactly as before, so ordinary primary-key inference is
untouched for every object that works today.

The primary key comes from the object's own key when it has one. Absent a primary key, the first
unique index whose every key column is non-nullable and readable is used, in index order — which
is what the data adapter reports as `DataTable.PrimaryKey` on the unnarrowed path, so the two
paths agree and the narrowed one does not start demanding `source.key-fields` for an object the
other resolves on its own.

Identity columns are carried from `sys.columns.is_identity` rather than through
`DataColumn.AutoIncrement`. That setter coerces a DataType it cannot increment to `Int32`, and SQL
Server allows identity on `tinyint`, `numeric` and `decimal`, so using it as the transport would
report the wrong `SystemType` and reach parameter typing and the generated API schemas.

A primary key that cannot be read is rejected at initialization, with the column and its data
type named. This covers a key configured over such a column, and the object's own database key
when no key is configured — single column or one member of a composite key. Omitting it would
leave the key in `SourceDefinition.PrimaryKey` while absent from `SourceDefinition.Columns`, and
that inconsistency surfaces much later as a lookup failure. The generic "primary key not
configured" error is not used for these, because it reads as something the user forgot to
configure even though no configuration can express that key.

Configuration naming a column left out of the projection also fails initialization. The exposed
and backing column maps are built from entity fields and mappings without requiring the column to
exist in `SourceDefinition.Columns`, and the authorization resolver accepts explicitly included
field names, so such a reference keeps resolving after the column is gone and then fails per
request rather than at startup. `mappings`, `fields`, a permission's `fields.include` and a
database policy are all rejected; `exclude` is left alone, since it asks for what already
happened. The policy case matters for the same reason the field-permission approach was withdrawn:
a policy is parsed per request against the OData model, which `EdmModelBuilder` builds from
`SourceDefinition.Columns`, so one naming an absent column returns 400 on every request for that
role.

The catalog facts that the `Columns` schema collection does not carry — which columns the
database hides from `SELECT *`, and which columns form the object's primary key — come from a new
provider hook, `GetObjectCatalogMetadataAsync`, which returns null in the base class. Only
`MsSqlMetadataProvider` implements it, reading `sys.columns` joined to `sys.indexes` /
`sys.index_columns`, cached once per object for the duration of initialization. Providers that
declare no unsupported types never call it, and neither does an object that holds none: the
classification runs first over the `Columns` schema collection, which is read for every object
anyway, so only an object whose projection must be narrowed pays the additional query.

If nothing unsupported is present, or the catalog cannot be read, or it does not report a usable
type name, the projection falls back to `SELECT *` and behavior is exactly what it is today. That
last case includes an engine without `sys.columns.is_hidden`, which exists from SQL Server 2016
on, and a login without `VIEW DEFINITION`. When every column of an object is unsupported it fails
with a clear initialization error instead, since falling back there would re-issue the projection
that cannot be read.

Skipped columns are logged once per object at Warning level, naming each column and its type, so
the omission is discoverable rather than silent.

### Deliberately limited to three types

`MsSqlQueryBuilder`'s autoentity discovery skips objects containing `geography`, `geometry`,
`hierarchyid`, `sql_variant`, `xml`, `rowversion` or `vector`. That list is intentionally not
reused here: `SqlTypeConstants.SupportedSqlDbTypes` marks `timestamp` and `vector` as supported,
and there are dedicated `vector` tests, so excluding them would regress shipped behavior. This
change is scoped to the CLR user-defined types, which are the ones whose CLR type the provider
does not report.

### Why not honor `fields.include` instead

An earlier revision of this PR narrowed the projection to the columns the permissions allow to be
read. I withdrew it: read permission and physical existence are different things, and several
paths need a column to be in `SourceDefinition.Columns` without needing it to be readable. A
database policy on an excluded column stops parsing against the EDM model (`EdmModelBuilder`
iterates `Columns`) and returns 400 on every request in that role; entities sharing a
`source.object` share one `SourceDefinition`, so a per-entity filter cannot isolate anything;
multiple-create indexes `Columns` by relationship column name; REST PUT stops nulling the hidden
columns. Skipping by type has none of that blast radius, because a column the provider cannot
type was never usable in any of those paths.

## Compatibility impact

Skipping is provider-wide and driven by the column's data type alone, so it does not consult
permissions: a `geometry`, `geography` or `hierarchyid` column is left out even for a role that
grants unrestricted read, and `fields.include` / `fields.exclude` no longer narrow discovery.
They are not ignored either — naming one of these columns in `fields`, `mappings` or a
permission's `fields.include` now fails initialization, because the reference cannot be honored
once the column is not part of the exposed contract.

That is a deliberate widening, and it takes nothing away in practice. Those three types cannot be
read today at all — the object fails discovery and the entity never loads, which is #3801. The
observable change is that such an entity now loads with the column absent, instead of not
loading. No column that previously reached `SourceDefinition.Columns` stops reaching it, so REST,
GraphQL, OpenAPI, MCP and database policies see exactly what they see today for every object that
works today.

Objects that fail today now fail with a specific reason instead of the provider's opaque error:
one whose configured or database primary key is of an unsupported type, and one whose every
column is. Providers other than MSSQL and DWSQL declare no unsupported types and keep
`SELECT *`. DWSQL shares `MsSqlMetadataProvider` and therefore inherits the override, which is
inert there since Synapse has no spatial types.

The one thing worth reviewing is discoverability: an omitted column is now a Warning in the log
rather than a startup failure. I chose the Warning deliberately, but if you would rather the
engine keep failing loudly and require an explicit opt-in per entity, that is a small change and
I am happy to make it.

## How was this tested?

- [x] Integration Tests
- [ ] Unit Tests

Eleven tests in `src/Service.Tests/UnitTests/SqlMetadataProviderUnitTests.cs` infer metadata
against a live MSSQL instance:

| Test | What it asserts |
| --- | --- |
| `ValidateUnsupportedColumnTypeIsNotInferred` | a `geometry` column is absent from the inferred `SourceDefinition` while the supported columns are present, on the strength of its type alone |
| `ValidateObjectWithOnlyUnsupportedColumnsFailsInitialization` | an object whose every column is unsupported fails with a specific error instead of the provider's opaque one |
| `ValidatePrimaryKeyOnUnsupportedColumnFailsInitialization` | a configured key naming an unsupported column fails, naming the column and its type |
| `ValidateHiddenPeriodColumnsAreNotInferred` | the `HIDDEN` period columns of a temporal table stay out of the exposed contract, as does the spatial column |
| `ValidateUnsupportedDatabasePrimaryKeyFailsInitialization` | an object whose own database key is of an unsupported type is rejected before adapter execution, with the reason |
| `ValidateUnsupportedColumnInCompositeDatabasePrimaryKeyFailsInitialization` | the same when the unsupported column is one member of a composite key |
| `ValidateConfiguredKeyIsUsedWhenUniqueIndexColumnIsUnsupported` | an object whose unique index covers an unsupported column loads when a supported key is configured through `source.key-fields` |
| `ValidateUniqueKeyIsInferredWhenNoDatabasePrimaryKeyExists` | an object with no database primary key has its non-nullable unique key inferred, with no `source.key-fields` configured |
| `ValidateConfiguredReferenceToUnsupportedColumnFailsInitialization` | a `mappings` entry over an unsupported column fails initialization |
| `ValidateDatabasePolicyOverUnsupportedColumnFailsInitialization` | a database policy referencing an unsupported column fails initialization |
| `ValidateIdentityTypeIsPreservedOnTheNarrowedPath` | a `decimal` identity column keeps its reported type and is still marked auto-generated |

Run against SQL Server 2025 (RTM-CU8-GDR) 17.0.4085.5, Developer Edition, in a local Linux
container, with `DatabaseSchema-MsSql.sql` applied in full:

```
total: 11; failed: 0; passed: 11
```

MSSQL only. DWSQL, MySQL and PostgreSQL need engines I do not have locally, so CI remains the
check for those suites — no fixture of theirs is touched by this change.

The fixtures follow the pattern already used for `vector` columns, in
`src/Service.Tests/DatabaseSchema-MsSql.sql`:

- `geometry_type_table` and `geometry_only_view` — a spatial column, and an object whose every
  column is spatial.
- `temporal_geometry_type_table` — system-versioned, with `HIDDEN` period columns and a spatial
  column.
- `hierarchyid_pk_table` and `hierarchyid_composite_pk_table` — an unsupported type as the
  database primary key, alone and as one member of a composite key.
- `hierarchyid_unique_table` — no database primary key, an unsupported column under a unique
  index, and a supported column to configure as the key.
- `unique_key_geometry_table` — no database primary key, a non-nullable unique index over a
  supported column, and a spatial column.
- `decimal_identity_geometry_table` — a `decimal(18, 0)` identity column, whose CLR type
  `DataColumn.AutoIncrement` would coerce to `Int32`, and a spatial column.

`config-generators/mssql-commands.txt` and `src/Service.Tests/dab-config.MsSql.json` carry the
`GeometryType` entity, and
`src/Service.Tests/Snapshots/ConfigurationTests.TestReadingRuntimeConfigForMsSql.verified.txt`
has the matching block. I added only that block rather than accepting the full received file: on
my machine the committed `dab-config.MsSql.json` and the committed snapshot already disagree on
action ordering for `Book` and `WebsiteUser`, and I did not want to bake that local difference
into the snapshot. Happy to regenerate both properly if you prefer.

The entities for the objects added in the latest round are declared in memory inside the tests
rather than in `dab-config.MsSql.json`, since several of them fail by design and every MSSQL
fixture initializes every configured entity. No further snapshot regeneration is involved.

## Sample Request(s)

Table:

```sql
create table dbo.Geom
(
    Id       int identity(1,1) not null primary key,
    Name     nvarchar(100)     not null,
    Location geometry          null
);
```

Entity — no special configuration needed:

```json
"Geom": {
  "source": { "object": "dbo.Geom", "type": "table" },
  "permissions": [
    { "role": "anonymous", "actions": [ { "action": "read" } ] }
  ]
}
```

Before this change the engine fails while reading metadata for `Geom`. After it, the entity loads
and responds:

```
GET /api/Geom
```

```json
{ "value": [ { "Id": 1, "Name": "Shaft collar" } ] }
```

with this in the log at startup:

```
warn: Skipping column(s) of dbo.Geom whose data type is not supported: Location (geometry).
      They are not exposed through REST, GraphQL or MCP.
```