### PR TITLE
Add Missing Architecture Versions for Nuget Package

### DIFF
--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -10,7 +10,7 @@
     <ToolCommandName>dab</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <OutputPath>$(BaseOutputPath)\cli</OutputPath>
-    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <PackageId>Microsoft.DataApiBuilder</PackageId>
     <Title>Microsoft.DataApiBuilder</Title>
     <Authors>Microsoft</Authors>

--- a/src/Service/Azure.DataApiBuilder.Service.csproj
+++ b/src/Service/Azure.DataApiBuilder.Service.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net10.0</TargetFramework>
         <Configurations>Debug;Release;Docker</Configurations>
         <OutputPath>$(BaseOutputPath)\engine</OutputPath>
-        <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <!-- ASPDEPR008: WebHost is obsolete on net10. The test-only
              CreateWebHostBuilder / CreateWebHostFromInMemoryUpdatableConfBuilder


### PR DESCRIPTION
## Why make this change?

- Solves issue #3811 

## What is this change?

This change adds the missing `linux-arm64` and `osx-arm-64` versions to the RID (RuntimeIdentifier) in order to allow us to publish versions of the Nuget package that support those architectures.

## How was this tested?

Tested by creating a local nupkg to ensure all of the architectures are built correctly.
`dotnet restore .\src\Azure.DataApiBuilder.sln --force`
`dotnet pack .\src\Cli\Cli.csproj`
<img width="1461" height="677" alt="image" src="https://github.com/user-attachments/assets/dcc2391e-84d5-4b3b-9d3d-c0089eb08e09" />
<img width="997" height="322" alt="image" src="https://github.com/user-attachments/assets/038e5c06-ef9a-41c6-ae63-44dbb33cffba" />
